### PR TITLE
[minion] Disable GPG commit signing in test git repos

### DIFF
--- a/internal/git/hooks/hooks_test.go
+++ b/internal/git/hooks/hooks_test.go
@@ -14,6 +14,10 @@ func initGitRepo(t *testing.T) string {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
+	cmd = exec.Command("git", "-C", dir, "config", "commit.gpgsign", "false")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config commit.gpgsign: %v\n%s", err, out)
+	}
 	return dir
 }
 
@@ -115,7 +119,7 @@ func TestInstallWorktree(t *testing.T) {
 	mainDir := initGitRepo(t)
 
 	// Need at least one commit to create a worktree
-	cmd := exec.Command("git", "-C", mainDir, "commit", "--allow-empty", "-m", "init")
+	cmd := exec.Command("git", "-C", mainDir, "commit", "--allow-empty", "--no-gpg-sign", "-m", "init")
 	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
 		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Objective

Any test helper that initializes a temporary git repository for use in tests should explicitly disable GPG commit signing via `git config commit.gpgsign false` and pass `--no-gpg-sign` to any `git commit` calls. This matches the pattern used in the project's canonical `testutil.InitRepo` (or equivalent) helper and prevents test failures in CI environments where GPG keys are not configured.

## Why

Tests that create git repos fail in CI environments (GitHub Actions, etc.) where GPG signing is enabled globally but no signing key is configured, causing intermittent and confusing CI failures.

---

Automated PR by [partio-io/minions](https://github.com/partio-io/minions) · Task: `ci-gpg-signing-test-fix`

*Created by an unattended coding agent. Please review carefully.*