### PR TITLE
Add interactive [Y/n/a] prompt for commit-to-session linking

### DIFF
--- a/cmd/partio/status.go
+++ b/cmd/partio/status.go
@@ -44,6 +44,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Status:     enabled")
 	fmt.Printf("Strategy:   %s\n", cfg.Strategy)
+	fmt.Printf("Linking:    %s\n", cfg.CommitLinking)
 	fmt.Printf("Agent:      %s\n", cfg.Agent)
 
 	// Check hooks

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,16 @@ type Config struct {
 	Strategy        string          `json:"strategy"`
 	Agent           string          `json:"agent"`
 	LogLevel        string          `json:"log_level"`
+	CommitLinking   string          `json:"commit_linking"`
 	StrategyOptions StrategyOptions `json:"strategy_options"`
 }
+
+// CommitLinking values.
+const (
+	CommitLinkingAsk    = "ask"
+	CommitLinkingAlways = "always"
+	CommitLinkingNever  = "never"
+)
 
 // StrategyOptions holds strategy-specific options.
 type StrategyOptions struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,9 @@ func TestDefaults(t *testing.T) {
 	if d.LogLevel != "info" {
 		t.Errorf("expected log_level=info, got %s", d.LogLevel)
 	}
+	if d.CommitLinking != CommitLinkingAsk {
+		t.Errorf("expected commit_linking=ask, got %s", d.CommitLinking)
+	}
 	if d.StrategyOptions.PushSessions != true {
 		t.Errorf("expected push_sessions=true, got %v", d.StrategyOptions.PushSessions)
 	}
@@ -41,7 +44,7 @@ func TestMergeFromFile(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.json")
 
-	err := os.WriteFile(settingsPath, []byte(`{"strategy": "auto-commit", "log_level": "debug"}`), 0o644)
+	err := os.WriteFile(settingsPath, []byte(`{"strategy": "auto-commit", "log_level": "debug", "commit_linking": "always"}`), 0o644)
 	if err != nil {
 		t.Fatalf("writing test settings: %v", err)
 	}
@@ -55,6 +58,9 @@ func TestMergeFromFile(t *testing.T) {
 	if cfg.LogLevel != "debug" {
 		t.Errorf("expected log_level=debug, got %s", cfg.LogLevel)
 	}
+	if cfg.CommitLinking != CommitLinkingAlways {
+		t.Errorf("expected commit_linking=always, got %s", cfg.CommitLinking)
+	}
 	// Unset fields should retain defaults
 	if cfg.Agent != "" {
 		t.Errorf("expected agent='' (auto-detect default), got %s", cfg.Agent)
@@ -65,6 +71,7 @@ func TestEnvOverrides(t *testing.T) {
 	t.Setenv("PARTIO_STRATEGY", "env-strategy")
 	t.Setenv("PARTIO_LOG_LEVEL", "error")
 	t.Setenv("PARTIO_ENABLED", "false")
+	t.Setenv("PARTIO_COMMIT_LINKING", "never")
 
 	cfg := Defaults()
 	applyEnv(&cfg)
@@ -77,6 +84,9 @@ func TestEnvOverrides(t *testing.T) {
 	}
 	if cfg.Enabled != false {
 		t.Errorf("expected enabled=false, got %v", cfg.Enabled)
+	}
+	if cfg.CommitLinking != CommitLinkingNever {
+		t.Errorf("expected commit_linking=never, got %s", cfg.CommitLinking)
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -3,10 +3,11 @@ package config
 // Defaults returns a Config with default values.
 func Defaults() Config {
 	return Config{
-		Enabled:  true,
-		Strategy: "manual-commit",
-		Agent:    "",
-		LogLevel: "info",
+		Enabled:       true,
+		Strategy:      "manual-commit",
+		Agent:         "",
+		LogLevel:      "info",
+		CommitLinking: CommitLinkingAsk,
 		StrategyOptions: StrategyOptions{
 			PushSessions: true,
 		},

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -18,4 +18,7 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("PARTIO_AGENT"); v != "" {
 		cfg.Agent = v
 	}
+	if v := os.Getenv("PARTIO_COMMIT_LINKING"); v != "" {
+		cfg.CommitLinking = v
+	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -57,6 +57,9 @@ func mergeFromFile(dst *Config, path string) {
 	if v, ok := raw["log_level"]; ok {
 		_ = json.Unmarshal(v, &dst.LogLevel)
 	}
+	if v, ok := raw["commit_linking"]; ok {
+		_ = json.Unmarshal(v, &dst.CommitLinking)
+	}
 	if v, ok := raw["strategy_options"]; ok {
 		_ = json.Unmarshal(v, &dst.StrategyOptions)
 	}

--- a/internal/config/save.go
+++ b/internal/config/save.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// SaveRepoSetting updates a single key in the repo-level settings.json,
+// preserving all other settings. The file is created if it does not exist.
+func SaveRepoSetting(repoRoot, key string, value any) error {
+	settingsPath := filepath.Join(repoRoot, PartioDir, "settings.json")
+
+	raw := make(map[string]json.RawMessage)
+
+	existing, err := os.ReadFile(settingsPath)
+	if err == nil {
+		_ = json.Unmarshal(existing, &raw)
+	}
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	raw[key] = json.RawMessage(encoded)
+
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(settingsPath, data, 0o644)
+}

--- a/internal/config/save_test.go
+++ b/internal/config/save_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveRepoSetting_NewFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := SaveRepoSetting(dir, "commit_linking", CommitLinkingAlways); err != nil {
+		t.Fatalf("SaveRepoSetting: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, PartioDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("reading settings.json: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+
+	var val string
+	if err := json.Unmarshal(raw["commit_linking"], &val); err != nil {
+		t.Fatalf("unmarshaling commit_linking: %v", err)
+	}
+	if val != CommitLinkingAlways {
+		t.Errorf("expected %s, got %s", CommitLinkingAlways, val)
+	}
+}
+
+func TestSaveRepoSetting_PreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	partioDir := filepath.Join(dir, PartioDir)
+	if err := os.MkdirAll(partioDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Write initial settings
+	initial := `{"enabled": true, "strategy": "manual-commit"}`
+	if err := os.WriteFile(filepath.Join(partioDir, "settings.json"), []byte(initial), 0o644); err != nil {
+		t.Fatalf("writing initial settings: %v", err)
+	}
+
+	if err := SaveRepoSetting(dir, "commit_linking", CommitLinkingAlways); err != nil {
+		t.Fatalf("SaveRepoSetting: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(partioDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("reading settings.json: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+
+	// Check commit_linking was added
+	var linking string
+	if err := json.Unmarshal(raw["commit_linking"], &linking); err != nil {
+		t.Fatalf("unmarshaling commit_linking: %v", err)
+	}
+	if linking != CommitLinkingAlways {
+		t.Errorf("expected commit_linking=%s, got %s", CommitLinkingAlways, linking)
+	}
+
+	// Check existing settings preserved
+	var enabled bool
+	if err := json.Unmarshal(raw["enabled"], &enabled); err != nil {
+		t.Fatalf("unmarshaling enabled: %v", err)
+	}
+	if !enabled {
+		t.Error("expected enabled to be preserved as true")
+	}
+}

--- a/internal/hooks/commit_linking.go
+++ b/internal/hooks/commit_linking.go
@@ -1,0 +1,62 @@
+package hooks
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/partio-io/cli/internal/config"
+)
+
+// shouldLinkCommit determines whether the current commit should be linked to
+// the active agent session. It returns true if the commit should be linked.
+//
+// When commit_linking is "ask", it prompts the user interactively via /dev/tty.
+// The prompt offers [Y/n/a]: Y (default) links, n skips, a links and persists
+// "always" to settings so future commits are linked without prompting.
+func shouldLinkCommit(repoRoot string, cfg config.Config) bool {
+	switch cfg.CommitLinking {
+	case config.CommitLinkingAlways:
+		slog.Debug("commit linking: always (auto-linking)")
+		return true
+	case config.CommitLinkingNever:
+		slog.Debug("commit linking: never (skipping)")
+		return false
+	default: // "ask" or unset
+		return promptCommitLinking(repoRoot)
+	}
+}
+
+// promptCommitLinking opens /dev/tty to ask the user whether to link this
+// commit. If /dev/tty is not available (non-interactive), it defaults to
+// linking the commit.
+func promptCommitLinking(repoRoot string) bool {
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		slog.Debug("commit linking: no TTY available, auto-linking")
+		return true
+	}
+	defer func() { _ = tty.Close() }()
+
+	_, _ = fmt.Fprint(tty, "partio: Link this commit to the active AI session? [Y/n/a] ")
+
+	reader := bufio.NewReader(tty)
+	line, _ := reader.ReadString('\n')
+	answer := strings.TrimSpace(strings.ToLower(line))
+
+	switch answer {
+	case "n":
+		slog.Debug("commit linking: user chose not to link")
+		return false
+	case "a":
+		slog.Debug("commit linking: user chose always")
+		if err := config.SaveRepoSetting(repoRoot, "commit_linking", config.CommitLinkingAlways); err != nil {
+			slog.Warn("could not persist commit_linking=always", "error", err)
+		}
+		return true
+	default: // "", "y", "Y"
+		return true
+	}
+}

--- a/internal/hooks/commit_linking_test.go
+++ b/internal/hooks/commit_linking_test.go
@@ -1,0 +1,46 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/partio-io/cli/internal/config"
+)
+
+func TestShouldLinkCommit(t *testing.T) {
+	tests := []struct {
+		name     string
+		linking  string
+		wantLink bool
+	}{
+		{
+			name:     "always links without prompt",
+			linking:  config.CommitLinkingAlways,
+			wantLink: true,
+		},
+		{
+			name:     "never skips without prompt",
+			linking:  config.CommitLinkingNever,
+			wantLink: false,
+		},
+		{
+			name:     "ask defaults to link when no TTY",
+			linking:  config.CommitLinkingAsk,
+			wantLink: true, // no TTY in test environment → auto-link
+		},
+		{
+			name:     "empty defaults to link when no TTY",
+			linking:  "",
+			wantLink: true, // treated as "ask" → no TTY → auto-link
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{CommitLinking: tt.linking}
+			got := shouldLinkCommit(t.TempDir(), cfg)
+			if got != tt.wantLink {
+				t.Errorf("shouldLinkCommit() = %v, want %v", got, tt.wantLink)
+			}
+		})
+	}
+}

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -97,6 +97,11 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 		agentActive = running && sessionPath != ""
 	}
 
+	// Check commit linking preference before saving state.
+	if agentActive && !shouldLinkCommit(repoRoot, cfg) {
+		agentActive = false
+	}
+
 	state := preCommitState{
 		AgentActive:   agentActive,
 		AgentName:     detector.Name(),


### PR DESCRIPTION
## Summary

- Adds a `commit_linking` setting (`ask`, `always`, `never`) to control whether commits are linked to active AI agent sessions
- Default is `ask`: shows a `[Y/n/a]` prompt during pre-commit when a session is active (Y=link, n=skip, a=always link and persist)
- Non-interactive environments (no TTY) auto-link without prompting
- Setting stored in `.partio/settings.json`, overridable via `PARTIO_COMMIT_LINKING` env var
- Displayed in `partio status` output

## Changes

- `internal/config/config.go`: Added `CommitLinking` field and constants
- `internal/config/defaults.go`: Default to `ask`
- `internal/config/env.go`: Support `PARTIO_COMMIT_LINKING` env var
- `internal/config/load.go`: Merge `commit_linking` from settings files
- `internal/config/save.go`: New — persist individual settings back to `settings.json`
- `internal/hooks/commit_linking.go`: New — prompt logic with TTY detection
- `internal/hooks/precommit.go`: Integrate commit linking check before saving state
- `cmd/partio/status.go`: Show `commit_linking` in status output

## Test plan

- [x] `make test` passes — all existing + new tests pass
- [x] `make lint` passes (no new issues)
- [ ] Manual: `commit_linking=ask` prompts on TTY, auto-links without TTY
- [ ] Manual: answering `a` persists `always` to settings.json
- [ ] Manual: `commit_linking=never` skips checkpoint creation
- [ ] Manual: `PARTIO_COMMIT_LINKING=always` env var overrides config

🤖 Generated with [Claude Code](https://claude.com/claude-code)