### PR TITLE
Add research-minion researcher/persona/publisher (slice 2)

### DIFF
--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -4,48 +4,183 @@ target_repos:
   - cli
 ---
 
-# Research minion (skeleton)
+# Research minion
 
-Tracer-bullet stub for the research minion path. Slice 1 of the
-multi-slice rollout described in
-`partio-minions/docs/2026-05-05-research-minion/issues/01-workflow-skeleton.md`.
+Unattended research pipeline for complex `partio-io/cli` issues. A
+parent issue labeled `minion-research` (or commented `/minion
+research`) fires `research.yml`, which clones `jcleira/argos` into the
+workspace and runs this program. Slice 2 of the rollout described in
+`partio-minions/docs/2026-05-05-research-minion/`.
 
-The single agent below posts a one-line acknowledgement comment on
-the parent issue to confirm that label → workflow → minions runtime
-→ `gh` side effect all wire up correctly. The real researcher,
-persona, prd-writer, slicer, and publisher agents land in slices 2
-through 4.
+This slice wires the first half of the pipeline:
+
+- `researcher` drives a `/code-research`-style interview against the
+  parent issue and writes the questions to a shared transcript.
+- `persona` answers each question the way jcleira would, grounded in
+  the argos TELOS and memory substrate, never leaking personal data.
+- `publisher` posts the resulting Q&A transcript as a comment on the
+  parent issue so the work is visible.
+
+The `prd-writer` and `slicer` agents, idempotency markers, and the
+`minion-research-completed` label arrive in later slices. This run
+produces no PR; its only side effect is the publisher's issue comment.
+
+Every agent runs as its own one-shot Claude session, in the order
+declared below. Each agent gets a fresh, isolated worktree that is
+discarded when it finishes, so worktree-relative files do NOT survive
+between agents. State is therefore exchanged through a stable path
+outside any worktree. Every agent computes the exact same path:
+
+```
+TRANSCRIPT="/tmp/minion-research-transcript-${MINION_ISSUE_NUMBER:-0}.md"
+```
+
+The parent issue number is in `$MINION_ISSUE_NUMBER`. The parent
+issue body is also provided to every agent under an "Issue" section of
+its prompt. The repository for all `gh` calls is `partio-io/cli`.
+
+Because state lives in `$TRANSCRIPT` and nothing is written into the
+worktree, every agent legitimately produces "no changes" and the run
+ends without a PR. That is intended.
+
+## Context
+
+- `argos/telos/MISSION.md`
+- `argos/telos/GOALS.md`
+- `argos/telos/PROJECTS.md`
+- `argos/telos/BELIEFS.md`
+- `argos/memory/*.md`
 
 ## Agents
 
-### stub
+### researcher
 
 ```capabilities
-tools: Bash
-max_turns: 5
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+max_turns: 40
 ```
 
-Post a one-line "research started" comment on the parent issue, then
-exit cleanly without modifying the worktree.
+You are the researcher. Interview the parent issue relentlessly, in
+the spirit of the `/code-research` skill: walk down every branch of
+the design tree, resolving dependencies between decisions one at a
+time, until there is enough shared understanding to hand off to a PRD
+writer in a later phase. If a question can be answered by exploring
+the `cli` codebase, explore the codebase instead of asking. For every
+question, also state your own recommended answer — the persona phase
+decides, but it needs your recommendation as the default.
 
-The parent issue number is available in the env var
-`$MINION_ISSUE_NUMBER`. The workflow run id is in `$GITHUB_RUN_ID`.
+You do NOT answer the questions yourself, and you do NOT interact with
+any human — this is a fully autonomous run. Produce the questions
+only.
 
-Run, in this exact order:
+Transcript protocol:
 
-1. Compute a 7-character run identifier from the workflow run id:
+1. Compute the shared path:
 
-   ```bash
-   RUN_SHA7=$(printf '%s' "$GITHUB_RUN_ID" | sha1sum | head -c 7)
+   ```
+   TRANSCRIPT="/tmp/minion-research-transcript-${MINION_ISSUE_NUMBER:-0}.md"
    ```
 
-2. Post the comment:
+2. Initialize it fresh (truncate any stale content from a previous
+   run), starting with a single title line naming the parent issue,
+   for example `Research transcript — issue #<n>`.
 
-   ```bash
-   gh issue comment "$MINION_ISSUE_NUMBER" \
-     --repo partio-io/cli \
-     --body "research started — run-id \`$RUN_SHA7\`"
+3. For each question, append a block to `$TRANSCRIPT` consisting of a
+   line that reads exactly `## Q<n>` (sequential, starting at 1), the
+   question text on the following lines, and a final line
+   `Recommended: <your recommended answer>`. One block per question.
+   Ask one question at a time, in dependency order, the way
+   `/code-research` would.
+
+4. When you have enough to hand off to the PRD writer, append a final
+   line to `$TRANSCRIPT` that reads exactly `RESEARCH_COMPLETE` on its
+   own line, then stop.
+
+Do not create or modify any file in the working directory. Write only
+`$TRANSCRIPT`. Do not run `git` and do not open a PR.
+
+### persona
+
+```capabilities
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+max_turns: 40
+```
+
+You answer each research question as jcleira would.
+
+Privacy directive (load-bearing — must not be edited away): Use TELOS
+and memory to *decide* — what answer would jcleira give? Never quote,
+paraphrase, or reference personal data (health, training, daily diary
+content, finances, location, calendar) in any output. Output answers
+in your own words, framed as decisions on the question at hand.
+
+Substrate: the four argos TELOS files (`MISSION.md`, `GOALS.md`,
+`PROJECTS.md`, `BELIEFS.md`) are already injected into your prompt
+under the pre-read context section. In addition, read every file
+matching `argos/memory/*.md` from the cloned argos repository so you
+have the full memory substrate (~48 files). Resolve the argos clone
+location in this order: if `$GITHUB_WORKSPACE` is set and
+`$GITHUB_WORKSPACE/argos` exists, use that; otherwise search upward
+from the current directory for a sibling `argos/` directory; otherwise
+fall back to the pre-read TELOS alone. You decide at runtime which
+substrate is relevant to each question — there is no curation.
+
+Transcript protocol:
+
+1. Compute the shared path:
+
+   ```
+   TRANSCRIPT="/tmp/minion-research-transcript-${MINION_ISSUE_NUMBER:-0}.md"
    ```
 
-3. Exit. Do not write any files. Do not modify the worktree. Do not
-   call any other tools.
+2. Read `$TRANSCRIPT`. It contains numbered `## Q<n>` question blocks
+   written by the researcher and a trailing `RESEARCH_COMPLETE` line.
+
+3. Walk the questions in order. For each `## Q<n>` block that is not
+   already followed by an `## Answer` block, append immediately after
+   that question a line that reads exactly `## Answer` followed by
+   jcleira's decision in your own words. Move to the next unanswered
+   question and repeat until every question has an `## Answer` block.
+
+Output answers as decisions, not as recitations of substrate. Do not
+create or modify any file in the working directory other than
+appending to `$TRANSCRIPT`. Do not run `git` and do not open a PR.
+
+### publisher
+
+```capabilities
+tools:
+  - Read
+  - Bash
+max_turns: 10
+```
+
+You publish the completed transcript so the research is visible on the
+parent issue.
+
+1. Compute the shared path:
+
+   ```
+   TRANSCRIPT="/tmp/minion-research-transcript-${MINION_ISSUE_NUMBER:-0}.md"
+   ```
+
+2. Post its full contents as a single comment on the parent issue:
+
+   ```
+   gh issue comment "$MINION_ISSUE_NUMBER" --repo partio-io/cli --body-file "$TRANSCRIPT"
+   ```
+
+This transitional transcript comment carries no idempotency marker —
+that arrives with the PRD comment in a later slice. Post exactly one
+comment. Do not modify the worktree, do not run `git`, and do not open
+a PR.


### PR DESCRIPTION
## Summary

Slice 2 of the research-minion PRD (`partio-minions/docs/2026-05-05-research-minion`). Replaces the slice-1 stub agent in `.minions/programs/research.md` with three real sub-agents that, together, produce a Q&A transcript and post it on the parent issue.

- **researcher** — `/code-research`-style interview against the parent issue. Writes one numbered `## Q<n>` block per question with a `Recommended:` line, then appends `RESEARCH_COMPLETE`.
- **persona** — answers each `## Q<n>` with an `## Answer` block, grounded in argos TELOS + all `argos/memory/*.md` loaded at runtime. Carries the PRD's load-bearing privacy directive verbatim (use TELOS/memory to *decide*, never quote or paraphrase health/training/diary/finance/location/calendar data).
- **publisher** — posts the transcript as a single comment via `gh issue comment --body-file`.

## Design note worth reviewing

The PRD assumes sub-agents share a worktree (`./research-transcript.md`). The minions runtime actually gives each agent its own worktree (`taskID = prog.ID + "-" + agent.Name` in `internal/executor/executor.go`) and force-removes it on finish, so a worktree-relative transcript wouldn't survive between agents. This PR uses a stable path outside any worktree: `/tmp/minion-research-transcript-\${MINION_ISSUE_NUMBER:-0}.md`. Nothing is written into the worktree, so the run produces no PR — consistent with the PRD's "no PR for research" intent.

The persona agent independently resolves the argos clone via `\$GITHUB_WORKSPACE/argos` with an upward-search fallback, so it doesn't rely on the `## Context` pre-reader (which doesn't expand globs and joins against `workspaceRoot`, not `\$GITHUB_WORKSPACE`).

## Out of scope (later slices)

- `prd-writer` agent + PRD comment formatting (slice 3).
- `slicer` agent + child issues (slice 4).
- Idempotency markers (slice 5).
- `minion-research-completed` label flip (slice 3).

## Test plan

- [ ] Merge to \`main\`.
- [ ] Re-trigger workflow on partio-io/cli#24 (unlabel + relabel \`minion-research\`).
- [ ] Confirm a new comment appears containing \`## Q<n>\` / \`## Answer\` blocks (not the slice-1 \`research started — run-id ...\` stub).
- [ ] Manual review of the comment confirms no personal data leak: no Whoop/Garmin numbers, no diary excerpts, no calendar event names, no financial figures, no specific location strings. Answers read as decisions, not recitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)