### PR TITLE
Capture Claude Code Plan Files in Checkpoints

### DIFF
--- a/internal/agent/claude/jsonl.go
+++ b/internal/agent/claude/jsonl.go
@@ -10,6 +10,7 @@ type jsonlEntry struct {
 	Content   json.RawMessage `json:"content,omitempty"`
 	Timestamp float64         `json:"timestamp,omitempty"`
 	SessionID string          `json:"sessionId,omitempty"`
+	Slug      string          `json:"slug,omitempty"`
 
 	// For content blocks
 	ContentBlocks []contentBlock `json:"contentBlocks,omitempty"`

--- a/internal/agent/claude/jsonl_test.go
+++ b/internal/agent/claude/jsonl_test.go
@@ -87,6 +87,49 @@ func TestParseJSONLEmpty(t *testing.T) {
 	}
 }
 
+func TestParseJSONLWithSlug(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	lines := `{"type":"human","role":"human","message":"Build a todo app","timestamp":1700000000,"sessionId":"sess-456","slug":"noble-mixing-unicorn"}
+{"type":"assistant","role":"assistant","message":"I'll help you build a todo app.","timestamp":1700000010}
+`
+
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	data, err := ParseJSONL(path)
+	if err != nil {
+		t.Fatalf("ParseJSONL error: %v", err)
+	}
+
+	if data.PlanSlug != "noble-mixing-unicorn" {
+		t.Errorf("expected plan slug 'noble-mixing-unicorn', got %q", data.PlanSlug)
+	}
+}
+
+func TestParseJSONLWithoutSlug(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	lines := `{"type":"human","role":"human","message":"Hello","timestamp":1700000000,"sessionId":"sess-789"}
+`
+
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	data, err := ParseJSONL(path)
+	if err != nil {
+		t.Fatalf("ParseJSONL error: %v", err)
+	}
+
+	if data.PlanSlug != "" {
+		t.Errorf("expected empty plan slug, got %q", data.PlanSlug)
+	}
+}
+
 func TestSanitizePath(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/agent/claude/parse_jsonl.go
+++ b/internal/agent/claude/parse_jsonl.go
@@ -22,6 +22,7 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 		messages    []agent.Message
 		prompt      string
 		sessionID   string
+		slug        string
 		totalTokens int
 		firstTS     time.Time
 		lastTS      time.Time
@@ -45,6 +46,10 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 
 		if entry.SessionID != "" && sessionID == "" {
 			sessionID = entry.SessionID
+		}
+
+		if entry.Slug != "" && slug == "" {
+			slug = entry.Slug
 		}
 
 		ts := time.Unix(int64(entry.Timestamp), 0)
@@ -91,6 +96,7 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 		Context:     generateContext(messages),
 		TotalTokens: totalTokens,
 		Duration:    duration,
+		PlanSlug:    slug,
 	}, nil
 }
 

--- a/internal/agent/claude/read_plan.go
+++ b/internal/agent/claude/read_plan.go
@@ -1,0 +1,31 @@
+package claude
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// ReadPlanFile reads the Claude Code plan file for the given slug.
+// Returns ("", nil) if slug is empty or the file doesn't exist.
+func ReadPlanFile(slug string) (string, error) {
+	if slug == "" {
+		return "", nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(home, ".claude", "plans", slug+".md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	return string(data), nil
+}

--- a/internal/agent/claude/read_plan_test.go
+++ b/internal/agent/claude/read_plan_test.go
@@ -1,0 +1,56 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadPlanFileExisting(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	plansDir := filepath.Join(home, ".claude", "plans")
+	if err := os.MkdirAll(plansDir, 0o755); err != nil {
+		t.Fatalf("creating plans dir: %v", err)
+	}
+
+	content := "# My Plan\n\nBuild a todo app with React."
+	if err := os.WriteFile(filepath.Join(plansDir, "noble-mixing-unicorn.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing plan file: %v", err)
+	}
+
+	got, err := ReadPlanFile("noble-mixing-unicorn")
+	if err != nil {
+		t.Fatalf("ReadPlanFile error: %v", err)
+	}
+
+	if got != content {
+		t.Errorf("expected %q, got %q", content, got)
+	}
+}
+
+func TestReadPlanFileMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := ReadPlanFile("nonexistent-slug")
+	if err != nil {
+		t.Fatalf("ReadPlanFile error: %v", err)
+	}
+
+	if got != "" {
+		t.Errorf("expected empty string for missing plan, got %q", got)
+	}
+}
+
+func TestReadPlanFileEmptySlug(t *testing.T) {
+	got, err := ReadPlanFile("")
+	if err != nil {
+		t.Fatalf("ReadPlanFile error: %v", err)
+	}
+
+	if got != "" {
+		t.Errorf("expected empty string for empty slug, got %q", got)
+	}
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -11,6 +11,7 @@ type SessionData struct {
 	Context     string        `json:"context"`
 	TotalTokens int           `json:"total_tokens"`
 	Duration    time.Duration `json:"duration"`
+	PlanSlug    string        `json:"plan_slug,omitempty"`
 }
 
 // Message represents a single message in an agent transcript.

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -16,6 +16,7 @@ type Checkpoint struct {
 	Agent       string    `json:"agent"`
 	AgentPct    int       `json:"agent_percent"`
 	ContentHash string    `json:"content_hash"`
+	PlanSlug    string    `json:"plan_slug,omitempty"`
 }
 
 // Metadata is the JSON schema for checkpoint metadata stored on the orphan branch.
@@ -28,6 +29,7 @@ type Metadata struct {
 	Agent        string `json:"agent"`
 	AgentPercent int    `json:"agent_percent"`
 	ContentHash  string `json:"content_hash"`
+	PlanSlug     string `json:"plan_slug,omitempty"`
 }
 
 // NewID generates a 12-character hex checkpoint ID.

--- a/internal/checkpoint/store.go
+++ b/internal/checkpoint/store.go
@@ -25,6 +25,7 @@ type SessionFiles struct {
 	Diff        string
 	FullJSONL   string
 	Metadata    SessionMetadata
+	Plan        string
 	Prompt      string
 }
 

--- a/internal/checkpoint/to_metadata.go
+++ b/internal/checkpoint/to_metadata.go
@@ -13,5 +13,6 @@ func (c *Checkpoint) ToMetadata() Metadata {
 		Agent:        c.Agent,
 		AgentPercent: c.AgentPct,
 		ContentHash:  c.ContentHash,
+		PlanSlug:     c.PlanSlug,
 	}
 }

--- a/internal/checkpoint/write.go
+++ b/internal/checkpoint/write.go
@@ -55,6 +55,11 @@ func (s *Store) Write(cp *Checkpoint, sessionData *SessionFiles) error {
 		return fmt.Errorf("hashing diff: %w", err)
 	}
 
+	planHash, err := s.hashObject(sessionData.Plan)
+	if err != nil {
+		return fmt.Errorf("hashing plan: %w", err)
+	}
+
 	// Build session subtree (0/)
 	sessionTree, err := s.mktree([]treeEntry{
 		{mode: "100644", typ: "blob", hash: contentHashHash, name: "content_hash.txt"},
@@ -62,6 +67,7 @@ func (s *Store) Write(cp *Checkpoint, sessionData *SessionFiles) error {
 		{mode: "100644", typ: "blob", hash: diffHash, name: "diff.patch"},
 		{mode: "100644", typ: "blob", hash: fullHash, name: "full.jsonl"},
 		{mode: "100644", typ: "blob", hash: sessionMetaHash, name: "metadata.json"},
+		{mode: "100644", typ: "blob", hash: planHash, name: "plan.md"},
 		{mode: "100644", typ: "blob", hash: promptHash, name: "prompt.txt"},
 	})
 	if err != nil {

--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -94,6 +94,7 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 
 	if sessionData != nil {
 		cp.SessionID = sessionData.SessionID
+		cp.PlanSlug = sessionData.PlanSlug
 	}
 
 	// Prepare session files
@@ -116,6 +117,15 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		sessionFiles.Prompt = sessionData.Prompt
 		sessionFiles.Metadata.TotalTokens = sessionData.TotalTokens
 		sessionFiles.Metadata.Duration = sessionData.Duration.String()
+	}
+
+	if sessionData != nil && sessionData.PlanSlug != "" {
+		planContent, err := claude.ReadPlanFile(sessionData.PlanSlug)
+		if err != nil {
+			slog.Warn("could not read plan file", "slug", sessionData.PlanSlug, "error", err)
+		} else {
+			sessionFiles.Plan = planContent
+		}
 	}
 
 	if sessionPath != "" {


### PR DESCRIPTION
* Objective

Capture Claude Code plan files within checkpoints.

* Why

Including the plan alongside the transcript and diff provides complete context for why changes were made.

* How

Extract the plan slug from JSONL session transcripts and read the related markdown file from ~/.claude/plans/<slug>.md. Store this file as plan.md in the checkpoint tree next to the transcript and diff.

Partio-Checkpoint: 2407f22c2aff
Partio-Attribution: 100% agent