### PR TITLE
Add Codex CLI agent integration

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.2
+          go install github.com/partio-io/minions/cmd/minions@v0.0.3
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run doc-update program

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.2
+          go install github.com/partio-io/minions/cmd/minions@v0.0.3
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.2
+          go install github.com/partio-io/minions/cmd/minions@v0.0.3
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.2
+          go install github.com/partio-io/minions/cmd/minions@v0.0.3
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.minions/programs/implement.md
+++ b/.minions/programs/implement.md
@@ -31,3 +31,14 @@ A human will review your PR. Make it easy for them:
   - Key design decisions you made
   - How to test the changes
   - Reference to the source issue (e.g., "Resolves #120")
+
+## Agents
+
+### implement
+
+```capabilities
+max_turns: 100
+checks: true
+retry_on_fail: true
+retry_max_turns: 20
+```

--- a/cmd/partio/status.go
+++ b/cmd/partio/status.go
@@ -48,6 +48,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	fmt.Println("Status:     enabled")
 	fmt.Printf("Strategy:   %s\n", cfg.Strategy)
 
+	// Detect which agent is currently running; fall back to configured agent name.
 	detectors := []agent.Detector{claude.New(), codex.New()}
 	detectedAgent := cfg.Agent
 	for _, d := range detectors {

--- a/cmd/partio/status.go
+++ b/cmd/partio/status.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/partio-io/cli/internal/agent"
+	"github.com/partio-io/cli/internal/agent/claude"
+	"github.com/partio-io/cli/internal/agent/codex"
 	"github.com/partio-io/cli/internal/config"
 	"github.com/partio-io/cli/internal/git"
 )
@@ -44,7 +47,16 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Status:     enabled")
 	fmt.Printf("Strategy:   %s\n", cfg.Strategy)
-	fmt.Printf("Agent:      %s\n", cfg.Agent)
+
+	detectors := []agent.Detector{claude.New(), codex.New()}
+	detectedAgent := cfg.Agent
+	for _, d := range detectors {
+		if running, _ := d.IsRunning(); running {
+			detectedAgent = d.Name()
+			break
+		}
+	}
+	fmt.Printf("Agent:      %s\n", detectedAgent)
 
 	// Check hooks
 	hooksDir, hooksErr := git.HooksDir(repoRoot)

--- a/cmd/partio/status.go
+++ b/cmd/partio/status.go
@@ -50,14 +50,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	// Detect which agent is currently running; fall back to configured agent name.
 	detectors := []agent.Detector{claude.New(), codex.New()}
-	detectedAgent := cfg.Agent
-	for _, d := range detectors {
-		if running, _ := d.IsRunning(); running {
-			detectedAgent = d.Name()
-			break
-		}
+	if detected := agent.Detect(detectors); detected != nil {
+		fmt.Printf("Agent:      %s (running)\n", detected.Name())
+	} else {
+		fmt.Printf("Agent:      %s\n", cfg.Agent)
 	}
-	fmt.Printf("Agent:      %s\n", detectedAgent)
 
 	// Check hooks
 	hooksDir, hooksErr := git.HooksDir(repoRoot)

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -1,0 +1,14 @@
+package codex
+
+// Detector implements the agent.Detector interface for Codex CLI.
+type Detector struct{}
+
+// New creates a new Codex CLI detector.
+func New() *Detector {
+	return &Detector{}
+}
+
+// Name returns the agent name.
+func (d *Detector) Name() string {
+	return "codex"
+}

--- a/internal/agent/codex/find_session_dir.go
+++ b/internal/agent/codex/find_session_dir.go
@@ -1,0 +1,23 @@
+package codex
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FindSessionDir returns the Codex CLI session directory for the given repo.
+// Codex stores its data at ~/.codex/.
+func (d *Detector) FindSessionDir(repoRoot string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+
+	sessionDir := filepath.Join(home, ".codex")
+	if _, err := os.Stat(sessionDir); err != nil {
+		return "", fmt.Errorf("no Codex session directory found for %s", repoRoot)
+	}
+
+	return sessionDir, nil
+}

--- a/internal/agent/codex/find_session_dir.go
+++ b/internal/agent/codex/find_session_dir.go
@@ -16,7 +16,7 @@ func (d *Detector) FindSessionDir(repoRoot string) (string, error) {
 
 	sessionDir := filepath.Join(home, ".codex")
 	if _, err := os.Stat(sessionDir); err != nil {
-		return "", fmt.Errorf("no Codex session directory found for %s", repoRoot)
+		return "", fmt.Errorf("no Codex session directory found: %w", err)
 	}
 
 	return sessionDir, nil

--- a/internal/agent/codex/process.go
+++ b/internal/agent/codex/process.go
@@ -1,0 +1,24 @@
+package codex
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// execCommand is the function used to run pgrep. It can be overridden in tests.
+var execCommand = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// IsRunning checks if a Codex CLI process is currently running.
+func (d *Detector) IsRunning() (bool, error) {
+	out, err := execCommand("pgrep", "-f", "codex")
+	if err != nil {
+		// pgrep returns exit code 1 if no processes found
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}

--- a/internal/agent/codex/process_test.go
+++ b/internal/agent/codex/process_test.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 )
@@ -59,6 +60,7 @@ func TestIsRunning(t *testing.T) {
 
 			d := New()
 			got, err := d.IsRunning()
+
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -72,5 +74,44 @@ func TestIsRunning(t *testing.T) {
 				t.Errorf("IsRunning() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestName(t *testing.T) {
+	d := New()
+	if got := d.Name(); got != "codex" {
+		t.Errorf("Name() = %q, want %q", got, "codex")
+	}
+}
+
+func TestFindSessionDir_NoCodexDir(t *testing.T) {
+	// Point HOME at a temp directory that has no .codex subdirectory.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	d := New()
+	_, err := d.FindSessionDir("/some/repo")
+	if err == nil {
+		t.Fatal("expected error when ~/.codex does not exist, got nil")
+	}
+}
+
+func TestFindSessionDir_CodexDirExists(t *testing.T) {
+	// Create a temp HOME with a .codex directory.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	codexDir := tmp + "/.codex"
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	d := New()
+	got, err := d.FindSessionDir("/some/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != codexDir {
+		t.Errorf("FindSessionDir() = %q, want %q", got, codexDir)
 	}
 }

--- a/internal/agent/codex/process_test.go
+++ b/internal/agent/codex/process_test.go
@@ -1,0 +1,76 @@
+package codex
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestIsRunning(t *testing.T) {
+	// Generate a real exit-1 error to simulate pgrep finding no processes.
+	_, pgrepNotFoundErr := exec.Command("bash", "-c", "exit 1").Output()
+
+	tests := []struct {
+		name    string
+		out     []byte
+		err     error
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "process running",
+			out:  []byte("1234\n"),
+			err:  nil,
+			want: true,
+		},
+		{
+			name: "process running multiple pids",
+			out:  []byte("1234\n5678\n"),
+			err:  nil,
+			want: true,
+		},
+		{
+			name: "process not running returns exit 1",
+			out:  nil,
+			err:  pgrepNotFoundErr,
+			want: false,
+		},
+		{
+			name: "empty output means not running",
+			out:  []byte(""),
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "whitespace only output means not running",
+			out:  []byte("   \n"),
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := execCommand
+			defer func() { execCommand = orig }()
+
+			execCommand = func(name string, args ...string) ([]byte, error) {
+				return tt.out, tt.err
+			}
+
+			d := New()
+			got, err := d.IsRunning()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("IsRunning() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agent/detect.go
+++ b/internal/agent/detect.go
@@ -1,0 +1,19 @@
+package agent
+
+import "log/slog"
+
+// Detect iterates over the provided detectors and returns the first one
+// whose process is currently running. If no agent is detected, it returns nil.
+func Detect(detectors []Detector) Detector {
+	for _, d := range detectors {
+		running, err := d.IsRunning()
+		if err != nil {
+			slog.Debug("error checking agent", "agent", d.Name(), "error", err)
+			continue
+		}
+		if running {
+			return d
+		}
+	}
+	return nil
+}

--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/partio-io/cli/internal/agent"
 	"github.com/partio-io/cli/internal/agent/claude"
 	"github.com/partio-io/cli/internal/attribution"
 	"github.com/partio-io/cli/internal/checkpoint"
@@ -65,11 +66,16 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		attr = &attribution.Result{AgentPercent: 100}
 	}
 
-	// Parse agent session data
-	detector := claude.New()
-	sessionPath, sessionData, err := detector.FindLatestSession(repoRoot)
-	if err != nil {
-		slog.Warn("could not read agent session", "error", err)
+	// Parse agent session data (Claude-specific; skipped for other agents).
+	var sessionPath string
+	var sessionData *agent.SessionData
+	if state.AgentName == "" || state.AgentName == "claude-code" {
+		detector := claude.New()
+		var parseErr error
+		sessionPath, sessionData, parseErr = detector.FindLatestSession(repoRoot)
+		if parseErr != nil {
+			slog.Warn("could not read agent session", "error", parseErr)
+		}
 	}
 
 	// Skip if this session is already fully condensed and ended — re-processing
@@ -100,13 +106,19 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		return fmt.Errorf("getting post-amend commit: %w", err)
 	}
 
+	// Use the detected agent name from pre-commit state, falling back to config.
+	agentName := state.AgentName
+	if agentName == "" {
+		agentName = cfg.Agent
+	}
+
 	// Create checkpoint with the post-amend hash
 	cp := &checkpoint.Checkpoint{
 		ID:          cpID,
 		CommitHash:  commitHash,
 		Branch:      state.Branch,
 		CreatedAt:   time.Now(),
-		Agent:       cfg.Agent,
+		Agent:       agentName,
 		AgentPct:    attr.AgentPercent,
 		ContentHash: commitHash,
 	}
@@ -122,7 +134,7 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		Context:     "",
 		FullJSONL:   "",
 		Metadata: checkpoint.SessionMetadata{
-			Agent: cfg.Agent,
+			Agent: agentName,
 		},
 		Prompt: "",
 	}

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/partio-io/cli/internal/agent/claude"
+	"github.com/partio-io/cli/internal/agent/codex"
 	"github.com/partio-io/cli/internal/config"
 	"github.com/partio-io/cli/internal/git"
 	"github.com/partio-io/cli/internal/session"
@@ -27,10 +28,10 @@ func (r *Runner) PreCommit() error {
 }
 
 func runPreCommit(repoRoot string, cfg config.Config) error {
-	detector := claude.New()
+	claudeDetector := claude.New()
 
-	// Detect if agent is running
-	running, err := detector.IsRunning()
+	// Detect if Claude Code is running (with full session capture support).
+	running, err := claudeDetector.IsRunning()
 	if err != nil {
 		slog.Warn("could not detect agent process", "error", err)
 		running = false
@@ -40,7 +41,7 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 		// Quick check: find the latest JSONL path without a full parse and see if
 		// we have already captured this session in a fully-condensed ended state.
 		// This avoids the expensive JSONL parse for stale sessions.
-		latestPath, pathErr := detector.FindLatestJSONLPath(repoRoot)
+		latestPath, pathErr := claudeDetector.FindLatestJSONLPath(repoRoot)
 		if pathErr == nil {
 			sid := claude.PeekSessionID(latestPath)
 			if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sid, latestPath) {
@@ -50,9 +51,21 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 		}
 	}
 
+	// If Claude Code is not running, check for Codex CLI.
+	if !running {
+		codexDetector := codex.New()
+		codexRunning, codexErr := codexDetector.IsRunning()
+		if codexErr != nil {
+			slog.Warn("could not detect codex process", "error", codexErr)
+		} else if codexRunning {
+			running = true
+			slog.Debug("codex agent detected")
+		}
+	}
+
 	var sessionPath string
 	if running {
-		path, _, err := detector.FindLatestSession(repoRoot)
+		path, _, err := claudeDetector.FindLatestSession(repoRoot)
 		if err != nil {
 			slog.Debug("agent running but no session found", "error", err)
 		} else {

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -30,39 +30,33 @@ func (r *Runner) PreCommit() error {
 }
 
 func runPreCommit(repoRoot string, cfg config.Config) error {
-	// Try each detector in order; first running agent wins.
 	detectors := []agent.Detector{claude.New(), codex.New()}
-	var activeDetector agent.Detector
-	for _, d := range detectors {
-		running, err := d.IsRunning()
-		if err != nil {
-			slog.Warn("could not detect agent process", "agent", d.Name(), "error", err)
-			continue
-		}
-		if running {
-			activeDetector = d
-			break
-		}
+	detected := agent.Detect(detectors)
+
+	running := detected != nil
+	if !running {
+		slog.Debug("no agent process detected")
 	}
 
-	running := activeDetector != nil
-
-	// For Claude, perform the quick JSONL check to skip already-captured sessions.
-	// This avoids the expensive JSONL parse for stale sessions.
-	if claudeDetector, ok := activeDetector.(*claude.Detector); ok {
+	// Claude-specific session checks
+	claudeDetector, isClaude := detected.(*claude.Detector)
+	if running && isClaude {
+		// Quick check: find the latest JSONL path without a full parse and see if
+		// we have already captured this session in a fully-condensed ended state.
+		// This avoids the expensive JSONL parse for stale sessions.
 		latestPath, pathErr := claudeDetector.FindLatestJSONLPath(repoRoot)
 		if pathErr == nil {
 			sid := claude.PeekSessionID(latestPath)
 			if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sid, latestPath) {
 				slog.Debug("skipping already-condensed ended session", "session_id", sid)
 				running = false
-				activeDetector = nil
+				detected = nil
 			}
 		}
 	}
 
 	var sessionPath string
-	if claudeDetector, ok := activeDetector.(*claude.Detector); ok {
+	if running && isClaude {
 		path, _, err := claudeDetector.FindLatestSession(repoRoot)
 		if err != nil {
 			slog.Debug("agent running but no session found", "error", err)
@@ -73,15 +67,18 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 	}
 
 	agentName := ""
-	if activeDetector != nil {
-		agentName = activeDetector.Name()
+	if detected != nil {
+		agentName = detected.Name()
 	}
 
 	branch, _ := git.CurrentBranch()
 	commitHash, _ := git.CurrentCommit()
 
+	// For Claude, require a session path. For other agents, mark active if running.
+	agentActive := running && (sessionPath != "" || !isClaude)
+
 	state := preCommitState{
-		AgentActive:   running && (sessionPath != "" || agentName == "codex"),
+		AgentActive:   agentActive,
 		AgentName:     agentName,
 		SessionPath:   sessionPath,
 		PreCommitHash: commitHash,

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/partio-io/cli/internal/agent"
 	"github.com/partio-io/cli/internal/agent/claude"
 	"github.com/partio-io/cli/internal/agent/codex"
 	"github.com/partio-io/cli/internal/config"
@@ -16,6 +17,7 @@ import (
 // preCommitState records the state captured during pre-commit for use by post-commit.
 type preCommitState struct {
 	AgentActive   bool   `json:"agent_active"`
+	AgentName     string `json:"agent_name,omitempty"`
 	SessionPath   string `json:"session_path,omitempty"`
 	PreCommitHash string `json:"pre_commit_hash,omitempty"`
 	Branch        string `json:"branch"`
@@ -28,43 +30,39 @@ func (r *Runner) PreCommit() error {
 }
 
 func runPreCommit(repoRoot string, cfg config.Config) error {
-	claudeDetector := claude.New()
-
-	// Detect if Claude Code is running (with full session capture support).
-	running, err := claudeDetector.IsRunning()
-	if err != nil {
-		slog.Warn("could not detect agent process", "error", err)
-		running = false
+	// Try each detector in order; first running agent wins.
+	detectors := []agent.Detector{claude.New(), codex.New()}
+	var activeDetector agent.Detector
+	for _, d := range detectors {
+		running, err := d.IsRunning()
+		if err != nil {
+			slog.Warn("could not detect agent process", "agent", d.Name(), "error", err)
+			continue
+		}
+		if running {
+			activeDetector = d
+			break
+		}
 	}
 
-	if running {
-		// Quick check: find the latest JSONL path without a full parse and see if
-		// we have already captured this session in a fully-condensed ended state.
-		// This avoids the expensive JSONL parse for stale sessions.
+	running := activeDetector != nil
+
+	// For Claude, perform the quick JSONL check to skip already-captured sessions.
+	// This avoids the expensive JSONL parse for stale sessions.
+	if claudeDetector, ok := activeDetector.(*claude.Detector); ok {
 		latestPath, pathErr := claudeDetector.FindLatestJSONLPath(repoRoot)
 		if pathErr == nil {
 			sid := claude.PeekSessionID(latestPath)
 			if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sid, latestPath) {
 				slog.Debug("skipping already-condensed ended session", "session_id", sid)
 				running = false
+				activeDetector = nil
 			}
 		}
 	}
 
-	// If Claude Code is not running, check for Codex CLI.
-	if !running {
-		codexDetector := codex.New()
-		codexRunning, codexErr := codexDetector.IsRunning()
-		if codexErr != nil {
-			slog.Warn("could not detect codex process", "error", codexErr)
-		} else if codexRunning {
-			running = true
-			slog.Debug("codex agent detected")
-		}
-	}
-
 	var sessionPath string
-	if running {
+	if claudeDetector, ok := activeDetector.(*claude.Detector); ok {
 		path, _, err := claudeDetector.FindLatestSession(repoRoot)
 		if err != nil {
 			slog.Debug("agent running but no session found", "error", err)
@@ -74,11 +72,17 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 		}
 	}
 
+	agentName := ""
+	if activeDetector != nil {
+		agentName = activeDetector.Name()
+	}
+
 	branch, _ := git.CurrentBranch()
 	commitHash, _ := git.CurrentCommit()
 
 	state := preCommitState{
-		AgentActive:   running && sessionPath != "",
+		AgentActive:   running && (sessionPath != "" || agentName == "codex"),
+		AgentName:     agentName,
 		SessionPath:   sessionPath,
 		PreCommitHash: commitHash,
 		Branch:        branch,


### PR DESCRIPTION
## Summary

- Add `internal/agent/codex/` package with `Detector` implementation for OpenAI Codex CLI process detection
- Add `agent.Detect()` detection chain function that tries multiple detectors and returns the first running agent
- Update pre-commit and post-commit hooks to use the detection chain instead of hardcoded `claude.New()`, with Claude-specific session parsing guarded behind a type assertion
- Update `partio status` to show the currently running agent with `(running)` indicator
- Add table-driven unit tests for Codex process detection (5 cases), name, and session dir discovery

## Test plan

- [x] `make test` passes — all existing and new tests green
- [x] `make lint` passes — 0 issues
- [x] Codex detector correctly returns "codex" name
- [x] Process detection handles: running, multiple PIDs, not running (exit 1), empty output, whitespace-only output
- [x] FindSessionDir returns error when `~/.codex` doesn't exist, and returns path when it does
- [x] Hooks still work correctly for Claude Code (session parsing, condensed skip logic)
- [x] Hooks mark agent active for Codex even without session path

🤖 Generated with [Claude Code](https://claude.com/claude-code)