### PR TITLE
Fix JSONL parsing for newer Claude Code transcript format

### DIFF
--- a/internal/agent/claude/jsonl_test.go
+++ b/internal/agent/claude/jsonl_test.go
@@ -130,6 +130,40 @@ func TestParseJSONLWithoutSlug(t *testing.T) {
 	}
 }
 
+func TestParseJSONLWithStringTimestamps(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	lines := `{"type":"user","role":"user","slug":"logical-knitting-toast","sessionId":"sess-abc","message":{"role":"user","content":[{"type":"text","text":"Implement the plan"}]},"timestamp":"2026-02-21T06:14:47.736Z"}
+{"type":"assistant","role":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll implement that."}]},"timestamp":"2026-02-21T06:14:50.332Z"}
+`
+
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	data, err := ParseJSONL(path)
+	if err != nil {
+		t.Fatalf("ParseJSONL error: %v", err)
+	}
+
+	if data.PlanSlug != "logical-knitting-toast" {
+		t.Errorf("expected plan slug 'logical-knitting-toast', got %q", data.PlanSlug)
+	}
+
+	if data.SessionID != "sess-abc" {
+		t.Errorf("expected session ID 'sess-abc', got %q", data.SessionID)
+	}
+
+	if len(data.Transcript) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(data.Transcript))
+	}
+
+	if data.Prompt != "Implement the plan" {
+		t.Errorf("expected prompt 'Implement the plan', got %q", data.Prompt)
+	}
+}
+
 func TestSanitizePath(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/agent/claude/parse_jsonl.go
+++ b/internal/agent/claude/parse_jsonl.go
@@ -52,11 +52,13 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 			slug = entry.Slug
 		}
 
-		ts := time.Unix(int64(entry.Timestamp), 0)
-		if firstTS.IsZero() {
-			firstTS = ts
+		ts := entry.Timestamp.Time
+		if !ts.IsZero() {
+			if firstTS.IsZero() {
+				firstTS = ts
+			}
+			lastTS = ts
 		}
-		lastTS = ts
 
 		// Extract message content
 		text := extractText(entry)
@@ -77,7 +79,7 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 		messages = append(messages, msg)
 
 		// First human message is the prompt
-		if prompt == "" && role == "human" {
+		if prompt == "" && (role == "human" || role == "user") {
 			prompt = text
 		}
 	}
@@ -165,7 +167,7 @@ func generateContext(messages []agent.Message) string {
 
 	summary := "AI coding session"
 	for _, m := range messages {
-		if m.Role == "human" {
+		if m.Role == "human" || m.Role == "user" {
 			if len(m.Content) > 200 {
 				summary = m.Content[:200] + "..."
 			} else {


### PR DESCRIPTION
* Objective

Update JSONL parsing to support the newer Claude Code transcript format.

* Why

The updated format includes ISO 8601 string timestamps and the "user" role, which were not previously supported.
Zero timestamps should not be interpreted as the Unix epoch start.

* How

Handle ISO 8601 string timestamps in addition to Unix epoch floats by introducing a flexTimestamp unmarshaler.

Recognize the "user" role alongside "human" when extracting prompts and generating context.

Skip zero timestamps instead of treating them as the epoch start.

Partio-Checkpoint: 67d0e2cc87ff
Partio-Attribution: 100% agent