### PR TITLE
fix(minion): link built PR to its issue and refuse to false-close

### DIFF
--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -77,10 +77,33 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           ISSUE_NUM="${{ steps.program.outputs.issue_num }}"
-          gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" \
+          REPO="${{ github.repository }}"
+
+          # Find the PR this run opened. The branch name is deterministic per
+          # issue, so we can locate the PR without the agent reporting it.
+          PR=$(gh pr list --repo "$REPO" \
+            --head "minion/implement-implement-${ISSUE_NUM}" \
+            --state open --json number --jq '.[0].number // empty')
+
+          # A "successful" run that produced no PR is a silent failure, not a
+          # completion. Fail red instead of closing the issue with no work done.
+          if [ -z "$PR" ]; then
+            echo "::error::Program succeeded but no PR exists for #${ISSUE_NUM}; refusing to mark done."
+            exit 1
+          fi
+
+          # Keep the PR and issue linked. implement.md asks the agent to add a
+          # "Closes #N" reference but it does not do so reliably, so enforce it.
+          if ! gh pr view "$PR" --repo "$REPO" --json body --jq '.body' \
+              | grep -qE "#${ISSUE_NUM}([^0-9]|$)"; then
+            BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body')
+            gh pr edit "$PR" --repo "$REPO" --body "${BODY}"$'\n\n'"Closes #${ISSUE_NUM}"
+          fi
+
+          gh issue edit "$ISSUE_NUM" --repo "$REPO" \
             --add-label "minion-done" --remove-label "minion-executing"
-          gh issue close "$ISSUE_NUM" --repo "${{ github.repository }}" \
-            --comment "Minion completed successfully."
+          gh issue close "$ISSUE_NUM" --repo "$REPO" \
+            --comment "Minion completed — see PR #${PR}."
 
       - name: Mark failed
         if: failure() && steps.program.outputs.issue_num != ''


### PR DESCRIPTION
## Problem

Two issues in `minion.yml`'s **`Mark done`** step:

1. **Built PRs aren't linked to their issue.** `implement.md` asks the agent to add a `Resolves #N` reference, but that's a soft prompt instruction the agent follows unreliably — e.g. PR #486 (for #25) shipped with no reference, so the PR and issue show as unrelated.
2. **A no-PR "success" false-closes the issue.** `Mark done` runs on any `success()` from `minions run` and closes the issue — even when the run produced no PR. An agent that authenticated but made no changes (historically, a Claude auth `401` that gets swallowed as "no changes") still exits `0`, so the issue was closed with a *"completed successfully"* comment and zero work. This is what closed **#450** with no PR on Jul 6.

## Fix

`Mark done` now does this deterministically — no reliance on the agent:

- **Finds the PR** by its deterministic branch name (`minion/implement-implement-<issue>`).
- **Refuses to close if there's no PR** — exits non-zero so the job goes red and the existing `Mark failed` step flags the issue, instead of false-closing it.
- **Enforces the issue link** — if the PR body doesn't already reference `#<issue>`, appends `Closes #<issue>`, so the PR shows as linked on the issue.
- **Names the PR** in the completion comment (`Minion completed — see PR #123.`).

## Why in the workflow, not the prompt

The PR is opened by the agent via `Bash` + `gh` (there is no PR-creation code in the `minions` CLI), so there's no deterministic hook in the CLI. Doing it in the workflow makes it reliable and ships on the **next run** with no `minions` release or pin bump.

Assumption: the build branch is `minion/implement-implement-<issue>`, which is how `minions` deterministically names it today (`buildTaskID`, with a regression test). If that scheme changes, the lookup here must change with it.

## Testing

- YAML parses (`yaml.safe_load`).
- `bash -n` on the extracted step script — no syntax errors.
- Lookup verified against a real run: #25 → PR #486 on branch `minion/implement-implement-25`, which the new `--head` query matches.

⚠️ There is **no CI-on-PR in this repo**, so this has not executed in Actions yet — the first real minion build after merge is the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
