### PR TITLE
Bump Minions to v0.0.2

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.1
+          go install github.com/partio-io/minions/cmd/minions@v0.0.2
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run doc-update program

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.1
+          go install github.com/partio-io/minions/cmd/minions@v0.0.2
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.1
+          go install github.com/partio-io/minions/cmd/minions@v0.0.2
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.1
+          go install github.com/partio-io/minions/cmd/minions@v0.0.2
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program


### PR DESCRIPTION
* Objective

Update the Minions dependency to version 0.0.2.

* Why

This ensures the project uses the latest available version with its associated fixes and improvements.

* How

Increase the Minions version reference to v0.0.2 in the relevant configuration files.

Partio-Checkpoint: 08f546c81718
Partio-Attribution: 100% agent