### PR TITLE
Add slicer agent + child issues + status comment (slice 4)

### DIFF
--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -9,10 +9,10 @@ target_repos:
 Unattended research pipeline for complex `partio-io/cli` issues. A
 parent issue labeled `minion-research` (or commented `/minion
 research`) fires `research.yml`, which clones `jcleira/argos` into the
-workspace and runs this program. Slice 3 of the rollout described in
+workspace and runs this program. Slice 4 of the rollout described in
 `partio-minions/docs/2026-05-05-research-minion/`.
 
-This slice wires the research → PRD half of the pipeline:
+This slice completes the research → PRD → slice → publish pipeline:
 
 - `researcher` drives a `/code-research`-style interview against the
   parent issue and writes the questions to a shared transcript.
@@ -20,26 +20,33 @@ This slice wires the research → PRD half of the pipeline:
   the argos TELOS and memory substrate, never leaking personal data.
 - `prd-writer` reads the completed Q&A transcript and synthesizes a
   PRD body in the shape produced by the `/code-create-prd` skill.
-- `publisher` posts the PRD body as a comment on the parent issue,
-  prefixed with a run-scoped idempotency marker, and labels the parent
-  `minion-research-completed` so the research phase is visible. The
-  parent issue is intentionally left open and never receives
-  `minion-done`.
+- `slicer` reads the PRD body and decomposes it into vertical-slice
+  blocks, one per child issue, in the spirit of the
+  `/code-create-issues` skill.
+- `publisher` posts the PRD body as a comment on the parent issue
+  (prefixed with a run-scoped idempotency marker), labels the parent
+  `minion-research-completed`, opens one child issue per slice (each
+  labeled `minion-approved` so `minion.yml` auto-fires `implement.md`,
+  plus `minion-research-output` for provenance), and posts a status
+  comment linking the child issues. The parent issue is intentionally
+  left open and never receives `minion-done`.
 
-The `slicer` agent and child-issue creation arrive in slice 4. The
-*skip-if-marker-exists* idempotency check (re-runs reading existing
-comments before writing) arrives in slice 5. This run produces no PR;
-its only side effects are the PRD comment and the parent label.
+The *skip-if-marker-exists* idempotency check (re-runs reading existing
+comments and issues before writing) arrives in slice 5; this slice
+writes the markers but does not yet check for them. This run produces
+no PR; its only side effects are the PRD comment, the parent label, the
+child issues, and the status comment.
 
 Every agent runs as its own one-shot Claude session, in the order
 declared below. Each agent gets a fresh, isolated worktree that is
 discarded when it finishes, so worktree-relative files do NOT survive
 between agents. State is therefore exchanged through stable paths
-outside any worktree. Every agent computes the exact same paths:
+outside any worktree. The stable paths used across agents are:
 
 ```
 TRANSCRIPT="/tmp/minion-research-transcript-${MINION_ISSUE_NUMBER:-0}.md"
 PRD_DRAFT="/tmp/minion-research-prd-draft-${MINION_ISSUE_NUMBER:-0}.md"
+SLICES="/tmp/minion-research-slices-${MINION_ISSUE_NUMBER:-0}.md"
 ```
 
 The parent issue number is in `$MINION_ISSUE_NUMBER`. The parent
@@ -222,17 +229,83 @@ Do not create or modify any file in the working directory. Write only
 `$PRD_DRAFT`. Do not run `git` and do not open a PR. Do not post any
 comment yourself — the publisher handles that.
 
+### slicer
+
+```capabilities
+tools:
+  - Read
+  - Write
+  - Bash
+max_turns: 20
+```
+
+You decompose the PRD that `prd-writer` produced into vertical slices,
+one block per slice. You do NOT interview, synthesize a new PRD, or
+touch any GitHub artifact — the publisher consumes your output.
+
+Slicing philosophy (mirrors the `/code-create-issues` skill): cut the
+PRD into thin vertical slices that each pass through every layer
+end-to-end, ordered so each slice builds on the one before it. The
+first slice is a walking skeleton — the smallest change that proves the
+whole path works; later slices add behavior. Each slice must be
+independently shippable and reviewable on its own.
+
+Slice protocol:
+
+1. Compute the shared paths:
+
+   ```
+   PRD_DRAFT="/tmp/minion-research-prd-draft-${MINION_ISSUE_NUMBER:-0}.md"
+   SLICES="/tmp/minion-research-slices-${MINION_ISSUE_NUMBER:-0}.md"
+   ```
+
+2. Read `$PRD_DRAFT`. It is the PRD body synthesized from the research
+   transcript. Treat its Implementation Decisions and User Stories as
+   the source of truth for what to slice.
+
+3. Decompose the PRD into N vertical slices and write `$SLICES` with
+   one block per slice, in dependency order. Use exactly this block
+   shape — plain labeled fields, no markdown headings, so the publisher
+   can parse each block reliably:
+
+   ```
+   === SLICE 1 ===
+   Title: <concise imperative title for the slice>
+   Description:
+   <1 to 3 short paragraphs describing the end-to-end behavior this
+   slice delivers, from the user's perspective>
+   Acceptance criteria:
+   - [ ] <observable behavior that proves this slice works>
+   - [ ] <one criterion per line, each independently checkable>
+   Modules touched:
+   - <module or area this slice changes>
+   Out of scope:
+   - <what this slice defers, pointing to a later slice when relevant>
+   ```
+
+   Number the blocks sequentially: `=== SLICE 1 ===`, `=== SLICE 2 ===`,
+   and so on. Every block must contain at minimum a Title, a
+   Description, and a non-empty Acceptance criteria checklist; fill in
+   Modules touched and Out of scope whenever the PRD gives you the
+   material.
+
+Write only `$SLICES`. Do not create or modify any file in the working
+directory, do not run `git`, do not call `gh`, and do not open a PR.
+The publisher turns these blocks into child issues.
+
 ### publisher
 
 ```capabilities
 tools:
   - Read
+  - Write
   - Bash
-max_turns: 10
+max_turns: 30
 ```
 
-You publish the PRD that `prd-writer` produced and mark the parent
-issue as research-completed.
+You publish the research output: post the PRD as a comment, open one
+child issue per slice, and post a status comment linking the children.
+You also mark the parent issue as research-completed.
 
 1. Compute the shared paths:
 
@@ -272,6 +345,67 @@ issue as research-completed.
    gh issue edit "$MINION_ISSUE_NUMBER" --repo partio-io/cli --add-label minion-research-completed
    ```
 
+6. Read the slice blocks the slicer wrote:
+
+   ```
+   SLICES="/tmp/minion-research-slices-${MINION_ISSUE_NUMBER:-0}.md"
+   ```
+
+   `$SLICES` holds N blocks, each delimited by a `=== SLICE <n> ===`
+   line and carrying Title, Description, Acceptance criteria, Modules
+   touched, and Out of scope fields. Read the whole file and let
+   `TOTAL` be the number of slice blocks.
+
+7. For each slice block, in order (`<n>` from 1 to `TOTAL`), open one
+   child issue on `partio-io/cli`. First write the child body to a file
+   with the `Write` tool:
+
+   ```
+   CHILD_BODY="/tmp/minion-research-child-${MINION_ISSUE_NUMBER:-0}-<n>.md"
+   ```
+
+   The body file must contain, in order:
+
+   - Line 1, exactly: `<!-- minion:slice parent=#<N> slice=<n>/<total> -->`
+     where `<N>` is `$MINION_ISSUE_NUMBER`, `<n>` is the slice ordinal,
+     and `<total>` is `TOTAL` (for example `slice=2/5`).
+   - A blank line, then the slice Description.
+   - The slice Acceptance criteria checklist.
+   - The slice Modules touched list.
+   - A final line, exactly: `Parent: #<N>` (again `$MINION_ISSUE_NUMBER`).
+
+   Then create the issue, titled with the slice Title, carrying both
+   labels:
+
+   ```
+   gh issue create --repo partio-io/cli --title "<slice Title>" --label minion-approved --label minion-research-output --body-file "$CHILD_BODY"
+   ```
+
+   `gh issue create` prints the new issue URL on stdout. Record the
+   trailing number of that URL as the child issue number, and keep the
+   numbers in slice order for the status comment.
+
+8. Post one final status comment on the parent issue. Write its body
+   with the `Write` tool:
+
+   ```
+   STATUS_BODY="/tmp/minion-research-status-${MINION_ISSUE_NUMBER:-0}.md"
+   ```
+
+   The status body must contain, in order:
+
+   - Line 1, exactly: `<!-- minion:research-status parent=#<N> -->`
+     where `<N>` is `$MINION_ISSUE_NUMBER`.
+   - A blank line, then one line per child issue in slice order, each
+     formatted as `- #<child-number>` so it renders as a clickable
+     reference in the parent thread.
+
+   Then post it:
+
+   ```
+   gh issue comment "$MINION_ISSUE_NUMBER" --repo partio-io/cli --body-file "$STATUS_BODY"
+   ```
+
 Hard constraints:
 
 - Do NOT add the `minion-done` label to the parent issue. This slice
@@ -280,6 +414,12 @@ Hard constraints:
   open until jcleira closes it manually.
 - Do NOT post the raw transcript as a comment. The PRD comment
   replaces the transitional transcript comment from slice 2.
-- Post exactly one issue comment (the PRD comment) and run exactly
-  one `gh issue edit` (the label add). Do not modify the worktree, do
-  not run `git`, and do not open a PR.
+- Child issues carry exactly the `minion-approved` and
+  `minion-research-output` labels — never `minion-done`, and never
+  close a child.
+- Do NOT check for or skip existing comments or issues. Writing the
+  markers is in scope; the skip-if-marker-exists check is slice 5.
+- Post exactly two comments on the parent (the PRD comment, then the
+  status comment), open exactly one child issue per slice, and run
+  exactly one `gh issue edit` (the label add). Do not modify the
+  worktree, do not run `git`, and do not open a PR.


### PR DESCRIPTION
## Slice 4 — slicer agent + child issues + status comment

Fourth slice of the research-minion rollout
(`partio-minions/docs/2026-05-05-research-minion/`). Completes the
research → PRD → slice → publish pipeline in
`.minions/programs/research.md`. Single-file change; no Go runtime,
workflow, or simple-task-flow changes.

### What changed
- **New `slicer` agent** between `prd-writer` and `publisher`: reads the
  PRD draft, writes vertical-slice blocks (Title, Description,
  Acceptance criteria, Modules touched, Out of scope) to a stable
  `/tmp/minion-research-slices-*` path. Uses `=== SLICE n ===`
  delimiters + labeled fields rather than markdown headings, so the
  program parser doesn't mistake slice blocks for agent sections.
- **`publisher` extended**: opens one child issue per slice
  (`gh issue create`) with labels `minion-approved` +
  `minion-research-output`; each child body's line 1 is
  `<!-- minion:slice parent=#<N> slice=<n>/<total> -->` and ends with
  `Parent: #<N>`. Then posts a status comment (line 1
  `<!-- minion:research-status parent=#<N> -->`) listing the children.
  Gained `Write`; `max_turns` 10 → 30.

### Verification
- `minions run .minions/programs/research.md --dry-run`: agent count
  4 → 5, order `researcher, persona, prd-writer, slicer, publisher`.
- Heading audit confirms no phantom agent sections leak from the new
  prose.
- `minion.yml` and `implement.md` confirmed untouched.

### Pending before merge (criteria 7-8)
Live smoke run on a test issue: PRD comment → N child issues (both
labels) → status comment listing them, plus one child observed to
trigger `minion.yml` → `implement.md` → PR. This burns Claude Max
quota and creates real GitHub artifacts, so it's a human-triggered
pre-merge check — not run yet. Issue-04's row in `issues.md` stays
unchecked until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
