### PR TITLE
Fix Homebrew formula name to "partio" instead of "cli"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 version: 2
 
+project_name: partio
+
 builds:
   - main: ./cmd/partio
     binary: partio
@@ -30,7 +32,8 @@ changelog:
       - "^ci:"
 
 brews:
-  - repository:
+  - name: partio
+    repository:
       owner: partio-io
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"


### PR DESCRIPTION
* Objective

Update the Homebrew formula name to "partio" instead of "cli".

* Why

GoReleaser defaults the formula name to the repository name. Without explicit settings, the archives and Homebrew tap use the incorrect name.

* How

Explicitly set the project_name and brew name to "partio" so the generated archives and Homebrew tap use the correct name.

Partio-Checkpoint: d6001bed7142
Partio-Attribution: 100% agent