### PR TITLE
security: disable partio session capture/push on this public repo

### DIFF
--- a/.partio/settings.json
+++ b/.partio/settings.json
@@ -1,9 +1,9 @@
 {
-  "enabled": true,
+  "enabled": false,
   "strategy": "manual-commit",
   "agent": "claude-code",
   "log_level": "info",
   "strategy_options": {
-    "push_sessions": true
+    "push_sessions": false
   }
 }


### PR DESCRIPTION
## What

Turns partio off for this repository at the committed-config level (`.partio/settings.json`):

- `strategy_options.push_sessions`: `true` → `false` — stops the pre-push hook from pushing `partio/checkpoints/v1` to `origin`.
- `enabled`: `true` → `false` — also stops local session capture.

## Why

This repo is **public**. The pre-push hook (`internal/hooks/prepush.go`) does `git push --no-verify origin partio/checkpoints/v1` whenever `push_sessions` is true — which published captured local session transcripts to the public repo. The checkpoint branches have been deleted; this prevents any clone from re-creating and re-publishing them.

`push_sessions: false` is the load-bearing fix (the hook gates the push on exactly that field). `enabled: false` additionally disables capture here — if you'd rather keep local-only checkpoints, revert just that field; the public push stays off as long as `push_sessions` is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)