### PR TITLE
ci: bump minions install pin v0.0.5 -> v0.0.6

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.5
+          go install github.com/partio-io/minions/cmd/minions@v0.0.6
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run doc-update program

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.5
+          go install github.com/partio-io/minions/cmd/minions@v0.0.6
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.5
+          go install github.com/partio-io/minions/cmd/minions@v0.0.6
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.5
+          go install github.com/partio-io/minions/cmd/minions@v0.0.6
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.5
+          go install github.com/partio-io/minions/cmd/minions@v0.0.6
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program


### PR DESCRIPTION
## Objective

Bump the `minions` install pin from `@v0.0.5` to `@v0.0.6` across all minion workflows.

## Why

[minions v0.0.6](https://github.com/partio-io/minions/releases/tag/v0.0.6) fixes the shared-branch bug: each issue-triggered build now gets its own branch (`minion/<prog>-<agent>-<issue>`) instead of the shared `minion/implement-implement`, so sequential/concurrent builds no longer collide into one PR. CI keeps running the old buggy v0.0.5 until this pin is bumped.

## How

`@v0.0.5` → `@v0.0.6` in the five workflows that install minions: `minion.yml`, `research.yml`, `plan.yml`, `propose.yml`, `doc-minion.yml`. No other changes.

Pre-flighted `go install github.com/partio-io/minions/cmd/minions@v0.0.6` — resolves and builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
