### PR TITLE
[minion] Filter injected system-reminder messages from session transcripts

### DIFF
--- a/internal/agent/claude/parse_jsonl.go
+++ b/internal/agent/claude/parse_jsonl.go
@@ -5,10 +5,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/partio-io/cli/internal/agent"
 )
+
+var systemReminderRe = regexp.MustCompile(`(?s)<system-reminder>.*?</system-reminder>`)
+
+// stripSystemReminders removes all <system-reminder>...</system-reminder> blocks from text.
+// Returns the stripped text and whether any reminders were found.
+func stripSystemReminders(text string) (string, bool) {
+	stripped := systemReminderRe.ReplaceAllString(text, "")
+	had := stripped != text
+	return strings.TrimSpace(stripped), had
+}
 
 // ParseJSONL reads a Claude Code JSONL transcript and extracts session data.
 func ParseJSONL(path string) (*agent.SessionData, error) {
@@ -24,6 +36,7 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 		sessionID   string
 		slug        string
 		totalTokens int
+		promptCount int
 		firstTS     time.Time
 		lastTS      time.Time
 	)
@@ -71,6 +84,17 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 			role = entry.Type
 		}
 
+		// Filter system-reminder injections from user/human messages
+		if role == "human" || role == "user" {
+			filtered, _ := stripSystemReminders(text)
+			if filtered == "" {
+				// Message was entirely system-reminder content; skip it
+				continue
+			}
+			text = filtered
+			promptCount++
+		}
+
 		msg := agent.Message{
 			Role:      role,
 			Content:   text,
@@ -99,6 +123,7 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 		TotalTokens: totalTokens,
 		Duration:    duration,
 		PlanSlug:    slug,
+		PromptCount: promptCount,
 	}, nil
 }
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -12,6 +12,7 @@ type SessionData struct {
 	TotalTokens int           `json:"total_tokens"`
 	Duration    time.Duration `json:"duration"`
 	PlanSlug    string        `json:"plan_slug,omitempty"`
+	PromptCount int           `json:"prompt_count,omitempty"`
 }
 
 // Message represents a single message in an agent transcript.

--- a/internal/checkpoint/metadata.go
+++ b/internal/checkpoint/metadata.go
@@ -5,4 +5,5 @@ type SessionMetadata struct {
 	Agent       string `json:"agent"`
 	TotalTokens int    `json:"total_tokens"`
 	Duration    string `json:"duration"`
+	PromptCount int    `json:"prompt_count,omitempty"`
 }


### PR DESCRIPTION
## Objective

When parsing AI agent session transcripts (Claude Code or others), detect and filter out messages that consist entirely of `<system-reminder>...</system-reminder>` content injected with the `user` role by tooling. For mixed messages, strip the system-reminder tags and preserve the real user content. These injected messages should not be counted as user prompts in attribution or checkpoint metadata.

## Why

Tools that augment Claude Code sessions inject system-reminder blocks as `user`-role messages. Without filtering, these inflate user prompt counts and pollute checkpoint attribution data, misrepresenting what the human actually typed.

---

Automated PR by [partio-io/minions](https://github.com/partio-io/minions) · Task: `filter-system-reminder-messages-from-transcripts`

*Created by an unattended coding agent. Please review carefully.*