### PR TITLE
Add `partio prune` command to delete old checkpoints

### DIFF
--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -21,21 +21,24 @@ This slice completes the research → PRD → slice → publish pipeline:
 - `prd-writer` reads the completed Q&A transcript and synthesizes a
   PRD body in the shape produced by the `/code-create-prd` skill.
 - `slicer` reads the PRD body and decomposes it into vertical-slice
-  blocks, one per child issue, in the spirit of the
+  blocks, one block per slice, in the spirit of the
   `/code-create-issues` skill.
 - `publisher` posts the PRD body as a comment on the parent issue
-  (prefixed with a run-scoped idempotency marker), labels the parent
-  `minion-research-completed`, opens one child issue per slice (each
-  labeled `minion-approved` so `minion.yml` auto-fires `implement.md`,
-  plus `minion-research-output` for provenance), and posts a status
-  comment linking the child issues. The parent issue is intentionally
-  left open and never receives `minion-done`.
+  (prefixed with a run-scoped idempotency marker), posts the slice
+  plan as a second comment on the same parent issue, and labels the
+  parent `minion-research-completed`. It does NOT open child issues and
+  does NOT apply `minion-approved` — a research run produces review
+  artifacts only. The parent issue is intentionally left open and never
+  receives `minion-done`. Implementation is triggered manually after
+  review: when jcleira labels the parent `minion-approved` (or comments
+  `/minion build`), `minion.yml` fires `implement.md` once on the parent
+  and produces a single feature PR.
 
 The *skip-if-marker-exists* idempotency check (re-runs reading existing
-comments and issues before writing) arrives in slice 5; this slice
-writes the markers but does not yet check for them. This run produces
-no PR; its only side effects are the PRD comment, the parent label, the
-child issues, and the status comment.
+comments before writing) arrives in slice 5; this slice writes the
+markers but does not yet check for them. This run produces no PR; its
+only side effects are the PRD comment, the slices comment, and the
+parent label.
 
 Every agent runs as its own one-shot Claude session, in the order
 declared below. Each agent gets a fresh, isolated worktree that is
@@ -291,7 +294,8 @@ Slice protocol:
 
 Write only `$SLICES`. Do not create or modify any file in the working
 directory, do not run `git`, do not call `gh`, and do not open a PR.
-The publisher turns these blocks into child issues.
+The publisher posts these blocks as a slice-plan comment on the parent
+issue.
 
 ### publisher
 
@@ -303,9 +307,10 @@ tools:
 max_turns: 30
 ```
 
-You publish the research output: post the PRD as a comment, open one
-child issue per slice, and post a status comment linking the children.
-You also mark the parent issue as research-completed.
+You publish the research output: post the PRD as a comment, post the
+slice plan as a second comment, and mark the parent issue as
+research-completed. You do NOT open child issues and you do NOT trigger
+implementation — a research run produces review artifacts only.
 
 1. Compute the shared paths:
 
@@ -353,73 +358,50 @@ You also mark the parent issue as research-completed.
 
    `$SLICES` holds N blocks, each delimited by a `=== SLICE <n> ===`
    line and carrying Title, Description, Acceptance criteria, Modules
-   touched, and Out of scope fields. Read the whole file and let
-   `TOTAL` be the number of slice blocks.
+   touched, and Out of scope fields. Read the whole file.
 
-7. For each slice block, in order (`<n>` from 1 to `TOTAL`), open one
-   child issue on `partio-io/cli`. First write the child body to a file
-   with the `Write` tool:
-
-   ```
-   CHILD_BODY="/tmp/minion-research-child-${MINION_ISSUE_NUMBER:-0}-<n>.md"
-   ```
-
-   The body file must contain, in order:
-
-   - Line 1, exactly: `<!-- minion:slice parent=#<N> slice=<n>/<total> -->`
-     where `<N>` is `$MINION_ISSUE_NUMBER`, `<n>` is the slice ordinal,
-     and `<total>` is `TOTAL` (for example `slice=2/5`).
-   - A blank line, then the slice Description.
-   - The slice Acceptance criteria checklist.
-   - The slice Modules touched list.
-   - A final line, exactly: `Parent: #<N>` (again `$MINION_ISSUE_NUMBER`).
-
-   Then create the issue, titled with the slice Title, carrying both
-   labels:
+7. Post the slice plan as a single second comment on the parent issue —
+   NOT as separate issues. First assemble the comment body with the
+   `Write` tool:
 
    ```
-   gh issue create --repo partio-io/cli --title "<slice Title>" --label minion-approved --label minion-research-output --body-file "$CHILD_BODY"
+   SLICES_COMMENT="/tmp/minion-research-slices-comment-${MINION_ISSUE_NUMBER:-0}.md"
    ```
 
-   `gh issue create` prints the new issue URL on stdout. Record the
-   trailing number of that URL as the child issue number, and keep the
-   numbers in slice order for the status comment.
+   The body must contain, in order:
 
-8. Post one final status comment on the parent issue. Write its body
-   with the `Write` tool:
-
-   ```
-   STATUS_BODY="/tmp/minion-research-status-${MINION_ISSUE_NUMBER:-0}.md"
-   ```
-
-   The status body must contain, in order:
-
-   - Line 1, exactly: `<!-- minion:research-status parent=#<N> -->`
+   - Line 1, exactly: `<!-- minion:research-slices parent=#<N> -->`
      where `<N>` is `$MINION_ISSUE_NUMBER`.
-   - A blank line, then one line per child issue in slice order, each
-     formatted as `- #<child-number>` so it renders as a clickable
-     reference in the parent thread.
+   - A blank line, then a `## Proposed slices` heading.
+   - One readable section per slice, in slice order, rendered from the
+     slicer's blocks: a `### Slice <n> — <Title>` heading, then the
+     slice Description, its Acceptance criteria checklist, its Modules
+     touched list, and its Out of scope list. Convert the slicer's
+     plain `=== SLICE <n> ===` field format into this readable Markdown
+     — do not paste the raw `===` delimiters.
 
-   Then post it:
+   Then post it as a comment on the parent issue:
 
    ```
-   gh issue comment "$MINION_ISSUE_NUMBER" --repo partio-io/cli --body-file "$STATUS_BODY"
+   gh issue comment "$MINION_ISSUE_NUMBER" --repo partio-io/cli --body-file "$SLICES_COMMENT"
    ```
 
 Hard constraints:
 
-- Do NOT add the `minion-done` label to the parent issue. This slice
-  posts research output only; the parent is not considered "done".
-- Do NOT call `gh issue close` on the parent issue. The parent stays
-  open until jcleira closes it manually.
+- Do NOT open child issues. The slice plan is posted as a comment on
+  the parent issue, not as separate issues — a research run must not
+  create any GitHub issue.
+- Do NOT apply `minion-approved` (or `minion-ready`) to the parent or
+  anything else, and do NOT trigger `implement.md`. Implementation is
+  started manually by jcleira after he reviews the PRD and slice plan.
+- Do NOT add the `minion-done` label to the parent issue, and do NOT
+  call `gh issue close` on it. The parent stays open until jcleira
+  closes it manually.
 - Do NOT post the raw transcript as a comment. The PRD comment
   replaces the transitional transcript comment from slice 2.
-- Child issues carry exactly the `minion-approved` and
-  `minion-research-output` labels — never `minion-done`, and never
-  close a child.
-- Do NOT check for or skip existing comments or issues. Writing the
-  markers is in scope; the skip-if-marker-exists check is slice 5.
+- Do NOT check for or skip existing comments. Writing the markers is in
+  scope; the skip-if-marker-exists check is slice 5.
 - Post exactly two comments on the parent (the PRD comment, then the
-  status comment), open exactly one child issue per slice, and run
-  exactly one `gh issue edit` (the label add). Do not modify the
-  worktree, do not run `git`, and do not open a PR.
+  slice-plan comment), and run exactly one `gh issue edit` (the
+  `minion-research-completed` label add). Do not modify the worktree,
+  do not run `git`, and do not open a PR.

--- a/cmd/partio/list.go
+++ b/cmd/partio/list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -12,15 +13,28 @@ import (
 )
 
 func newListCmd() *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List captured checkpoints",
 		Long:  `List all captured checkpoints sorted by creation time (newest first).`,
-		RunE:  runList,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(jsonOutput)
+		},
 	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+
+	return cmd
 }
 
-func runList(cmd *cobra.Command, args []string) error {
+// checkpointListOutput is the JSON envelope for checkpoint listings.
+type checkpointListOutput struct {
+	Checkpoints []checkpoint.Metadata `json:"checkpoints"`
+}
+
+func runList(jsonOutput bool) error {
 	_, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("must be run inside a git repository")
@@ -29,10 +43,20 @@ func runList(cmd *cobra.Command, args []string) error {
 	checkpoints, err := checkpoint.List()
 	if err != nil {
 		if err == checkpoint.ErrNoBranch {
+			if jsonOutput {
+				return json.NewEncoder(os.Stdout).Encode(checkpointListOutput{Checkpoints: []checkpoint.Metadata{}})
+			}
 			fmt.Println("No checkpoints found. Run 'partio enable' and make some commits to capture checkpoints.")
 			return nil
 		}
 		return err
+	}
+
+	if jsonOutput {
+		if checkpoints == nil {
+			checkpoints = []checkpoint.Metadata{}
+		}
+		return json.NewEncoder(os.Stdout).Encode(checkpointListOutput{Checkpoints: checkpoints})
 	}
 
 	if len(checkpoints) == 0 {

--- a/cmd/partio/list.go
+++ b/cmd/partio/list.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/partio-io/cli/internal/checkpoint"
+	"github.com/partio-io/cli/internal/git"
+)
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List captured checkpoints",
+		Long:  `List all captured checkpoints sorted by creation time (newest first).`,
+		RunE:  runList,
+	}
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	_, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("must be run inside a git repository")
+	}
+
+	checkpoints, err := checkpoint.List()
+	if err != nil {
+		if err == checkpoint.ErrNoBranch {
+			fmt.Println("No checkpoints found. Run 'partio enable' and make some commits to capture checkpoints.")
+			return nil
+		}
+		return err
+	}
+
+	if len(checkpoints) == 0 {
+		fmt.Println("No checkpoints found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tCOMMIT\tAGENT\tATTRIBUTION\tCREATED\tBRANCH")
+	for _, cp := range checkpoints {
+		id := cp.ID
+		if len(id) > 12 {
+			id = id[:12]
+		}
+		commit := cp.CommitHash
+		if len(commit) > 7 {
+			commit = commit[:7]
+		}
+		attribution := fmt.Sprintf("%d%%", cp.AgentPercent)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			id, commit, cp.Agent, attribution, cp.CreatedAt, cp.Branch)
+	}
+	_ = w.Flush()
+
+	return nil
+}

--- a/cmd/partio/list_test.go
+++ b/cmd/partio/list_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/partio-io/cli/internal/checkpoint"
+)
+
+func TestListCmd_JSONFlag(t *testing.T) {
+	cmd := newListCmd()
+	// Verify --json flag exists
+	f := cmd.Flags().Lookup("json")
+	if f == nil {
+		t.Fatal("expected --json flag to be defined")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected --json default to be false, got %s", f.DefValue)
+	}
+}
+
+func TestCheckpointListOutput_EmptyJSON(t *testing.T) {
+	out := checkpointListOutput{
+		Checkpoints: []checkpoint.Metadata{},
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(out); err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	raw, ok := decoded["checkpoints"]
+	if !ok {
+		t.Fatal("expected 'checkpoints' key in JSON output")
+	}
+
+	var arr []json.RawMessage
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		t.Fatalf("checkpoints is not an array: %v", err)
+	}
+
+	if len(arr) != 0 {
+		t.Errorf("expected empty checkpoints array, got %d items", len(arr))
+	}
+}
+
+func TestCheckpointListOutput_WithCheckpoints(t *testing.T) {
+	out := checkpointListOutput{
+		Checkpoints: []checkpoint.Metadata{
+			{
+				ID:           "abcdef123456",
+				SessionID:    "session-1",
+				CommitHash:   "abc123def456",
+				Branch:       "main",
+				CreatedAt:    "2025-01-15T10:30:00Z",
+				Agent:        "claude-code",
+				AgentPercent: 100,
+				ContentHash:  "hash123",
+			},
+			{
+				ID:           "fedcba654321",
+				SessionID:    "session-2",
+				CommitHash:   "def456abc789",
+				Branch:       "feature",
+				CreatedAt:    "2025-01-15T11:00:00Z",
+				Agent:        "claude-code",
+				AgentPercent: 0,
+				ContentHash:  "hash456",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(out); err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	// Verify valid JSON
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	// Verify envelope
+	raw, ok := decoded["checkpoints"]
+	if !ok {
+		t.Fatal("expected 'checkpoints' key in JSON output")
+	}
+
+	// Verify array contents
+	var checkpoints []map[string]interface{}
+	if err := json.Unmarshal(raw, &checkpoints); err != nil {
+		t.Fatalf("checkpoints is not a valid array: %v", err)
+	}
+
+	if len(checkpoints) != 2 {
+		t.Fatalf("expected 2 checkpoints, got %d", len(checkpoints))
+	}
+
+	// Verify required fields in first checkpoint
+	requiredFields := []string{"id", "commit_hash", "agent", "agent_percent", "created_at", "branch"}
+	for _, field := range requiredFields {
+		if _, ok := checkpoints[0][field]; !ok {
+			t.Errorf("expected field %q in checkpoint JSON", field)
+		}
+	}
+
+	// Verify specific values
+	if checkpoints[0]["id"] != "abcdef123456" {
+		t.Errorf("expected id=abcdef123456, got %v", checkpoints[0]["id"])
+	}
+	if checkpoints[0]["branch"] != "main" {
+		t.Errorf("expected branch=main, got %v", checkpoints[0]["branch"])
+	}
+	if checkpoints[0]["agent"] != "claude-code" {
+		t.Errorf("expected agent=claude-code, got %v", checkpoints[0]["agent"])
+	}
+}
+
+func TestCheckpointListOutput_NilBecomesEmptyArray(t *testing.T) {
+	// When checkpoints is nil, JSON should still produce an empty array
+	// This mirrors the behavior in runList where nil is replaced with empty slice
+	checkpoints := []checkpoint.Metadata(nil)
+	checkpoints = []checkpoint.Metadata{} // same as what runList does
+
+	out := checkpointListOutput{Checkpoints: checkpoints}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(out); err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var decoded struct {
+		Checkpoints []json.RawMessage `json:"checkpoints"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if decoded.Checkpoints == nil {
+		t.Error("expected non-nil checkpoints array")
+	}
+	if len(decoded.Checkpoints) != 0 {
+		t.Errorf("expected empty array, got %d items", len(decoded.Checkpoints))
+	}
+}

--- a/cmd/partio/main.go
+++ b/cmd/partio/main.go
@@ -66,6 +66,7 @@ func newRootCmd() *cobra.Command {
 		newCleanCmd(),
 		newRewindCmd(),
 		newResumeCmd(),
+		newListCmd(),
 	)
 
 	return root

--- a/cmd/partio/main.go
+++ b/cmd/partio/main.go
@@ -67,6 +67,7 @@ func newRootCmd() *cobra.Command {
 		newRewindCmd(),
 		newResumeCmd(),
 		newListCmd(),
+		newPruneCmd(),
 	)
 
 	return root

--- a/cmd/partio/prune.go
+++ b/cmd/partio/prune.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/partio-io/cli/internal/checkpoint"
+	"github.com/partio-io/cli/internal/git"
+)
+
+func newPruneCmd() *cobra.Command {
+	var (
+		olderThan string
+		dryRun    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Delete old checkpoints",
+		Long:  `Remove checkpoints older than a retention window from the checkpoint branch. The checkpoint linked to the current HEAD is never deleted.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPrune(olderThan, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVar(&olderThan, "older-than", "90d", "retention window (e.g. 30d, 90d)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what would be deleted without making changes")
+
+	return cmd
+}
+
+func parseDuration(s string) (time.Duration, error) {
+	if !strings.HasSuffix(s, "d") {
+		return 0, fmt.Errorf("unsupported duration format %q (use e.g. 30d, 90d)", s)
+	}
+	days, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+	if err != nil || days <= 0 {
+		return 0, fmt.Errorf("invalid duration %q: must be a positive number of days", s)
+	}
+	return time.Duration(days) * 24 * time.Hour, nil
+}
+
+type checkpointEntry struct {
+	id        string
+	shard     string
+	rest      string
+	meta      checkpoint.Metadata
+	createdAt time.Time
+}
+
+func listCheckpoints(branch string) ([]checkpointEntry, error) {
+	shards, err := git.ExecGit("ls-tree", "--name-only", branch)
+	if err != nil || shards == "" {
+		return nil, nil
+	}
+
+	var entries []checkpointEntry
+	for _, shard := range strings.Split(shards, "\n") {
+		if shard == "" {
+			continue
+		}
+		rests, err := git.ExecGit("ls-tree", "--name-only", branch+":"+shard)
+		if err != nil {
+			continue
+		}
+		for _, rest := range strings.Split(rests, "\n") {
+			if rest == "" {
+				continue
+			}
+			metaJSON, err := git.ExecGit("show", branch+":"+shard+"/"+rest+"/metadata.json")
+			if err != nil {
+				continue
+			}
+			var meta checkpoint.Metadata
+			if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+				continue
+			}
+			createdAt, err := time.Parse(time.RFC3339, meta.CreatedAt)
+			if err != nil {
+				continue
+			}
+			entries = append(entries, checkpointEntry{
+				id:        shard + rest,
+				shard:     shard,
+				rest:      rest,
+				meta:      meta,
+				createdAt: createdAt,
+			})
+		}
+	}
+	return entries, nil
+}
+
+func runPrune(olderThan string, dryRun bool) error {
+	_, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("must be run inside a git repository")
+	}
+
+	retention, err := parseDuration(olderThan)
+	if err != nil {
+		return err
+	}
+
+	const branch = "partio/checkpoints/v1"
+
+	_, err = git.ExecGit("rev-parse", "--verify", branch)
+	if err != nil {
+		return fmt.Errorf("no checkpoint branch found - run 'partio enable' first")
+	}
+
+	headCommit, err := git.ExecGit("rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("getting HEAD: %w", err)
+	}
+
+	cutoff := time.Now().Add(-retention)
+
+	all, err := listCheckpoints(branch)
+	if err != nil {
+		return fmt.Errorf("listing checkpoints: %w", err)
+	}
+	if len(all) == 0 {
+		fmt.Println("No checkpoints found.")
+		return nil
+	}
+
+	var toPrune []checkpointEntry
+	for _, cp := range all {
+		if cp.meta.CommitHash == headCommit {
+			continue // never prune the checkpoint linked to HEAD
+		}
+		if cp.createdAt.Before(cutoff) {
+			toPrune = append(toPrune, cp)
+		}
+	}
+
+	if len(toPrune) == 0 {
+		fmt.Println("Nothing to prune.")
+		return nil
+	}
+
+	if dryRun {
+		fmt.Printf("Would remove %d of %d checkpoints (dry run):\n", len(toPrune), len(all))
+		for _, cp := range toPrune {
+			fmt.Printf("  %s  branch=%s  created=%s\n", cp.id, cp.meta.Branch, cp.meta.CreatedAt)
+		}
+		return nil
+	}
+
+	// Build set of entries to prune, keyed by shard → rest
+	pruneSet := make(map[string]map[string]bool)
+	for _, cp := range toPrune {
+		if pruneSet[cp.shard] == nil {
+			pruneSet[cp.shard] = make(map[string]bool)
+		}
+		pruneSet[cp.shard][cp.rest] = true
+	}
+
+	// Rebuild the orphan branch tree without pruned entries
+	currentTree, err := git.ExecGit("rev-parse", branch+"^{tree}")
+	if err != nil {
+		return fmt.Errorf("getting current tree: %w", err)
+	}
+
+	rootEntries, err := git.ExecGit("ls-tree", currentTree)
+	if err != nil {
+		return fmt.Errorf("listing root tree: %w", err)
+	}
+
+	var newRootLines []string
+	for _, line := range strings.Split(rootEntries, "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		tabParts := strings.SplitN(line, "\t", 2)
+		if len(parts) < 4 || len(tabParts) < 2 {
+			continue
+		}
+		shardName := tabParts[1]
+
+		prunedInShard := pruneSet[shardName]
+		if prunedInShard == nil {
+			newRootLines = append(newRootLines, line)
+			continue
+		}
+
+		// Filter entries within this shard
+		shardTreeHash := parts[2]
+		shardEntries, err := git.ExecGit("ls-tree", shardTreeHash)
+		if err != nil {
+			newRootLines = append(newRootLines, line)
+			continue
+		}
+
+		var filteredLines []string
+		for _, shardLine := range strings.Split(shardEntries, "\n") {
+			if shardLine == "" {
+				continue
+			}
+			shardTabParts := strings.SplitN(shardLine, "\t", 2)
+			if len(shardTabParts) < 2 {
+				continue
+			}
+			if prunedInShard[shardTabParts[1]] {
+				continue
+			}
+			filteredLines = append(filteredLines, shardLine)
+		}
+
+		if len(filteredLines) == 0 {
+			continue // drop empty shard
+		}
+
+		newShardHash, err := git.ExecGitStdin(strings.Join(filteredLines, "\n")+"\n", "mktree")
+		if err != nil {
+			return fmt.Errorf("creating shard tree: %w", err)
+		}
+
+		newRootLines = append(newRootLines, fmt.Sprintf("040000 tree %s\t%s", newShardHash, shardName))
+	}
+
+	var newRootTree string
+	if len(newRootLines) == 0 {
+		newRootTree, err = git.ExecGitStdin("\n", "mktree")
+	} else {
+		newRootTree, err = git.ExecGitStdin(strings.Join(newRootLines, "\n")+"\n", "mktree")
+	}
+	if err != nil {
+		return fmt.Errorf("creating root tree: %w", err)
+	}
+
+	parentCommit, err := git.ExecGit("rev-parse", branch)
+	if err != nil {
+		return fmt.Errorf("getting parent commit: %w", err)
+	}
+
+	commitMsg := fmt.Sprintf("prune: removed %d checkpoints older than %s", len(toPrune), olderThan)
+	commitHash, err := git.ExecGit("commit-tree", newRootTree, "-p", parentCommit, "-m", commitMsg)
+	if err != nil {
+		return fmt.Errorf("creating commit: %w", err)
+	}
+
+	_, err = git.ExecGit("update-ref", "refs/heads/"+branch, commitHash)
+	if err != nil {
+		return fmt.Errorf("updating ref: %w", err)
+	}
+
+	fmt.Printf("Pruned %d of %d checkpoints (older than %s).\n", len(toPrune), len(all), olderThan)
+	return nil
+}

--- a/cmd/partio/prune_test.go
+++ b/cmd/partio/prune_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"30d", 30 * 24 * time.Hour, false},
+		{"90d", 90 * 24 * time.Hour, false},
+		{"1d", 24 * time.Hour, false},
+		{"365d", 365 * 24 * time.Hour, false},
+		{"0d", 0, true},
+		{"-5d", 0, true},
+		{"d", 0, true},
+		{"30", 0, true},
+		{"30h", 0, true},
+		{"abc", 0, true},
+		{"", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseDuration(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseDuration(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/checkpoint/list.go
+++ b/internal/checkpoint/list.go
@@ -1,0 +1,65 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/partio-io/cli/internal/git"
+)
+
+// ErrNoBranch is returned when the checkpoint branch does not exist.
+var ErrNoBranch = fmt.Errorf("checkpoint branch does not exist")
+
+// List enumerates all checkpoints on the orphan branch and returns them
+// sorted newest-first by CreatedAt.
+func List() ([]Metadata, error) {
+	branch := git.CheckpointBranch
+
+	// Check branch exists
+	_, err := git.ExecGit("rev-parse", "--verify", branch)
+	if err != nil {
+		return nil, ErrNoBranch
+	}
+
+	// List top-level shard directories
+	shards, err := git.ExecGit("ls-tree", "--name-only", branch)
+	if err != nil || shards == "" {
+		return nil, nil
+	}
+
+	var results []Metadata
+
+	for _, shard := range strings.Split(shards, "\n") {
+		entries, err := git.ExecGit("ls-tree", "--name-only", branch+":"+shard)
+		if err != nil {
+			continue
+		}
+		for _, entry := range strings.Split(entries, "\n") {
+			if entry == "" {
+				continue
+			}
+			metaJSON, err := git.ExecGit("show", branch+":"+shard+"/"+entry+"/metadata.json")
+			if err != nil {
+				continue
+			}
+
+			var meta Metadata
+			if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+				continue
+			}
+			results = append(results, meta)
+		}
+	}
+
+	// Sort newest-first by CreatedAt
+	sort.Slice(results, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, results[i].CreatedAt)
+		tj, _ := time.Parse(time.RFC3339, results[j].CreatedAt)
+		return ti.After(tj)
+	})
+
+	return results, nil
+}

--- a/internal/checkpoint/list_test.go
+++ b/internal/checkpoint/list_test.go
@@ -1,7 +1,12 @@
 package checkpoint
 
 import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 )
@@ -83,4 +88,175 @@ func TestMetadataFields(t *testing.T) {
 	if err != nil {
 		t.Errorf("CreatedAt should be valid RFC3339: %v", err)
 	}
+}
+
+// TestListFromWorktree verifies that listing checkpoints from a git worktree
+// produces the same results as listing from the main working tree. The checkpoint
+// branch (partio/checkpoints/v1) is stored via refs that are shared across
+// worktrees, so ExecGit and git ls-tree should resolve identically from either.
+func TestListFromWorktree(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	// Create a temporary directory for the main repo
+	mainDir := t.TempDir()
+
+	// Helper to run git in a specific directory
+	gitIn := func(dir string, args ...string) (string, error) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		return strings.TrimSpace(string(out)), err
+	}
+
+	mustGit := func(dir string, args ...string) string {
+		t.Helper()
+		out, err := gitIn(dir, args...)
+		if err != nil {
+			t.Fatalf("git %v in %s failed: %v\n%s", args, dir, err, out)
+		}
+		return out
+	}
+
+	// Initialize main repo with an initial commit
+	mustGit(mainDir, "init")
+	mustGit(mainDir, "config", "user.email", "test@test.com")
+	mustGit(mainDir, "config", "user.name", "Test")
+
+	initialFile := filepath.Join(mainDir, "README.md")
+	if err := os.WriteFile(initialFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(mainDir, "add", "README.md")
+	mustGit(mainDir, "commit", "-m", "initial commit")
+	commitHash := mustGit(mainDir, "rev-parse", "HEAD")
+
+	// Create the orphan checkpoint branch (same as enable.go)
+	treeHash := mustGit(mainDir, "hash-object", "-t", "tree", "/dev/null")
+	initCommit := mustGit(mainDir, "commit-tree", treeHash, "-m", "partio: initialize checkpoint storage")
+	mustGit(mainDir, "update-ref", "refs/heads/"+checkpointBranch, initCommit)
+
+	// Write two checkpoints using the Store
+	store := NewStore(mainDir)
+
+	cp1 := &Checkpoint{
+		ID:          "aabbccddeeff",
+		SessionID:   "session-1",
+		CommitHash:  commitHash,
+		Branch:      "main",
+		CreatedAt:   time.Now().Add(-time.Hour),
+		Agent:       "claude-code",
+		AgentPct:    100,
+		ContentHash: "hash1",
+	}
+
+	cp2 := &Checkpoint{
+		ID:          "112233445566",
+		SessionID:   "session-2",
+		CommitHash:  commitHash,
+		Branch:      "main",
+		CreatedAt:   time.Now(),
+		Agent:       "claude-code",
+		AgentPct:    100,
+		ContentHash: "hash2",
+	}
+
+	sessionData := &SessionFiles{
+		ContentHash: "content",
+		Context:     "context",
+		Diff:        "diff",
+		FullJSONL:   "{}",
+		Metadata:    SessionMetadata{Agent: "claude-code", TotalTokens: 100, Duration: "1m"},
+		Plan:        "plan",
+		Prompt:      "prompt",
+	}
+
+	if err := store.Write(cp1, sessionData); err != nil {
+		t.Fatalf("writing checkpoint 1: %v", err)
+	}
+	if err := store.Write(cp2, sessionData); err != nil {
+		t.Fatalf("writing checkpoint 2: %v", err)
+	}
+
+	// Create a worktree
+	worktreeDir := filepath.Join(t.TempDir(), "worktree")
+	mustGit(mainDir, "worktree", "add", worktreeDir, "-b", "worktree-branch")
+
+	// List checkpoints from the main repo
+	mainCheckpoints := listCheckpointsFromDir(t, mainDir, mustGit)
+
+	// List checkpoints from the worktree
+	worktreeCheckpoints := listCheckpointsFromDir(t, worktreeDir, mustGit)
+
+	// Verify both lists are non-empty
+	if len(mainCheckpoints) == 0 {
+		t.Fatal("expected checkpoints from main repo, got none")
+	}
+
+	// Verify the lists are identical
+	if len(mainCheckpoints) != len(worktreeCheckpoints) {
+		t.Fatalf("checkpoint count mismatch: main=%d worktree=%d",
+			len(mainCheckpoints), len(worktreeCheckpoints))
+	}
+
+	for id, mainMeta := range mainCheckpoints {
+		wtMeta, ok := worktreeCheckpoints[id]
+		if !ok {
+			t.Errorf("checkpoint %s found in main but not in worktree", id)
+			continue
+		}
+		if mainMeta.Branch != wtMeta.Branch {
+			t.Errorf("checkpoint %s branch mismatch: main=%s worktree=%s",
+				id, mainMeta.Branch, wtMeta.Branch)
+		}
+		if mainMeta.AgentPercent != wtMeta.AgentPercent {
+			t.Errorf("checkpoint %s agent_percent mismatch: main=%d worktree=%d",
+				id, mainMeta.AgentPercent, wtMeta.AgentPercent)
+		}
+		if mainMeta.CreatedAt != wtMeta.CreatedAt {
+			t.Errorf("checkpoint %s created_at mismatch: main=%s worktree=%s",
+				id, mainMeta.CreatedAt, wtMeta.CreatedAt)
+		}
+	}
+
+	// Verify both checkpoint IDs are present
+	for _, id := range []string{"aabbccddeeff", "112233445566"} {
+		if _, ok := mainCheckpoints[id]; !ok {
+			t.Errorf("expected checkpoint %s in results", id)
+		}
+	}
+}
+
+// listCheckpointsFromDir enumerates checkpoints from a directory using the same
+// git ls-tree approach as the List function.
+func listCheckpointsFromDir(t *testing.T, dir string, mustGit func(string, ...string) string) map[string]Metadata {
+	t.Helper()
+
+	result := make(map[string]Metadata)
+
+	shards := mustGit(dir, "ls-tree", "--name-only", checkpointBranch)
+	if shards == "" {
+		return result
+	}
+
+	for _, shard := range strings.Split(shards, "\n") {
+		entries := mustGit(dir, "ls-tree", "--name-only", checkpointBranch+":"+shard)
+		if entries == "" {
+			continue
+		}
+		for _, entry := range strings.Split(entries, "\n") {
+			cpID := shard + entry
+			metaJSON := mustGit(dir, "show", checkpointBranch+":"+shard+"/"+entry+"/metadata.json")
+
+			var meta Metadata
+			if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+				t.Fatalf("invalid metadata for checkpoint %s: %v", cpID, err)
+			}
+			result[cpID] = meta
+		}
+	}
+
+	return result
 }

--- a/internal/checkpoint/list_test.go
+++ b/internal/checkpoint/list_test.go
@@ -1,0 +1,86 @@
+package checkpoint
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestListSort(t *testing.T) {
+	now := time.Now()
+	metas := []Metadata{
+		{ID: "aaa111222333", CreatedAt: now.Add(-2 * time.Hour).Format(time.RFC3339)},
+		{ID: "bbb444555666", CreatedAt: now.Format(time.RFC3339)},
+		{ID: "ccc777888999", CreatedAt: now.Add(-1 * time.Hour).Format(time.RFC3339)},
+	}
+
+	sort.Slice(metas, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, metas[i].CreatedAt)
+		tj, _ := time.Parse(time.RFC3339, metas[j].CreatedAt)
+		return ti.After(tj)
+	})
+
+	if metas[0].ID != "bbb444555666" {
+		t.Errorf("expected newest first, got %s", metas[0].ID)
+	}
+	if metas[1].ID != "ccc777888999" {
+		t.Errorf("expected second newest second, got %s", metas[1].ID)
+	}
+	if metas[2].ID != "aaa111222333" {
+		t.Errorf("expected oldest last, got %s", metas[2].ID)
+	}
+}
+
+func TestListNoBranch(t *testing.T) {
+	// When run outside a git repo or without the checkpoint branch,
+	// List() should return ErrNoBranch.
+	// We can't easily mock git commands, so we verify the error sentinel exists.
+	if ErrNoBranch == nil {
+		t.Error("ErrNoBranch should not be nil")
+	}
+	if ErrNoBranch.Error() != "checkpoint branch does not exist" {
+		t.Errorf("unexpected error message: %s", ErrNoBranch.Error())
+	}
+}
+
+func TestListEmptyResult(t *testing.T) {
+	// An empty slice (not nil) should be treated as "no checkpoints".
+	var metas []Metadata
+	if len(metas) != 0 {
+		t.Error("expected empty slice")
+	}
+}
+
+func TestMetadataFields(t *testing.T) {
+	now := time.Now()
+	meta := Metadata{
+		ID:           "abcdef123456",
+		SessionID:    "session-1",
+		CommitHash:   "abc1234567890",
+		Branch:       "main",
+		CreatedAt:    now.Format(time.RFC3339),
+		Agent:        "claude-code",
+		AgentPercent: 100,
+		ContentHash:  "hash123",
+	}
+
+	// Verify ID prefix (12-char)
+	if len(meta.ID) != 12 {
+		t.Errorf("expected 12-char ID, got %d", len(meta.ID))
+	}
+
+	// Verify commit hash can be truncated to 7
+	commit := meta.CommitHash
+	if len(commit) > 7 {
+		commit = commit[:7]
+	}
+	if commit != "abc1234" {
+		t.Errorf("expected truncated commit abc1234, got %s", commit)
+	}
+
+	// Verify CreatedAt parses as RFC3339
+	_, err := time.Parse(time.RFC3339, meta.CreatedAt)
+	if err != nil {
+		t.Errorf("CreatedAt should be valid RFC3339: %v", err)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -21,3 +21,14 @@ func execGit(args ...string) (string, error) {
 func ExecGit(args ...string) (string, error) {
 	return execGit(args...)
 }
+
+// ExecGitStdin runs a git command with the given stdin and returns trimmed stdout.
+func ExecGitStdin(stdin string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
## Summary
- Adds a `partio prune` command that removes checkpoints older than a configurable retention window from the `partio/checkpoints/v1` orphan branch
- Supports `--older-than` flag (default `90d`) and `--dry-run` flag for previewing deletions
- Never deletes the checkpoint linked to the current HEAD
- Rebuilds the orphan branch tree using git plumbing (mktree, commit-tree, update-ref)
- Adds `ExecGitStdin` helper to the git package for piping stdin to git commands

## Test plan
- [x] `TestParseDuration` covers valid durations, zero/negative values, and invalid formats
- [x] All existing tests pass (`go test ./...`)
- [x] Linter passes (no new warnings from `golangci-lint run`)
- [ ] Manual: `partio prune --dry-run` on a repo with checkpoints shows what would be removed
- [ ] Manual: `partio prune --older-than 1d` removes old checkpoints and prints summary
- [ ] Manual: Checkpoint linked to HEAD is preserved even when older than retention window

🤖 Generated with [Claude Code](https://claude.com/claude-code)