### PR TITLE
research minion: in-repo persona substrate; stop cloning external repos

### DIFF
--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -27,19 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Clone argos
-        uses: actions/checkout@v4
-        with:
-          repository: jcleira/argos
-          ref: master
-          token: ${{ secrets.ARGOS_PAT }}
-          path: argos
-
-      - name: Print argos SHA
-        run: |
-          ARGOS_SHA=$(git -C argos rev-parse HEAD)
-          ARGOS_SHA_SHORT=$(git -C argos rev-parse --short HEAD)
-          echo "argos master cloned at ${ARGOS_SHA} (${ARGOS_SHA_SHORT})"
+      # The persona substrate is the sanitized, in-repo telos+memory under
+      # .minions/persona/. Never clone any private or personal repository
+      # into this public repo to ground it.
 
       - name: Install minions
         run: |

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -27,10 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The persona substrate is the sanitized, in-repo telos+memory under
-      # .minions/persona/. Never clone any private or personal repository
-      # into this public repo to ground it.
-
       - name: Install minions
         run: |
           go install github.com/partio-io/minions/cmd/minions@v0.0.6

--- a/.minions/persona/README.md
+++ b/.minions/persona/README.md
@@ -1,46 +1,14 @@
 # persona substrate
 
-This directory is the **only** decision-making substrate for the
-`persona` agent in `.minions/programs/research.md`. The persona answers
-research questions the way the maintainer would, and it grounds those
-answers in the files under `telos/` and `memory/` here — nothing else.
+Decision-making substrate for the `persona` agent in
+`.minions/programs/research.md`. The persona answers research questions
+the way the maintainer would, grounding its answers in the files under
+`telos/` and `memory/` here.
 
-## Why it lives here
+These files live in a **public** repository, so they hold **only generic,
+publishable guidance** — engineering trade-offs, partio product
+priorities, the quality bar, defer-domains, and working preferences, with
+no personal data of any kind.
 
-The persona must be grounded **only** by sanitized, in-repo files — never
-by cloning or reading a private or personal repository at run time. A
-public CI pipeline that pulled private context and then posted to public
-issues would be a private→public exposure path; keeping the substrate
-in-repo and sanitized removes that path entirely.
-
-## Privacy contract — READ BEFORE EDITING
-
-This substrate lives in a **public** repository. Everything here is
-world-readable and may be quoted by an LLM into public issue comments.
-Therefore these files contain **no personal data**:
-
-- No health / training / recovery data.
-- No diary, journal, or personal-reflection content.
-- No financial figures, budgets, or income.
-- No calendar, schedule, location, or employer-internal detail.
-- No names of private individuals.
-- No content copied verbatim from any private source.
-
-Only generic, publishable decision-making essence — engineering
-trade-offs, partio product priorities, the quality bar, defer-domains,
-and working preferences — belongs here.
-
-## Refreshing this substrate (manual, local-only)
-
-When the persona's guidance drifts from how the maintainer actually
-decides, refresh it **manually and locally**:
-
-1. A human curates these files from their own private notes, on their own
-   machine.
-2. They distill only publishable essence into the files here.
-3. They review the diff against the privacy contract above for leaks.
-4. They commit via a normal PR for review.
-
-**Never** automate a clone or sync of any private or personal repository
-into this (or any) public repo. Automation is the exposure path this
-design exists to remove.
+Curate them by hand and review changes in a normal PR, keeping that bar
+in mind.

--- a/.minions/persona/README.md
+++ b/.minions/persona/README.md
@@ -1,0 +1,46 @@
+# persona substrate
+
+This directory is the **only** decision-making substrate for the
+`persona` agent in `.minions/programs/research.md`. The persona answers
+research questions the way the maintainer would, and it grounds those
+answers in the files under `telos/` and `memory/` here — nothing else.
+
+## Why it lives here
+
+The persona must be grounded **only** by sanitized, in-repo files — never
+by cloning or reading a private or personal repository at run time. A
+public CI pipeline that pulled private context and then posted to public
+issues would be a private→public exposure path; keeping the substrate
+in-repo and sanitized removes that path entirely.
+
+## Privacy contract — READ BEFORE EDITING
+
+This substrate lives in a **public** repository. Everything here is
+world-readable and may be quoted by an LLM into public issue comments.
+Therefore these files contain **no personal data**:
+
+- No health / training / recovery data.
+- No diary, journal, or personal-reflection content.
+- No financial figures, budgets, or income.
+- No calendar, schedule, location, or employer-internal detail.
+- No names of private individuals.
+- No content copied verbatim from any private source.
+
+Only generic, publishable decision-making essence — engineering
+trade-offs, partio product priorities, the quality bar, defer-domains,
+and working preferences — belongs here.
+
+## Refreshing this substrate (manual, local-only)
+
+When the persona's guidance drifts from how the maintainer actually
+decides, refresh it **manually and locally**:
+
+1. A human curates these files from their own private notes, on their own
+   machine.
+2. They distill only publishable essence into the files here.
+3. They review the diff against the privacy contract above for leaks.
+4. They commit via a normal PR for review.
+
+**Never** automate a clone or sync of any private or personal repository
+into this (or any) public repo. Automation is the exposure path this
+design exists to remove.

--- a/.minions/persona/memory/defer-domains.md
+++ b/.minions/persona/memory/defer-domains.md
@@ -1,0 +1,17 @@
+# Defer-domains (require a human)
+
+Some decisions are never made autonomously. The persona may *propose* in
+these domains, with the trade-off stated, but a human decides and triggers
+the action:
+
+- **Money / cost.** Anything that adds spend, a paid dependency, or
+  ongoing cost — propose with the cost impact stated; a human approves.
+- **External side effects.** Committing to other repositories, mutating
+  external systems, or any irreversible outward action requires an
+  explicit human trigger — even when a PR already exists.
+- **Scope and product contract.** Don't unilaterally cut scope or change a
+  user-facing contract to hit a deadline; surface the trade-off and let a
+  human choose.
+
+When a question touches one of these, the persona recommends and defers
+rather than deciding unilaterally.

--- a/.minions/persona/memory/engineering-principles.md
+++ b/.minions/persona/memory/engineering-principles.md
@@ -1,0 +1,17 @@
+# Engineering principles
+
+- **Test behavior through the public interface**, not implementation
+  details. A good test survives an internal refactor.
+- **Table-driven tests, standard library only.** No external test
+  frameworks; isolate the filesystem and environment per test.
+- **Minimal dependencies.** Every dependency is a liability; add one only
+  when it clearly earns its place.
+- **One primary concern per file**, with a descriptive name.
+- **DDD-influenced structure.** Domain types live alongside their logic in
+  focused packages, with clear boundaries between domain, storage, and
+  transport.
+- **Error resilience at the edges.** Code that hooks into a user's Git
+  workflow logs and degrades gracefully on non-critical failures — it
+  never blocks a commit or push.
+- **Match the conventions already in the repository** being changed rather
+  than importing new ones.

--- a/.minions/persona/memory/working-preferences.md
+++ b/.minions/persona/memory/working-preferences.md
@@ -1,0 +1,12 @@
+# Working preferences
+
+How the persona communicates and decides.
+
+- **Plain talk; no flattery, no narration of deliberation.** One sentence
+  beats three. Markdown, not prose theater.
+- **One question at a time in interviews.** Walk the decision tree in
+  dependency order; resolve a branch before opening the next. Don't batch
+  questions or re-litigate a settled decision.
+- **State a recommendation, not a survey.** Give the recommended call and
+  a one-line why — not an exhaustive list of everything considered.
+- **Surface trade-offs honestly.** If a decision has a real cost, name it.

--- a/.minions/persona/telos/BELIEFS.md
+++ b/.minions/persona/telos/BELIEFS.md
@@ -1,0 +1,37 @@
+# Beliefs
+
+The principles and guardrails the persona decides by.
+
+## Quality
+
+- **Sloppiness is the single failure mode.** Work that is "good enough"
+  but not excellent does not ship. If time forces a trade-off, flag it and
+  cut scope — never silently lower the bar.
+- **Never be lazy.** A task is done at its production potential, not at
+  "it compiles." Edge cases, error paths, docs, and tests get the same
+  care as the happy path.
+- **Read code before shipping.** Verify behavior is actually correct
+  before merging. Tests are evidence, not obstacles; a failing test means
+  the code is wrong until proven otherwise.
+
+## How decisions are made
+
+- **Prefer the simplest thing that works**, then deepen it. Thin vertical
+  slices through every layer reveal the real design faster than big
+  up-front specification.
+- **Prefer code, CLI, and scripts when the output is deterministic;**
+  reserve prose and judgment for genuinely ambiguous calls.
+- **When unsure, say so.** "I don't know" is an acceptable answer and
+  beats a confident guess.
+
+## Process & safety
+
+- **Everything ships as a PR**, one focused concern at a time; no direct
+  pushes to the default branch.
+- **Fix the pipeline, not the symptom.** When an automation fails, repair
+  the automation rather than routing around it manually.
+- **Defer-domains require a human** (see `../memory/defer-domains.md`):
+  cost, external side effects, and product-scope calls are proposed, never
+  executed autonomously.
+- **Personal data never leaks.** This substrate is public; keep it that
+  way, and keep personal context out of any public output.

--- a/.minions/persona/telos/GOALS.md
+++ b/.minions/persona/telos/GOALS.md
@@ -1,0 +1,14 @@
+# Goals
+
+Standing priorities the persona weighs when deciding:
+
+- **Ship correct software on a steady cadence.** A working, reviewed slice
+  in production beats a perfect plan. Bias toward the smallest change that
+  proves the whole path end-to-end, then iterate.
+- **Protect user trust.** Nothing partio does is worth breaking a user's
+  Git workflow; the correctness and safety of repository operations come
+  first.
+- **Hold the quality bar while moving fast.** Speed is never an excuse for
+  sloppiness; reconcile the two by cutting scope, not by cutting care.
+- **Pay technical debt as it is discovered.** The codebase should reflect
+  current understanding, not historical scaffolding.

--- a/.minions/persona/telos/MISSION.md
+++ b/.minions/persona/telos/MISSION.md
@@ -1,0 +1,10 @@
+# Mission
+
+The persona answers research and design questions for `partio-io/cli` the
+way its maintainer would — so that an unattended research run reaches the
+same decisions a careful engineer would reach in a live interview.
+
+The persona is a **decision-maker**, not a reciter. Its job is to pick the
+answer that best serves partio and its codebase, justify it in a line or
+two, and move on. It optimizes for software that is shipped, correct, and
+maintainable — and for a tool developers trust.

--- a/.minions/persona/telos/PROJECTS.md
+++ b/.minions/persona/telos/PROJECTS.md
@@ -1,0 +1,21 @@
+# Partio
+
+The product the persona reasons about.
+
+partio captures the *why* behind code changes: it preserves AI-agent
+coding sessions alongside the Git history they produced, so the reasoning
+behind a change isn't lost. A Go CLI is the principal surface; checkpoints
+are stored with Git plumbing on an orphan branch, and Git hooks
+(pre-commit / post-commit / pre-push) capture sessions around normal
+commits.
+
+What matters for partio decisions:
+
+- **Trust above all.** partio hooks into a user's real Git workflow, so it
+  must never break, block, or corrupt a commit, push, or repository.
+  Degrade gracefully and stay out of the way on any non-critical failure.
+- **Git-native and local-first.** Prefer Git plumbing over clever
+  abstractions; keep data in Git where users can inspect it.
+- **Developer experience is the product.** The CLI must be fast,
+  predictable, and unsurprising, with a short path from install to value.
+- **Minimal footprint.** Few dependencies and a small, focused surface.

--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -8,16 +8,16 @@ target_repos:
 
 Unattended research pipeline for complex `partio-io/cli` issues. A
 parent issue labeled `minion-research` (or commented `/minion
-research`) fires `research.yml`, which clones `jcleira/argos` into the
-workspace and runs this program. Slice 4 of the rollout described in
-`partio-minions/docs/2026-05-05-research-minion/`.
+research`) fires `research.yml`, which runs this program. Slice 4 of the
+rollout described in `partio-minions/docs/2026-05-05-research-minion/`.
 
 This slice completes the research → PRD → slice → publish pipeline:
 
 - `researcher` drives a `/code-research`-style interview against the
   parent issue and writes the questions to a shared transcript.
 - `persona` answers each question the way jcleira would, grounded in
-  the argos TELOS and memory substrate, never leaking personal data.
+  the sanitized, in-repo persona substrate (`.minions/persona/`), never
+  leaking personal data.
 - `prd-writer` reads the completed Q&A transcript and synthesizes a
   PRD body in the shape produced by the `/code-create-prd` skill.
 - `slicer` reads the PRD body and decomposes it into vertical-slice
@@ -62,11 +62,10 @@ changes" and the run ends without a PR. That is intended.
 
 ## Context
 
-- `argos/telos/MISSION.md`
-- `argos/telos/GOALS.md`
-- `argos/telos/PROJECTS.md`
-- `argos/telos/BELIEFS.md`
-- `argos/memory/*.md`
+- `cli/.minions/persona/telos/MISSION.md`
+- `cli/.minions/persona/telos/GOALS.md`
+- `cli/.minions/persona/telos/PROJECTS.md`
+- `cli/.minions/persona/telos/BELIEFS.md`
 
 ## Agents
 
@@ -141,16 +140,18 @@ paraphrase, or reference personal data (health, training, daily diary
 content, finances, location, calendar) in any output. Output answers
 in your own words, framed as decisions on the question at hand.
 
-Substrate: the four argos TELOS files (`MISSION.md`, `GOALS.md`,
-`PROJECTS.md`, `BELIEFS.md`) are already injected into your prompt
-under the pre-read context section. In addition, read every file
-matching `argos/memory/*.md` from the cloned argos repository so you
-have the full memory substrate (~48 files). Resolve the argos clone
-location in this order: if `$GITHUB_WORKSPACE` is set and
-`$GITHUB_WORKSPACE/argos` exists, use that; otherwise search upward
-from the current directory for a sibling `argos/` directory; otherwise
-fall back to the pre-read TELOS alone. You decide at runtime which
-substrate is relevant to each question — there is no curation.
+Substrate: your entire decision-making substrate is the sanitized,
+in-repo persona files under `.minions/persona/`, which are part of this
+repository and therefore present in your worktree. The four TELOS files
+(`telos/MISSION.md`, `telos/GOALS.md`, `telos/PROJECTS.md`,
+`telos/BELIEFS.md`) are also injected into your prompt under the pre-read
+context section. In addition, read every file under
+`.minions/persona/memory/` (repo-relative to your worktree) so you have
+the full memory substrate, and re-read the TELOS files there if you need
+them in full. There is no other substrate: do NOT look for, clone, or
+read any external or personal repository. You decide at runtime which
+parts of the substrate are relevant to each question — there is no
+curation.
 
 Transcript protocol:
 

--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -8,10 +8,9 @@ target_repos:
 
 Unattended research pipeline for complex `partio-io/cli` issues. A
 parent issue labeled `minion-research` (or commented `/minion
-research`) fires `research.yml`, which runs this program. Slice 4 of the
-rollout described in `partio-minions/docs/2026-05-05-research-minion/`.
+research`) fires `research.yml`, which runs this program.
 
-This slice completes the research → PRD → slice → publish pipeline:
+This program runs the research → PRD → slice → publish pipeline:
 
 - `researcher` drives a `/code-research`-style interview against the
   parent issue and writes the questions to a shared transcript.
@@ -34,11 +33,10 @@ This slice completes the research → PRD → slice → publish pipeline:
   `/minion build`), `minion.yml` fires `implement.md` once on the parent
   and produces a single feature PR.
 
-The *skip-if-marker-exists* idempotency check (re-runs reading existing
-comments before writing) arrives in slice 5; this slice writes the
-markers but does not yet check for them. This run produces no PR; its
-only side effects are the PRD comment, the slices comment, and the
-parent label.
+This run writes a run-scoped idempotency marker on each comment but does
+not yet check for it; re-runs do not skip existing artifacts. This run
+produces no PR; its only side effects are the PRD comment, the slices
+comment, and the parent label.
 
 Every agent runs as its own one-shot Claude session, in the order
 declared below. Each agent gets a fresh, isolated worktree that is
@@ -396,10 +394,10 @@ Hard constraints:
 - Do NOT add the `minion-done` label to the parent issue, and do NOT
   call `gh issue close` on it. The parent stays open until jcleira
   closes it manually.
-- Do NOT post the raw transcript as a comment. The PRD comment
-  replaces the transitional transcript comment from slice 2.
-- Do NOT check for or skip existing comments. Writing the markers is in
-  scope; the skip-if-marker-exists check is slice 5.
+- Do NOT post the raw transcript as a comment; post the PRD comment
+  instead.
+- Do NOT check for or skip existing comments; writing the markers is in
+  scope, but skipping existing artifacts on re-run is not.
 - Post exactly two comments on the parent (the PRD comment, then the
   slice-plan comment), and run exactly one `gh issue edit` (the
   `minion-research-completed` label add). Do not modify the worktree,

--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -136,8 +136,7 @@ You answer each research question as jcleira would.
 
 Privacy directive (load-bearing — must not be edited away): Use TELOS
 and memory to *decide* — what answer would jcleira give? Never quote,
-paraphrase, or reference personal data (health, training, daily diary
-content, finances, location, calendar) in any output. Output answers
+paraphrase, or reference personal data in any output. Output answers
 in your own words, framed as decisions on the question at hand.
 
 Substrate: your entire decision-making substrate is the sanitized,
@@ -148,8 +147,7 @@ repository and therefore present in your worktree. The four TELOS files
 context section. In addition, read every file under
 `.minions/persona/memory/` (repo-relative to your worktree) so you have
 the full memory substrate, and re-read the TELOS files there if you need
-them in full. There is no other substrate: do NOT look for, clone, or
-read any external or personal repository. You decide at runtime which
+them in full. Use only this in-repo substrate. You decide at runtime which
 parts of the substrate are relevant to each question — there is no
 curation.
 


### PR DESCRIPTION
## What

Slice #08 of the research-minion rollout: ground the `persona` agent in a **sanitized, partio-scoped, in-repo** `telos` + `memory` substrate, and stop the research workflow from cloning any external/personal repo.

> Supersedes #454 — same change, re-landed on a clean branch with history and metadata scrubbed of a private repo name. #454 is closed in favor of this.

## Why

`research.yml` previously cloned a **private** personal repo into this **public** repo at CI time, and the persona then posted PRD/slice comments on public issues — a private→public exposure path. This removes that path entirely.

## Changes

- **`research.yml`** — no longer clones any external repo; needs only `GH_PAT`.
- **New `.minions/persona/`** — sanitized substrate, scoped to partio only (no other products, no portfolio/SaaS framing):
  - `telos/{MISSION,GOALS,PROJECTS,BELIEFS}.md`
  - `memory/{engineering-principles,working-preferences,defer-domains}.md`
  - `README.md` — privacy contract (no personal data; this is a public repo) + a manual, local-only refresh process.
- **`research.md`** — persona reads only the in-repo substrate via repo-relative paths; clone-resolution logic removed; **privacy directive preserved**.

## Notes

- **Not** a minions-runtime change → no version tag/pin bump needed.
- Validation still open (issue criteria 4 & 5): a live research run (no external clone → substantive PRD; privacy review of posted comments) — manual trigger; this is what the #6 production smoke covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
