### PR TITLE
Add entire.io Configuration for Claude Code Session Tracking

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,84 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-task"
+          }
+        ]
+      },
+      {
+        "matcher": "TodoWrite",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-todo"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code pre-task"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-end"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-start"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code stop"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code user-prompt-submit"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Read(./.entire/metadata/**)"
+    ]
+  }
+}

--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,5 @@
+{
+  "strategy": "manual-commit",
+  "enabled": true,
+  "telemetry": false
+}


### PR DESCRIPTION
* Objective

Add the entire.io configuration to enable session tracking for Claude Code.

* Why

Let's have entire.io enabled on all partio.io repository to track their improvements

* How

Include and configure the entire.io integration to capture and track Claude Code session activity.

Partio-Checkpoint: f38a01f21a8a
Partio-Attribution: 100% agent