### PR TITLE
Switch to Program-Based Execution and Add Ingest Prompt

### DIFF
--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -3,14 +3,9 @@ name: Run Minion
 on:
   workflow_dispatch:
     inputs:
-      task_file:
-        description: "Task YAML file path (e.g., tasks/detect-external-hooks.yaml) or 'tasks/' for all"
+      program:
+        description: "Program .md file path (e.g., .minions/programs/detect-hooks.md)"
         required: true
-        type: string
-      parallel:
-        description: "Max parallel minions"
-        required: false
-        default: "2"
         type: string
       dry_run:
         description: "Dry run (prompt generation only)"
@@ -18,11 +13,9 @@ on:
         default: false
         type: boolean
 
-  # Auto-trigger on issues labeled 'minion-ready' or 'minion-approved'
   issues:
     types: [labeled]
 
-  # Trigger on /minion build comment
   issue_comment:
     types: [created]
 
@@ -33,7 +26,6 @@ permissions:
 
 jobs:
   run-minion:
-    # Skip unless: workflow_dispatch, minion-ready/minion-approved label, or /minion build comment
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' && (github.event.label.name == 'minion-ready' || github.event.label.name == 'minion-approved')) ||
@@ -42,246 +34,61 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Check authorization
-        if: github.event_name != 'schedule'
+      - uses: actions/checkout@v4
+
+      - name: Determine program
+        id: program
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          ORG=$(echo "${{ github.repository }}" | cut -d'/' -f1)
-          ROLE=$(gh api "orgs/${ORG}/memberships/${{ github.actor }}" --jq '.role' 2>/dev/null || echo "none")
-          if [ "$ROLE" != "admin" ]; then
-            echo "::error::Unauthorized: ${{ github.actor }} (role: ${ROLE}) is not an org admin"
-            exit 1
-          fi
-          echo "Authorized: ${{ github.actor }} (org role: ${ROLE})"
-
-      # Mark issue as executing (issue-triggered runs only)
-      - name: Mark executing
-        if: github.event_name != 'workflow_dispatch'
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          ISSUE_NUM="${{ github.event.issue.number }}"
-
-          # Skip if already executing (dedup)
-          LABELS=$(gh issue view "$ISSUE_NUM" --repo "${{ github.repository }}" --json labels -q '.labels[].name')
-          if echo "$LABELS" | grep -q "minion-executing"; then
-            echo "::error::Issue #${ISSUE_NUM} is already executing"
-            exit 1
-          fi
-
-          gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" --add-label "minion-executing"
-
-      # Checkout this repo (cli = principal)
-      - name: Checkout cli
-        uses: actions/checkout@v4
-        with:
-          path: cli
-
-      # Install yq for parsing project.yaml
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-
-      # Checkout other repos defined in project.yaml (skip cli itself)
-      - name: Checkout project repos
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          for ENTRY in $(yq -r '.repos[] | .full_name + ":" + .name' cli/.minions/project.yaml); do
-            FULL="${ENTRY%%:*}"
-            SHORT="${ENTRY##*:}"
-            if [ "$SHORT" = "cli" ]; then
-              continue
-            fi
-            echo "Cloning ${FULL} -> ${SHORT}/"
-            gh repo clone "$FULL" "$SHORT" -- --depth=1
-          done
-
-      - name: Configure git auth
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-
-      # Checkout minions tool (for building)
-      - name: Checkout minions
-        uses: actions/checkout@v4
-        with:
-          repository: partio-io/minions
-          path: minions
-          token: ${{ secrets.GH_PAT }}
-
-      # Install toolchains
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.26"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
-
-      - name: Build minions
-        run: cd minions && make build
-
-      - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
-
-      # Determine task file (workflow_dispatch vs issue trigger)
-      - name: Determine task
-        id: task
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "task_file=${{ inputs.task_file }}" >> "$GITHUB_OUTPUT"
+            echo "path=${{ inputs.program }}" >> "$GITHUB_OUTPUT"
             echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
-            echo "parallel=${{ inputs.parallel }}" >> "$GITHUB_OUTPUT"
             echo "issue_num=" >> "$GITHUB_OUTPUT"
-
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+          else
             ISSUE_NUM="${{ github.event.issue.number }}"
             ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "${{ github.repository }}" --json body -q '.body')
-
-            TASK_YAML=$(echo "$ISSUE_BODY" | sed -n '/<!-- minion-task/,/minion-task -->/p' | sed '1d;$d')
-
-            if [ -z "$TASK_YAML" ]; then
-              echo "::error::No embedded minion-task YAML found in issue #${ISSUE_NUM}"
+            PROGRAM_PATH=$(echo "$ISSUE_BODY" | grep -oP '(?<=<!-- program: ).*(?= -->)' || true)
+            if [ -z "$PROGRAM_PATH" ]; then
+              echo "::error::No program reference in issue #${ISSUE_NUM}"
               exit 1
             fi
-
-            echo "$TASK_YAML" > "minions/tasks/_proposal-${ISSUE_NUM}.yaml"
-
-            echo "task_file=tasks/_proposal-${ISSUE_NUM}.yaml" >> "$GITHUB_OUTPUT"
+            echo "path=${PROGRAM_PATH}" >> "$GITHUB_OUTPUT"
             echo "dry_run=false" >> "$GITHUB_OUTPUT"
-            echo "parallel=1" >> "$GITHUB_OUTPUT"
-            echo "issue_num=${ISSUE_NUM}" >> "$GITHUB_OUTPUT"
-
-            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            gh issue comment "$ISSUE_NUM" --repo "${{ github.repository }}" \
-              --body "Minion build triggered. [View workflow run](${RUN_URL})"
-
-          else
-            ISSUE_NUM="${{ github.event.issue.number }}"
-            ISSUE_TITLE="$ISSUE_TITLE_ENV"
-            ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "${{ github.repository }}" --json body -q '.body')
-
-            TASK_YAML=$(echo "$ISSUE_BODY" | sed -n '/<!-- minion-task/,/minion-task -->/p' | sed '1d;$d')
-
-            if [ -n "$TASK_YAML" ]; then
-              echo "$TASK_YAML" > "minions/tasks/_proposal-${ISSUE_NUM}.yaml"
-              TASK_FILE="tasks/_proposal-${ISSUE_NUM}.yaml"
-            else
-              TASK_ID=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | head -c 60)
-              TASK_FILE="tasks/${TASK_ID}.yaml"
-
-              cat > "minions/${TASK_FILE}" <<YAML
-          id: ${TASK_ID}
-          title: "${ISSUE_TITLE}"
-          source: "${{ github.repository }}#${ISSUE_NUM}"
-          source_type: issue
-          description: |
-          $(echo "$ISSUE_BODY" | sed 's/^/  /')
-          target_repos:
-            - cli
-          acceptance_criteria:
-            - "All repo checks pass"
-          pr_labels:
-            - "minion"
-          YAML
-            fi
-
-            echo "task_file=${TASK_FILE}" >> "$GITHUB_OUTPUT"
-            echo "dry_run=false" >> "$GITHUB_OUTPUT"
-            echo "parallel=1" >> "$GITHUB_OUTPUT"
             echo "issue_num=${ISSUE_NUM}" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-          ISSUE_TITLE_ENV: ${{ github.event.issue.title }}
 
-      # Extract plan from issue comments (if available)
-      - name: Extract plan
-        id: plan
-        if: steps.task.outputs.issue_num != ''
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          ISSUE_NUM="${{ steps.task.outputs.issue_num }}"
-          PLAN_FILE="${{ github.workspace }}/minion-plan.md"
+      - name: Install minions
+        run: go install github.com/partio-io/minions/cmd/minions@latest
 
-          PLAN_BODY=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUM}/comments" \
-            --jq '[.[] | select(.body | contains("## Minion Plan"))] | last | .body // empty')
-
-          if [ -n "$PLAN_BODY" ]; then
-            echo "$PLAN_BODY" > "$PLAN_FILE"
-            echo "plan_file=${PLAN_FILE}" >> "$GITHUB_OUTPUT"
-            echo "Plan found, will be included as execution context"
-          else
-            echo "plan_file=" >> "$GITHUB_OUTPUT"
-            echo "No plan comment found, proceeding without plan"
-          fi
-
-      # Run the minion
-      - name: Execute minion
-        id: execute
+      - name: Run program
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          WORKSPACE_ROOT: ${{ github.workspace }}
-          MINION_PR_URLS_FILE: ${{ github.workspace }}/minion-pr-urls.txt
-          MINION_DEBUG_DIR: ${{ github.workspace }}/minion-debug
         run: |
-          cd minions
-          ARGS="run ${{ steps.task.outputs.task_file }}"
-          if [ "${{ steps.task.outputs.dry_run }}" = "true" ]; then
+          ARGS="run ${{ steps.program.outputs.path }}"
+          if [ "${{ steps.program.outputs.dry_run }}" = "true" ]; then
             ARGS="${ARGS} --dry-run"
           fi
-          ARGS="${ARGS} --parallel ${{ steps.task.outputs.parallel }}"
-          if [ -n "${{ steps.plan.outputs.plan_file }}" ]; then
-            ARGS="${ARGS} --plan-file ${{ steps.plan.outputs.plan_file }}"
-          fi
-          ./minions $ARGS
+          minions $ARGS
 
-      - name: Upload debug artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: minion-debug-${{ github.run_id }}
-          path: ${{ github.workspace }}/minion-debug/
-          if-no-files-found: ignore
-          retention-days: 7
-
-      # On success: mark done and close issue
       - name: Mark done
-        if: success() && steps.task.outputs.issue_num != ''
+        if: success() && steps.program.outputs.issue_num != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          ISSUE_NUM="${{ steps.task.outputs.issue_num }}"
-          COMMENT="Minion completed successfully."
-          PR_FILE="${{ github.workspace }}/minion-pr-urls.txt"
-          if [ -f "$PR_FILE" ] && [ -s "$PR_FILE" ]; then
-            COMMENT="${COMMENT}\n\nPRs created:"
-            while IFS= read -r url; do
-              COMMENT="${COMMENT}\n- ${url}"
-            done < "$PR_FILE"
-          fi
+          ISSUE_NUM="${{ steps.program.outputs.issue_num }}"
           gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" \
             --add-label "minion-done" --remove-label "minion-executing"
           gh issue close "$ISSUE_NUM" --repo "${{ github.repository }}" \
-            --comment "$(echo -e "$COMMENT")"
+            --comment "Minion completed successfully."
 
-      # On failure: mark failed with logs link
       - name: Mark failed
-        if: failure() && steps.task.outputs.issue_num != ''
+        if: failure() && steps.program.outputs.issue_num != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          ISSUE_NUM="${{ steps.task.outputs.issue_num }}"
+          ISSUE_NUM="${{ steps.program.outputs.issue_num }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" \
             --add-label "minion-failed" --remove-label "minion-executing"

--- a/.minions/ingest-prompt.md
+++ b/.minions/ingest-prompt.md
@@ -1,0 +1,45 @@
+You are analyzing content to extract feature ideas for the Partio project.
+
+Partio captures the reasoning behind code changes by hooking into Git workflows to preserve AI agent sessions alongside commits. It consists of:
+
+- **cli** (Go): The core CLI tool — hooks into git, captures sessions, stores checkpoints
+- **app** (Next.js): Dashboard for browsing checkpoint data
+- **docs** (Mintlify): Documentation site
+- **site** (Next.js): Marketing website
+- **extension**: Browser extension
+
+## Source Content
+
+Type: {{SOURCE_TYPE}}
+URL: {{SOURCE_URL}}
+
+### Content
+{{CONTENT}}
+
+## Instructions
+
+Analyze the content above and extract feature ideas that could be adapted for Partio. These are INSPIRATION — not direct copies. Partio and the source are related but independent products.
+
+For each feature idea, output a JSON object with these fields:
+
+```json
+{
+  "id": "kebab-case-id",
+  "title": "Short descriptive title",
+  "source": "reference to original (e.g., 'entireio/cli#373 (changelog 0.4.5)')",
+  "description": "What Partio should implement, adapted for its own architecture and conventions. Be specific about the desired behavior.",
+  "why": "Brief explanation of why this matters for Partio — what problem it solves or what value it adds for users.",
+  "user_relevance": "Why this change is relevant to Partio users — how it improves their experience, workflow, or the value they get from Partio.",
+  "target_repos": ["cli"],
+  "context_hints": ["cli/internal/relevant/path/"],
+  "acceptance_criteria": ["specific testable criterion 1", "specific testable criterion 2"]
+}
+```
+
+Do NOT include `docs` in `target_repos`. Documentation updates are handled automatically by the doc minion after code PRs merge — speculative docs PRs created alongside code changes become stale during review and get orphaned if the code PR is rejected.
+
+Output a JSON array of feature objects. Only include features that are genuinely relevant to Partio's domain (Git workflows, AI agent sessions, code attribution, checkpoints). Skip features that don't apply.
+
+If no relevant features are found, output an empty array: `[]`
+
+Output ONLY the JSON array, no other text.


### PR DESCRIPTION
* Objective

Update the Minion workflow to extract programs
from issues instead of YAML tasks and add a
configurable ingest prompt.

* Why

Standardize execution around .md program files,
remove hardcoded configuration, and allow host
projects to customize feature extraction logic.

* How

Programs-only execution: remove YAML task
support (runTasks, executeTask, runParallel).
Require the run command to accept only .md
program files. Update propose to embed
<!-- minion-program --> instead of YAML and
convert legacy <!-- minion-task --> formats
to programs on the fly.

Configurable ingest: load ingest-prompt.md
from the host project's .minions/ directory,
falling back to an embedded default if not
found. Resolve sources.yaml from the
principal repo defined in project config.

Project-agnostic setup: remove all hardcoded
partio-io references. Require
.minions/project.yaml in the host project.
Add internal/project and internal/repoconfig
packages, configurable FullNameFunc and
principalRepo, config-driven build info and
checks, dynamic repository checkout in
GitHub Actions via yq, git push auth fixes
for dynamic checkout, and a minions init
command for bootstrapping new projects.

Partio-Checkpoint: 99f3c67e32fb
Partio-Attribution: 100% agent