### PR TITLE
[minion] Add --absolute-path flag to `partio enable` for git hook setup

### DIFF
--- a/cmd/partio/enable.go
+++ b/cmd/partio/enable.go
@@ -15,15 +15,19 @@ import (
 )
 
 func newEnableCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Enable partio in the current repository",
 		Long:  `Sets up partio in the current git repository by creating the .partio/ config directory, installing git hooks, and creating the checkpoint orphan branch.`,
 		RunE:  runEnable,
 	}
+	cmd.Flags().Bool("absolute-path", false, "Install hooks using the absolute path to the partio binary (useful when partio is not on PATH in hook execution environments)")
+	return cmd
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
+	absolutePath, _ := cmd.Flags().GetBool("absolute-path")
+
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("must be run inside a git repository")
@@ -56,7 +60,19 @@ func runEnable(cmd *cobra.Command, args []string) error {
 	addToGitignore(repoRoot, ".partio/settings.local.json")
 
 	// Install git hooks
-	if err := githooks.Install(repoRoot); err != nil {
+	if absolutePath {
+		exePath, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolving partio binary path: %w", err)
+		}
+		exePath, err = filepath.EvalSymlinks(exePath)
+		if err != nil {
+			return fmt.Errorf("resolving partio binary symlinks: %w", err)
+		}
+		if err := githooks.InstallAbsolute(repoRoot, exePath); err != nil {
+			return fmt.Errorf("installing git hooks: %w", err)
+		}
+	} else if err := githooks.Install(repoRoot); err != nil {
 		return fmt.Errorf("installing git hooks: %w", err)
 	}
 

--- a/internal/git/hooks/hooks.go
+++ b/internal/git/hooks/hooks.go
@@ -25,6 +25,20 @@ exit 0
 `, partioMarker, name, name, name)
 }
 
+// hookScriptAbsolute returns the bash shim for a given hook name using an absolute binary path.
+func hookScriptAbsolute(name, binaryPath string) string {
+	return fmt.Sprintf(`#!/bin/bash
+%s
+%s _hook %s "$@"
+exit_code=$?
+[ $exit_code -ne 0 ] && exit $exit_code
+# Chain to original hook if backed up
+hooks_dir="$(git rev-parse --git-common-dir)/hooks"
+[ -f "$hooks_dir/%s.partio-backup" ] && exec "$hooks_dir/%s.partio-backup" "$@"
+exit 0
+`, partioMarker, binaryPath, name, name, name)
+}
+
 func isPartioHook(content string) bool {
 	return strings.Contains(content, partioMarker)
 }

--- a/internal/git/hooks/hooks_test.go
+++ b/internal/git/hooks/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -154,6 +155,35 @@ func TestInstallWorktree(t *testing.T) {
 		}
 		if !isPartioHook(string(data)) {
 			t.Errorf("hook %s missing partio marker in worktree", name)
+		}
+	}
+}
+
+func TestInstallAbsolute(t *testing.T) {
+	dir := initGitRepo(t)
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+
+	binaryPath := "/usr/local/bin/partio"
+	if err := InstallAbsolute(dir, binaryPath); err != nil {
+		t.Fatalf("InstallAbsolute error: %v", err)
+	}
+
+	for _, name := range hookNames {
+		path := filepath.Join(hooksDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("hook %s not found: %v", name, err)
+			continue
+		}
+		content := string(data)
+		if !isPartioHook(content) {
+			t.Errorf("hook %s missing partio marker", name)
+		}
+		if !strings.Contains(content, binaryPath) {
+			t.Errorf("hook %s missing absolute binary path %q", name, binaryPath)
+		}
+		if strings.Contains(content, "command -v partio") {
+			t.Errorf("hook %s should not use PATH lookup", name)
 		}
 	}
 }

--- a/internal/git/hooks/install.go
+++ b/internal/git/hooks/install.go
@@ -10,6 +10,17 @@ import (
 
 // Install installs partio git hooks into the repository, backing up existing hooks.
 func Install(repoRoot string) error {
+	return installHooks(repoRoot, "")
+}
+
+// InstallAbsolute installs partio git hooks using an absolute path to the partio binary.
+// This is useful in environments where the shell PATH differs between interactive and hook
+// execution contexts (e.g., nix, asdf, mise, or system-level git hooks).
+func InstallAbsolute(repoRoot, binaryPath string) error {
+	return installHooks(repoRoot, binaryPath)
+}
+
+func installHooks(repoRoot, binaryPath string) error {
 	hooksDir, err := git.HooksDir(repoRoot)
 	if err != nil {
 		return fmt.Errorf("resolving hooks directory: %w", err)
@@ -34,7 +45,12 @@ func Install(repoRoot string) error {
 		}
 
 		// Write our hook
-		script := hookScript(name)
+		var script string
+		if binaryPath != "" {
+			script = hookScriptAbsolute(name, binaryPath)
+		} else {
+			script = hookScript(name)
+		}
 		if err := os.WriteFile(hookPath, []byte(script), 0o755); err != nil {
 			return fmt.Errorf("writing %s hook: %w", name, err)
 		}


### PR DESCRIPTION
## Objective

Add an `--absolute-path` flag to `partio enable` that installs git hooks using the absolute path to the partio binary, rather than relying on PATH resolution. This is useful in environments where the shell PATH differs between interactive and hook execution contexts (e.g., nix, asdf, mise, or system-level git hooks).

---

Automated PR by [partio-io/minions](https://github.com/partio-io/minions) · Task: `absolute-git-hook-path-flag`

*Created by an unattended coding agent. Please review carefully.*