### PR TITLE
Add `partio restart` Command to Resume from Checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .partio/settings.local.json
-partio
+/partio

--- a/cmd/partio/main.go
+++ b/cmd/partio/main.go
@@ -65,6 +65,7 @@ func newRootCmd() *cobra.Command {
 		newResetCmd(),
 		newCleanCmd(),
 		newRewindCmd(),
+		newResumeCmd(),
 	)
 
 	return root

--- a/cmd/partio/resume.go
+++ b/cmd/partio/resume.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/partio-io/cli/internal/checkpoint"
+	"github.com/partio-io/cli/internal/git"
+)
+
+func newResumeCmd() *cobra.Command {
+	var (
+		printFlag bool
+		copyFlag  bool
+		branchFlag bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "resume <checkpoint-id>",
+		Short: "Resume a session from a checkpoint",
+		Long:  `Read checkpoint data from the orphan branch and launch a new Claude Code session with the previous context.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResume(args[0], printFlag, copyFlag, branchFlag)
+		},
+	}
+
+	cmd.Flags().BoolVar(&printFlag, "print", false, "print the composed context prompt to stdout")
+	cmd.Flags().BoolVar(&copyFlag, "copy", false, "copy the context prompt to clipboard")
+	cmd.Flags().BoolVar(&branchFlag, "branch", false, "create a branch at the checkpoint's commit before launching")
+
+	return cmd
+}
+
+func runResume(id string, printFlag, copyFlag, branchFlag bool) error {
+	_, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("must be run inside a git repository")
+	}
+
+	data, err := checkpoint.Read(id)
+	if err != nil {
+		return err
+	}
+
+	if branchFlag {
+		branchName := fmt.Sprintf("partio/resume/%s", id)
+		_, err := git.ExecGit("checkout", "-b", branchName, data.Metadata.CommitHash)
+		if err != nil {
+			return fmt.Errorf("creating resume branch: %w", err)
+		}
+		fmt.Printf("Created branch: %s\n", branchName)
+	}
+
+	prompt := composePrompt(id, data)
+
+	if printFlag {
+		fmt.Print(prompt)
+		return nil
+	}
+
+	if copyFlag {
+		return copyToClipboard(prompt)
+	}
+
+	return launchClaude(id, prompt)
+}
+
+func composePrompt(id string, data *checkpoint.CheckpointData) string {
+	meta := data.Metadata
+
+	plan := data.Plan
+	if plan == "" {
+		plan = "No plan was recorded."
+	}
+
+	diff := data.Diff
+	if diff == "" {
+		diff = "No diff was recorded."
+	}
+
+	prompt := data.Prompt
+	if prompt == "" && data.Context != "" {
+		prompt = data.Context
+	}
+	if prompt == "" {
+		prompt = "(No prompt was recorded.)"
+	}
+
+	return fmt.Sprintf(`# Previous Session Context
+
+You are continuing work from a previous Partio session (checkpoint %s).
+
+## Original Request
+
+%s
+
+## Plan
+
+%s
+
+## Changes Made
+
+%s
+
+## Session Info
+
+- **Branch:** %s
+- **Commit:** %s
+- **Date:** %s
+- **Agent:** %s (%d%%)
+
+---
+
+Please review the current state of the repository and continue this work.
+`, id, prompt, plan, diff, meta.Branch, meta.CommitHash, meta.CreatedAt, meta.Agent, meta.AgentPercent)
+}
+
+func copyToClipboard(text string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		cmd = exec.Command("xclip", "-selection", "clipboard")
+	default:
+		return fmt.Errorf("clipboard not supported on %s", runtime.GOOS)
+	}
+
+	cmd.Stdin = strings.NewReader(text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("copying to clipboard: %w", err)
+	}
+
+	fmt.Println("Context prompt copied to clipboard.")
+	return nil
+}
+
+func launchClaude(id, prompt string) error {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		fmt.Println("Claude Code not found in PATH. Printing context instead:")
+		fmt.Println()
+		fmt.Print(prompt)
+		return nil
+	}
+
+	// Write context file to temp directory
+	contextFile := filepath.Join(os.TempDir(), "partio-resume-"+id+".md")
+	if err := os.WriteFile(contextFile, []byte(prompt), 0o644); err != nil {
+		return fmt.Errorf("writing context file: %w", err)
+	}
+
+	fmt.Printf("Context written to %s\n", contextFile)
+	fmt.Println("Launching Claude Code...")
+
+	// Replace this process with claude
+	args := []string{
+		"claude",
+		fmt.Sprintf("Read %s for full context on a previous session, then continue that work.", contextFile),
+	}
+	return syscall.Exec(claudePath, args, os.Environ())
+}

--- a/internal/checkpoint/read.go
+++ b/internal/checkpoint/read.go
@@ -1,0 +1,53 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/partio-io/cli/internal/git"
+)
+
+// CheckpointData holds all readable data from a stored checkpoint.
+type CheckpointData struct {
+	Metadata Metadata
+	Prompt   string
+	Plan     string
+	Diff     string
+	Context  string
+}
+
+// Read retrieves all checkpoint data from the orphan branch by ID.
+func Read(id string) (*CheckpointData, error) {
+	if len(id) != 12 {
+		return nil, fmt.Errorf("checkpoint ID must be 12 characters (got %d)", len(id))
+	}
+
+	shard := Shard(id)
+	rest := Rest(id)
+	prefix := git.CheckpointBranch + ":" + shard + "/" + rest
+
+	// Read metadata (required)
+	metaJSON, err := git.ExecGit("show", prefix+"/metadata.json")
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint %s not found", id)
+	}
+
+	var meta Metadata
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		return nil, fmt.Errorf("invalid checkpoint metadata: %w", err)
+	}
+
+	// Read optional files — missing files are not errors
+	prompt, _ := git.ExecGit("show", prefix+"/0/prompt.txt")
+	plan, _ := git.ExecGit("show", prefix+"/0/plan.md")
+	diff, _ := git.ExecGit("show", prefix+"/0/diff.patch")
+	context, _ := git.ExecGit("show", prefix+"/0/context.md")
+
+	return &CheckpointData{
+		Metadata: meta,
+		Prompt:   prompt,
+		Plan:     plan,
+		Diff:     diff,
+		Context:  context,
+	}, nil
+}


### PR DESCRIPTION
* Objective

Add a `partio restart` command to resume sessions from saved checkpoints.

* Why

This allows users to restore prior work using stored prompt, plan, diff, and context data from the orphan branch.

* How

The command reads checkpoint data and composes a context prompt for Claude Code. It supports the --print, --copy, and --branch flags. By default, it writes a context file and launches Claude interactively using syscall.Exec.