### PR TITLE
Add research-minion workflow skeleton (slice 1)

### DIFF
--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -1,0 +1,66 @@
+name: Run Research Minion
+
+on:
+  issues:
+    types: [labeled]
+
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run-research:
+    if: >
+      (github.event_name == 'issues' &&
+       github.event.label.name == 'minion-research' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)) ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '/minion research') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: github-runner-partio-minion-ai-01
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone argos
+        uses: actions/checkout@v4
+        with:
+          repository: jcleira/argos
+          ref: master
+          token: ${{ secrets.GH_PAT }}
+          path: argos
+
+      - name: Print argos SHA
+        run: |
+          ARGOS_SHA=$(git -C argos rev-parse HEAD)
+          ARGOS_SHA_SHORT=$(git -C argos rev-parse --short HEAD)
+          echo "argos master cloned at ${ARGOS_SHA} (${ARGOS_SHA_SHORT})"
+
+      - name: Install minions
+        run: |
+          go install github.com/partio-io/minions/cmd/minions@v0.0.5
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Run program
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          MINION_ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          minions run .minions/programs/research.md --issue ${{ github.event.issue.number }}
+
+      - name: Mark failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          ISSUE_NUM="${{ github.event.issue.number }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" \
+            --add-label "minion-failed"
+          gh issue comment "$ISSUE_NUM" --repo "${{ github.repository }}" \
+            --body "Research minion execution failed. [View logs](${RUN_URL})"

--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -1,0 +1,51 @@
+---
+id: research
+target_repos:
+  - cli
+---
+
+# Research minion (skeleton)
+
+Tracer-bullet stub for the research minion path. Slice 1 of the
+multi-slice rollout described in
+`partio-minions/docs/2026-05-05-research-minion/issues/01-workflow-skeleton.md`.
+
+The single agent below posts a one-line acknowledgement comment on
+the parent issue to confirm that label → workflow → minions runtime
+→ `gh` side effect all wire up correctly. The real researcher,
+persona, prd-writer, slicer, and publisher agents land in slices 2
+through 4.
+
+## Agents
+
+### stub
+
+```capabilities
+tools: Bash
+max_turns: 5
+```
+
+Post a one-line "research started" comment on the parent issue, then
+exit cleanly without modifying the worktree.
+
+The parent issue number is available in the env var
+`$MINION_ISSUE_NUMBER`. The workflow run id is in `$GITHUB_RUN_ID`.
+
+Run, in this exact order:
+
+1. Compute a 7-character run identifier from the workflow run id:
+
+   ```bash
+   RUN_SHA7=$(printf '%s' "$GITHUB_RUN_ID" | sha1sum | head -c 7)
+   ```
+
+2. Post the comment:
+
+   ```bash
+   gh issue comment "$MINION_ISSUE_NUMBER" \
+     --repo partio-io/cli \
+     --body "research started — run-id \`$RUN_SHA7\`"
+   ```
+
+3. Exit. Do not write any files. Do not modify the worktree. Do not
+   call any other tools.


### PR DESCRIPTION
## Summary

Tracer-bullet slice 1 of the research-minion PRD
([partio-minions/docs/2026-05-05-research-minion/prd.md](https://github.com/partio-io/minions/blob/main/docs/2026-05-05-research-minion/prd.md)).

Proves the wire end-to-end (label → workflow trigger →
`author_association` gate → `jcleira/argos` clone via PAT → minions
runtime → multi-agent program parsing → `gh` side effect on the parent
issue) before any real research / persona / PRD-writer / slicer
logic is added in slices 2–4.

### What lands

- `.github/workflows/research.yml` — fires on `minion-research` label
  or `/minion research` comment from OWNER/MEMBER/COLLABORATOR; clones
  `jcleira/argos@master` into the workspace via `secrets.GH_PAT`; runs
  `minions run .minions/programs/research.md --issue <N>` with a
  90-minute timeout on the existing self-hosted runner. Adds
  `minion-failed` + run-URL comment on failure. **No** mark-done /
  auto-close step — the parent issue stays open.
- `.minions/programs/research.md` — single `stub` agent. Posts a
  one-line `research started — run-id <sha7>` comment on the parent
  issue and exits. Real agents land in slices 2–4.

### What's already in place (outside this PR)

- Three labels exist on `partio-io/cli`: `minion-research` (#006B75),
  `minion-research-output` (#BFD4F2), `minion-research-completed`
  (#0E8A16).
- `secrets.GH_PAT` is configured; the local PAT verifies it has
  `repo` scope and reads `jcleira/argos@master` cleanly. Final proof
  comes from the smoke run below.

### Worth flagging

- The slice spec calls for `git@github.com:jcleira/argos.git` with a
  PAT, which doesn't actually authenticate (PATs are HTTPS bearer
  tokens). I used `actions/checkout@v4` with `repository:`, `ref:
  master`, `token: secrets.GH_PAT`, `path: argos` — canonical pattern
  and functionally equivalent.
- `MINION_ISSUE_NUMBER` env var is set on the `Run program` step so
  the stub can `gh issue comment <N>`. Runtime injects issue
  *body* into the agent prompt but not the *number*; this is a
  small ad-hoc convention specific to this slice. Open question
  whether to extend the runtime instead — out of scope here.

## Test plan

- [ ] Merge this PR.
- [ ] Apply `minion-research` to a throwaway issue on `partio-io/cli`.
- [ ] Confirm the `Run Research Minion` workflow fires, the
  `Clone argos` step prints an SHA, and a comment from the runner
  reading `research started — run-id <sha7>` lands on the parent.
- [ ] Confirm the parent issue stays open (no mark-done step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)