### PR TITLE
ci: clone persona substrate repo at runtime via scoped PAT

### DIFF
--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: jcleira/argos
           ref: master
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.ARGOS_PAT }}
           path: argos
 
       - name: Print argos SHA


### PR DESCRIPTION
Historical: configured the research workflow to clone the persona substrate repo at runtime via a scoped PAT.

This runtime-clone approach was later removed for privacy — the substrate is now sanitized and in-repo. See the research-minion persona-substrate work.
