### PR TITLE
[minion] Post-commit cache to avoid redundant work on consecutive commits

### DIFF
--- a/internal/hooks/commit_cache.go
+++ b/internal/hooks/commit_cache.go
@@ -1,0 +1,83 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	commitCacheFile    = "processed-commits.json"
+	commitCacheMaxDays = 30
+	commitCacheMaxLen  = 100
+)
+
+type commitCacheEntry struct {
+	SHA         string    `json:"sha"`
+	ProcessedAt time.Time `json:"processed_at"`
+}
+
+type commitCache struct {
+	Entries []commitCacheEntry `json:"entries"`
+}
+
+func commitCachePath(partioDir string) string {
+	return filepath.Join(partioDir, "state", commitCacheFile)
+}
+
+func loadCommitCache(partioDir string) commitCache {
+	data, err := os.ReadFile(commitCachePath(partioDir))
+	if err != nil {
+		return commitCache{}
+	}
+	var cache commitCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return commitCache{}
+	}
+	return cache
+}
+
+func (c *commitCache) contains(sha string) bool {
+	for _, e := range c.Entries {
+		if e.SHA == sha {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *commitCache) add(sha string) {
+	c.Entries = append(c.Entries, commitCacheEntry{
+		SHA:         sha,
+		ProcessedAt: time.Now(),
+	})
+	c.prune()
+}
+
+func (c *commitCache) prune() {
+	cutoff := time.Now().AddDate(0, 0, -commitCacheMaxDays)
+	pruned := c.Entries[:0]
+	for _, e := range c.Entries {
+		if e.ProcessedAt.After(cutoff) {
+			pruned = append(pruned, e)
+		}
+	}
+	c.Entries = pruned
+
+	if len(c.Entries) > commitCacheMaxLen {
+		c.Entries = c.Entries[len(c.Entries)-commitCacheMaxLen:]
+	}
+}
+
+func saveCommitCache(partioDir string, cache commitCache) error {
+	stateDir := filepath.Join(partioDir, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(commitCachePath(partioDir), data, 0o644)
+}

--- a/internal/hooks/commit_cache_test.go
+++ b/internal/hooks/commit_cache_test.go
@@ -1,0 +1,113 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCommitCacheContains(t *testing.T) {
+	c := commitCache{
+		Entries: []commitCacheEntry{
+			{SHA: "abc123", ProcessedAt: time.Now()},
+		},
+	}
+
+	if !c.contains("abc123") {
+		t.Error("expected cache to contain abc123")
+	}
+	if c.contains("def456") {
+		t.Error("expected cache not to contain def456")
+	}
+}
+
+func TestCommitCacheAdd(t *testing.T) {
+	c := commitCache{}
+	c.add("abc123")
+
+	if !c.contains("abc123") {
+		t.Error("expected cache to contain abc123 after add")
+	}
+	if len(c.Entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(c.Entries))
+	}
+}
+
+func TestCommitCachePruneByAge(t *testing.T) {
+	old := time.Now().AddDate(0, 0, -(commitCacheMaxDays + 1))
+	c := commitCache{
+		Entries: []commitCacheEntry{
+			{SHA: "old1", ProcessedAt: old},
+			{SHA: "old2", ProcessedAt: old},
+			{SHA: "new1", ProcessedAt: time.Now()},
+		},
+	}
+	c.prune()
+
+	if len(c.Entries) != 1 {
+		t.Errorf("expected 1 entry after pruning old entries, got %d", len(c.Entries))
+	}
+	if c.Entries[0].SHA != "new1" {
+		t.Errorf("expected new1 to remain, got %s", c.Entries[0].SHA)
+	}
+}
+
+func TestCommitCachePruneByLength(t *testing.T) {
+	c := commitCache{}
+	for i := 0; i < commitCacheMaxLen+10; i++ {
+		c.Entries = append(c.Entries, commitCacheEntry{
+			SHA:         string(rune('a'+i%26)) + string(rune('0'+i%10)),
+			ProcessedAt: time.Now(),
+		})
+	}
+	c.prune()
+
+	if len(c.Entries) > commitCacheMaxLen {
+		t.Errorf("expected at most %d entries, got %d", commitCacheMaxLen, len(c.Entries))
+	}
+}
+
+func TestLoadSaveCommitCache(t *testing.T) {
+	dir := t.TempDir()
+
+	// Load from non-existent file returns empty cache
+	c := loadCommitCache(dir)
+	if len(c.Entries) != 0 {
+		t.Errorf("expected empty cache, got %d entries", len(c.Entries))
+	}
+
+	// Add and save
+	c.add("sha1")
+	c.add("sha2")
+	if err := saveCommitCache(dir, c); err != nil {
+		t.Fatalf("saveCommitCache: %v", err)
+	}
+
+	// Reload and verify
+	c2 := loadCommitCache(dir)
+	if !c2.contains("sha1") {
+		t.Error("expected reloaded cache to contain sha1")
+	}
+	if !c2.contains("sha2") {
+		t.Error("expected reloaded cache to contain sha2")
+	}
+}
+
+func TestLoadCommitCacheCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write corrupt JSON
+	stateDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(commitCachePath(dir), []byte("not json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	c := loadCommitCache(dir)
+	if len(c.Entries) != 0 {
+		t.Errorf("expected empty cache on corrupt file, got %d entries", len(c.Entries))
+	}
+}

--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -49,6 +49,15 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		return fmt.Errorf("getting current commit: %w", err)
 	}
 
+	// Skip if this commit was already processed (e.g. duplicate hook invocations
+	// during rebase, merge, or cherry-pick).
+	partioDir := filepath.Join(repoRoot, config.PartioDir)
+	cache := loadCommitCache(partioDir)
+	if cache.contains(commitHash) {
+		slog.Debug("post-commit: commit already processed, skipping", "commit", commitHash)
+		return nil
+	}
+
 	// Calculate attribution
 	attr, err := attribution.Calculate(commitHash, state.AgentActive)
 	if err != nil {
@@ -158,6 +167,12 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		if markErr := mgr.MarkCondensed(sessionData.SessionID); markErr != nil {
 			slog.Debug("could not mark session as condensed", "error", markErr)
 		}
+	}
+
+	// Record the post-amend commit hash so duplicate hook invocations are no-ops.
+	cache.add(commitHash)
+	if saveErr := saveCommitCache(partioDir, cache); saveErr != nil {
+		slog.Debug("could not save commit cache", "error", saveErr)
 	}
 
 	slog.Debug("checkpoint created", "id", cpID, "agent_pct", attr.AgentPercent)


### PR DESCRIPTION
## Objective

Introduce a lightweight post-commit cache (e.g., a small file in `.partio/`) that records which commit SHAs have already been fully processed. When the post-commit hook fires, check the cache first and skip processing if the commit was already handled. This prevents duplicate checkpoint writes when git operations trigger multiple hook invocations (e.g., rebases, merges, cherry-picks).

---

Automated PR by [partio-io/minions](https://github.com/partio-io/minions) · Task: `post-commit-cache`

*Created by an unattended coding agent. Please review carefully.*