### PR TITLE
Increase implement.md Max Turns to 100

### DIFF
--- a/.minions/programs/implement.md
+++ b/.minions/programs/implement.md
@@ -31,3 +31,14 @@ A human will review your PR. Make it easy for them:
   - Key design decisions you made
   - How to test the changes
   - Reference to the source issue (e.g., "Resolves #120")
+
+## Agents
+
+### implement
+
+```capabilities
+max_turns: 100
+checks: true
+retry_on_fail: true
+retry_max_turns: 20
+```


### PR DESCRIPTION
* Objective

Increase the maximum number of turns in implement.md to 100.

* Why

This allows longer execution flows without prematurely hitting the previous turn limit.

* How

Update the max turns setting in implement.md from its previous value to 100.

Partio-Checkpoint: 3f36cf37e947
Partio-Attribution: 100% agent