### PR TITLE
Install Minions from v0.0.1 tag

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@latest
+          go install github.com/partio-io/minions/cmd/minions@v0.0.1
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run doc-update program

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@latest
+          go install github.com/partio-io/minions/cmd/minions@v0.0.1
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@latest
+          go install github.com/partio-io/minions/cmd/minions@v0.0.1
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@latest
+          go install github.com/partio-io/minions/cmd/minions@v0.0.1
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program


### PR DESCRIPTION
* Objective

Install Minions using the v0.0.1 Git tag.

* Why

Pinning to a specific tag ensures a stable and
reproducible installation.

This avoids unexpected changes from newer
unreleased or breaking updates.

* How

Update the installation source to reference
the v0.0.1 tag instead of a branch or latest
commit.

Partio-Checkpoint: f785201ef12e
Partio-Attribution: 100% agent