### PR TITLE
[minion] Skip already-condensed ENDED sessions in post-commit hook

### DIFF
--- a/internal/agent/claude/find_latest_session.go
+++ b/internal/agent/claude/find_latest_session.go
@@ -10,17 +10,17 @@ import (
 	"github.com/partio-io/cli/internal/agent"
 )
 
-// FindLatestSession finds the most recently modified JSONL session file.
-func (d *Detector) FindLatestSession(repoRoot string) (string, *agent.SessionData, error) {
+// FindLatestJSONLPath returns the path of the most recently modified JSONL file
+// without parsing its contents. This is cheaper than FindLatestSession.
+func (d *Detector) FindLatestJSONLPath(repoRoot string) (string, error) {
 	sessionDir, err := d.FindSessionDir(repoRoot)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 
-	// Find all .jsonl files
 	entries, err := os.ReadDir(sessionDir)
 	if err != nil {
-		return "", nil, fmt.Errorf("reading session directory: %w", err)
+		return "", fmt.Errorf("reading session directory: %w", err)
 	}
 
 	var jsonlFiles []os.DirEntry
@@ -31,17 +31,24 @@ func (d *Detector) FindLatestSession(repoRoot string) (string, *agent.SessionDat
 	}
 
 	if len(jsonlFiles) == 0 {
-		return "", nil, fmt.Errorf("no JSONL session files found in %s", sessionDir)
+		return "", fmt.Errorf("no JSONL session files found in %s", sessionDir)
 	}
 
-	// Sort by modification time (most recent first)
 	sort.Slice(jsonlFiles, func(i, j int) bool {
 		ii, _ := jsonlFiles[i].Info()
 		jj, _ := jsonlFiles[j].Info()
 		return ii.ModTime().After(jj.ModTime())
 	})
 
-	latestPath := filepath.Join(sessionDir, jsonlFiles[0].Name())
+	return filepath.Join(sessionDir, jsonlFiles[0].Name()), nil
+}
+
+// FindLatestSession finds the most recently modified JSONL session file.
+func (d *Detector) FindLatestSession(repoRoot string) (string, *agent.SessionData, error) {
+	latestPath, err := d.FindLatestJSONLPath(repoRoot)
+	if err != nil {
+		return "", nil, err
+	}
 
 	// Parse the JSONL file
 	data, err := ParseJSONL(latestPath)

--- a/internal/agent/claude/peek_session_id.go
+++ b/internal/agent/claude/peek_session_id.go
@@ -1,0 +1,28 @@
+package claude
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
+
+// PeekSessionID reads just enough of a JSONL file to extract the session ID
+// without parsing the full transcript. Returns "" if the ID cannot be determined.
+func PeekSessionID(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry struct {
+			SessionID string `json:"sessionId"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &entry) == nil && entry.SessionID != "" {
+			return entry.SessionID
+		}
+	}
+	return ""
+}

--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/partio-io/cli/internal/checkpoint"
 	"github.com/partio-io/cli/internal/config"
 	"github.com/partio-io/cli/internal/git"
+	"github.com/partio-io/cli/internal/session"
 )
 
 // PostCommit runs post-commit hook logic.
@@ -60,6 +61,15 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 	sessionPath, sessionData, err := detector.FindLatestSession(repoRoot)
 	if err != nil {
 		slog.Warn("could not read agent session", "error", err)
+	}
+
+	// Skip if this session is already fully condensed and ended — re-processing
+	// it produces a redundant checkpoint with no new content.
+	if sessionData != nil && sessionData.SessionID != "" {
+		if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sessionData.SessionID, sessionPath) {
+			slog.Debug("post-commit: skipping already-condensed ended session", "session_id", sessionData.SessionID)
+			return nil
+		}
 	}
 
 	// Generate checkpoint ID and amend commit with trailers BEFORE writing
@@ -139,6 +149,15 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 	store := checkpoint.NewStore(repoRoot)
 	if err := store.Write(cp, sessionFiles); err != nil {
 		return fmt.Errorf("writing checkpoint: %w", err)
+	}
+
+	// Mark the session as condensed so subsequent commits with the same session
+	// are skipped. This is best-effort; failure is non-fatal.
+	if sessionData != nil && sessionData.SessionID != "" {
+		mgr := session.NewManager(filepath.Join(repoRoot, config.PartioDir))
+		if markErr := mgr.MarkCondensed(sessionData.SessionID); markErr != nil {
+			slog.Debug("could not mark session as condensed", "error", markErr)
+		}
 	}
 
 	slog.Debug("checkpoint created", "id", cpID, "agent_pct", attr.AgentPercent)

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -9,6 +9,7 @@ import (
 	"github.com/partio-io/cli/internal/agent/claude"
 	"github.com/partio-io/cli/internal/config"
 	"github.com/partio-io/cli/internal/git"
+	"github.com/partio-io/cli/internal/session"
 )
 
 // preCommitState records the state captured during pre-commit for use by post-commit.
@@ -33,6 +34,20 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 	if err != nil {
 		slog.Warn("could not detect agent process", "error", err)
 		running = false
+	}
+
+	if running {
+		// Quick check: find the latest JSONL path without a full parse and see if
+		// we have already captured this session in a fully-condensed ended state.
+		// This avoids the expensive JSONL parse for stale sessions.
+		latestPath, pathErr := detector.FindLatestJSONLPath(repoRoot)
+		if pathErr == nil {
+			sid := claude.PeekSessionID(latestPath)
+			if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sid, latestPath) {
+				slog.Debug("skipping already-condensed ended session", "session_id", sid)
+				running = false
+			}
+		}
 	}
 
 	var sessionPath string
@@ -68,4 +83,35 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 	}
 
 	return os.WriteFile(filepath.Join(stateDir, "pre-commit.json"), data, 0o644)
+}
+
+// shouldSkipSession returns true when the Partio session state shows that
+// sessionID has already been fully captured (condensed + ended) and the JSONL
+// at sessionPath has not been modified since the capture time. Both ENDED and
+// Condensed must be set; IDLE or ACTIVE sessions are never skipped.
+func shouldSkipSession(partioDir, sessionID, sessionPath string) bool {
+	if sessionID == "" || sessionPath == "" {
+		return false
+	}
+
+	mgr := session.NewManager(partioDir)
+	sess, err := mgr.Current()
+	if err != nil || sess == nil {
+		return false
+	}
+
+	if sess.State != session.StateEnded || !sess.Condensed || sess.CapturedSessionID != sessionID {
+		return false
+	}
+
+	// Allow skip only if the JSONL hasn't been modified since we captured it.
+	// If new messages were added, the modification time will be after CapturedAt.
+	if !sess.CapturedAt.IsZero() {
+		info, statErr := os.Stat(sessionPath)
+		if statErr == nil && info.ModTime().After(sess.CapturedAt) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/hooks/precommit_test.go
+++ b/internal/hooks/precommit_test.go
@@ -1,0 +1,106 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/partio-io/cli/internal/session"
+)
+
+func TestShouldSkipSession(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T, partioDir, jsonlPath string)
+		sessionID    string
+		modifyJSONL  bool // touch JSONL after marking condensed to simulate new content
+		wantSkip     bool
+	}{
+		{
+			name: "skip when ended and condensed with matching session ID",
+			setup: func(t *testing.T, partioDir, jsonlPath string) {
+				mgr := session.NewManager(partioDir)
+				if err := mgr.MarkCondensed("sess-123"); err != nil {
+					t.Fatalf("MarkCondensed: %v", err)
+				}
+			},
+			sessionID: "sess-123",
+			wantSkip:  true,
+		},
+		{
+			name: "do not skip when session ID does not match",
+			setup: func(t *testing.T, partioDir, jsonlPath string) {
+				mgr := session.NewManager(partioDir)
+				if err := mgr.MarkCondensed("sess-other"); err != nil {
+					t.Fatalf("MarkCondensed: %v", err)
+				}
+			},
+			sessionID: "sess-123",
+			wantSkip:  false,
+		},
+		{
+			name:      "do not skip when no session state exists",
+			setup:     func(t *testing.T, partioDir, jsonlPath string) {},
+			sessionID: "sess-123",
+			wantSkip:  false,
+		},
+		{
+			name: "do not skip when session is active (not ended)",
+			setup: func(t *testing.T, partioDir, jsonlPath string) {
+				mgr := session.NewManager(partioDir)
+				if _, err := mgr.Start("claude-code", "main", "/tmp/test"); err != nil {
+					t.Fatalf("Start: %v", err)
+				}
+				// Active session — do NOT mark condensed
+			},
+			sessionID: "sess-123",
+			wantSkip:  false,
+		},
+		{
+			name: "do not skip when JSONL was modified after capture",
+			setup: func(t *testing.T, partioDir, jsonlPath string) {
+				mgr := session.NewManager(partioDir)
+				if err := mgr.MarkCondensed("sess-123"); err != nil {
+					t.Fatalf("MarkCondensed: %v", err)
+				}
+			},
+			sessionID:   "sess-123",
+			modifyJSONL: true,
+			wantSkip:    false,
+		},
+		{
+			name:      "do not skip when session ID is empty",
+			setup:     func(t *testing.T, partioDir, jsonlPath string) {},
+			sessionID: "",
+			wantSkip:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			partioDir := t.TempDir()
+			jsonlDir := t.TempDir()
+			jsonlPath := filepath.Join(jsonlDir, "session.jsonl")
+
+			if err := os.WriteFile(jsonlPath, []byte(`{"sessionId":"sess-123"}`+"\n"), 0o644); err != nil {
+				t.Fatalf("writing JSONL: %v", err)
+			}
+
+			tt.setup(t, partioDir, jsonlPath)
+
+			if tt.modifyJSONL {
+				// Ensure modification time is strictly after CapturedAt by waiting a moment
+				time.Sleep(5 * time.Millisecond)
+				if err := os.WriteFile(jsonlPath, []byte(`{"sessionId":"sess-123"}`+"\n"+"new line\n"), 0o644); err != nil {
+					t.Fatalf("modifying JSONL: %v", err)
+				}
+			}
+
+			got := shouldSkipSession(partioDir, tt.sessionID, jsonlPath)
+			if got != tt.wantSkip {
+				t.Errorf("shouldSkipSession() = %v, want %v", got, tt.wantSkip)
+			}
+		})
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // Manager handles session lifecycle transitions.
@@ -29,4 +30,26 @@ func (m *Manager) save(s *Session) error {
 
 func (m *Manager) currentPath() string {
 	return filepath.Join(m.stateDir, "current.json")
+}
+
+// MarkCondensed marks the current session as ended and fully condensed with the
+// given Claude session ID. Future hook runs that see the same session ID and an
+// unmodified JSONL file will skip checkpoint creation.
+func (m *Manager) MarkCondensed(capturedSessionID string) error {
+	s, err := m.Current()
+	if err != nil {
+		return err
+	}
+	if s == nil {
+		// No tracked session yet — create a minimal one to persist condensed state.
+		if err := os.MkdirAll(m.stateDir, 0o755); err != nil {
+			return fmt.Errorf("creating session directory: %w", err)
+		}
+		s = &Session{}
+	}
+	s.State = StateEnded
+	s.Condensed = true
+	s.CapturedSessionID = capturedSessionID
+	s.CapturedAt = time.Now()
+	return m.save(s)
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -68,6 +68,59 @@ func TestManagerEnd(t *testing.T) {
 	}
 }
 
+func TestManagerMarkCondensed(t *testing.T) {
+	t.Run("marks existing session as condensed and ended", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+
+		_, err := mgr.Start("claude-code", "main", "/tmp/test")
+		if err != nil {
+			t.Fatalf("start error: %v", err)
+		}
+
+		if err := mgr.MarkCondensed("sess-abc"); err != nil {
+			t.Fatalf("mark condensed error: %v", err)
+		}
+
+		cur, err := mgr.Current()
+		if err != nil {
+			t.Fatalf("current error: %v", err)
+		}
+		if cur.State != StateEnded {
+			t.Errorf("expected state=ended, got %s", cur.State)
+		}
+		if !cur.Condensed {
+			t.Error("expected condensed=true")
+		}
+		if cur.CapturedSessionID != "sess-abc" {
+			t.Errorf("expected captured_session_id=sess-abc, got %s", cur.CapturedSessionID)
+		}
+		if cur.CapturedAt.IsZero() {
+			t.Error("expected captured_at to be set")
+		}
+	})
+
+	t.Run("creates session entry when none exists", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+
+		if err := mgr.MarkCondensed("sess-xyz"); err != nil {
+			t.Fatalf("mark condensed error: %v", err)
+		}
+
+		cur, err := mgr.Current()
+		if err != nil {
+			t.Fatalf("current error: %v", err)
+		}
+		if cur == nil {
+			t.Fatal("expected session to be created")
+		}
+		if cur.State != StateEnded || !cur.Condensed || cur.CapturedSessionID != "sess-xyz" {
+			t.Errorf("unexpected session state: %+v", cur)
+		}
+	})
+}
+
 func TestManagerClear(t *testing.T) {
 	dir := t.TempDir()
 	mgr := NewManager(dir)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -15,6 +15,13 @@ type Session struct {
 	EndedAt   time.Time `json:"ended_at,omitempty"`
 	Branch    string    `json:"branch"`
 	SourceDir string    `json:"source_dir"`
+
+	// Condensed is true when the session has been fully captured in a checkpoint
+	// and has ended. Post-commit sets this after creating a checkpoint so future
+	// commits with the same session can be skipped.
+	Condensed         bool      `json:"condensed,omitempty"`
+	CapturedSessionID string    `json:"captured_session_id,omitempty"`
+	CapturedAt        time.Time `json:"captured_at,omitempty"`
 }
 
 // New creates a new session with a generated UUID.


### PR DESCRIPTION
## Objective

In the post-commit hook, skip sessions that are already fully condensed and in ENDED state. Re-processing these sessions is redundant work that slows down commits, especially in repos with many historical sessions. Add a flag or field to session metadata to track condensation state and short-circuit hook processing for sessions that have nothing new to contribute.

---

Automated PR by [partio-io/minions](https://github.com/partio-io/minions) · Task: `skip-condensed-ended-sessions-postcommit`

*Created by an unattended coding agent. Please review carefully.*