### PR TITLE
Make `partio enable` idempotent for safe re-runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,6 @@ Partio supports git worktrees:
 
 ## Known Limitations
 
-- `partio enable` skips hook installation if `.partio/` already exists. To reinstall hooks, run `partio disable && partio enable`.
+- `partio enable` is idempotent — it can be re-run to repair hooks and ensure settings are consistent.
 - The `_hook` command accepts extra args (`cobra.MinimumNArgs(1)`) because git passes additional arguments to hooks (e.g., remote name and URL for pre-push).
 - Session JSONL parsing may produce empty context/prompt fields depending on the Claude session format.

--- a/cmd/partio/enable.go
+++ b/cmd/partio/enable.go
@@ -36,24 +36,14 @@ func runEnable(cmd *cobra.Command, args []string) error {
 
 	partioDir := filepath.Join(repoRoot, config.PartioDir)
 
-	// Check if already enabled
-	if _, err := os.Stat(partioDir); err == nil {
-		fmt.Println("partio is already enabled in this repository.")
-		return nil
-	}
-
-	// Create .partio/ directory
+	// Create .partio/ directory (no-op if it already exists)
 	if err := os.MkdirAll(partioDir, 0o755); err != nil {
 		return fmt.Errorf("creating .partio directory: %w", err)
 	}
 
-	// Write default settings.json
-	defaults := config.Defaults()
-	data, err := json.MarshalIndent(defaults, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshaling default config: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(partioDir, "settings.json"), data, 0o644); err != nil {
+	// Ensure settings.json exists with enabled: true
+	settingsPath := filepath.Join(partioDir, "settings.json")
+	if err := ensureSettingsEnabled(settingsPath); err != nil {
 		return fmt.Errorf("writing settings.json: %w", err)
 	}
 
@@ -62,7 +52,7 @@ func runEnable(cmd *cobra.Command, args []string) error {
 	addToGitignore(repoRoot, ".partio/sessions/")
 	addToGitignore(repoRoot, ".partio/state/")
 
-	// Install git hooks
+	// Install git hooks (reinstalls if missing or stale)
 	if absolutePath {
 		exePath, err := os.Executable()
 		if err != nil {
@@ -85,10 +75,53 @@ func runEnable(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("partio enabled successfully!")
-	fmt.Println("  - Created .partio/ config directory")
+	fmt.Println("  - Ensured .partio/ config directory exists")
 	fmt.Println("  - Installed git hooks (pre-commit, post-commit, pre-push)")
 	fmt.Println("  - Ready to capture AI sessions on commit")
 	return nil
+}
+
+// ensureSettingsEnabled creates settings.json with defaults if it doesn't exist,
+// or ensures enabled is set to true in existing settings.
+func ensureSettingsEnabled(settingsPath string) error {
+	existing, err := os.ReadFile(settingsPath)
+	if err != nil {
+		// File doesn't exist — write defaults
+		defaults := config.Defaults()
+		data, marshalErr := json.MarshalIndent(defaults, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("marshaling default config: %w", marshalErr)
+		}
+		return os.WriteFile(settingsPath, data, 0o644)
+	}
+
+	// File exists — parse and ensure enabled: true
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(existing, &raw); err != nil {
+		// Corrupted JSON — overwrite with defaults
+		defaults := config.Defaults()
+		data, marshalErr := json.MarshalIndent(defaults, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("marshaling default config: %w", marshalErr)
+		}
+		return os.WriteFile(settingsPath, data, 0o644)
+	}
+
+	// Check if enabled is already true
+	if v, ok := raw["enabled"]; ok {
+		var enabled bool
+		if json.Unmarshal(v, &enabled) == nil && enabled {
+			return nil // already enabled, preserve existing config
+		}
+	}
+
+	// Set enabled to true, preserving other settings
+	raw["enabled"] = json.RawMessage("true")
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	return os.WriteFile(settingsPath, data, 0o644)
 }
 
 func addToGitignore(repoRoot, entry string) {

--- a/cmd/partio/enable_test.go
+++ b/cmd/partio/enable_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureSettingsEnabled(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingContent string // empty means no file
+		wantEnabled     bool
+		wantStrategy    string // if non-empty, check this key is preserved
+	}{
+		{
+			name:        "no existing file creates defaults",
+			wantEnabled: true,
+		},
+		{
+			name:            "existing file with enabled false sets to true",
+			existingContent: `{"enabled": false, "strategy": "manual-commit", "agent": "claude-code"}`,
+			wantEnabled:     true,
+			wantStrategy:    "manual-commit",
+		},
+		{
+			name:            "existing file with enabled true is preserved",
+			existingContent: `{"enabled": true, "strategy": "custom-strategy", "agent": "claude-code"}`,
+			wantEnabled:     true,
+			wantStrategy:    "custom-strategy",
+		},
+		{
+			name:            "corrupted JSON is overwritten with defaults",
+			existingContent: `{not valid json`,
+			wantEnabled:     true,
+		},
+		{
+			name:            "missing enabled key sets it to true",
+			existingContent: `{"strategy": "manual-commit"}`,
+			wantEnabled:     true,
+			wantStrategy:    "manual-commit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			settingsPath := filepath.Join(dir, "settings.json")
+
+			if tt.existingContent != "" {
+				if err := os.WriteFile(settingsPath, []byte(tt.existingContent), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := ensureSettingsEnabled(settingsPath); err != nil {
+				t.Fatalf("ensureSettingsEnabled() error = %v", err)
+			}
+
+			data, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("reading settings.json: %v", err)
+			}
+
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(data, &raw); err != nil {
+				t.Fatalf("parsing settings.json: %v", err)
+			}
+
+			var enabled bool
+			if v, ok := raw["enabled"]; !ok {
+				t.Fatal("settings.json missing 'enabled' key")
+			} else if err := json.Unmarshal(v, &enabled); err != nil {
+				t.Fatalf("parsing 'enabled' value: %v", err)
+			}
+
+			if enabled != tt.wantEnabled {
+				t.Errorf("enabled = %v, want %v", enabled, tt.wantEnabled)
+			}
+
+			if tt.wantStrategy != "" {
+				var strategy string
+				if v, ok := raw["strategy"]; !ok {
+					t.Error("settings.json missing 'strategy' key")
+				} else if err := json.Unmarshal(v, &strategy); err != nil {
+					t.Errorf("parsing 'strategy' value: %v", err)
+				} else if strategy != tt.wantStrategy {
+					t.Errorf("strategy = %q, want %q", strategy, tt.wantStrategy)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Removes early return** when `.partio/` already exists — `partio enable` now always ensures hooks are installed and settings are consistent
- **Preserves existing config** — only sets `enabled: true` if it's missing or false; other settings (strategy, agent, etc.) are left intact
- **Handles corrupted settings.json** — overwrites with defaults if JSON is unparseable
- **Updates CLAUDE.md** — replaces the "known limitation" about skipping with documentation of the new idempotent behavior

Closes #450

## Test plan

- [x] `TestEnsureSettingsEnabled` covers: no file, enabled=false, enabled=true, corrupted JSON, missing enabled key
- [x] `go test ./...` passes
- [x] `golangci-lint run ./cmd/...` passes (pre-existing lint issues in unrelated codex package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)