### PR TITLE
feat(redact): layered secret detection using gitleaks patterns + entropy scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,34 @@ Supported `agent` values:
 - `claude-code` (default)
 - `codex`
 
+## Security & Privacy
+
+Before any session data is written to the checkpoint branch, partio runs a two-layer secret redaction pass over all user-visible text fields (prompt, context, diff, JSONL transcript, and plan):
+
+1. **Pattern-based detection** — gitleaks-compatible regular expressions detect common secret formats including AWS access keys, GitHub personal access tokens, Slack tokens, Stripe keys, Google API keys, npm/PyPI tokens, and generic `api_key=…` / `Bearer …` assignments. Matched secrets are replaced with `[REDACTED]`.
+
+2. **Entropy-based detection** — any whitespace-delimited token that is at least 20 characters long, composed entirely of base64/hex characters, and has a Shannon entropy ≥ 4.5 bits/char is also replaced with `[REDACTED]`. This catches high-entropy strings that don't match any known pattern while keeping short version strings, commit hashes, and natural-language words intact.
+
+Redaction is enabled by default and can be tuned in `.partio/settings.json`:
+
+```json
+{
+  "redact": {
+    "enabled": true,
+    "entropy_threshold": 4.5,
+    "entropy_min_length": 20
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Toggle redaction entirely |
+| `entropy_threshold` | `4.5` | Shannon entropy (bits/char) above which a token is redacted |
+| `entropy_min_length` | `20` | Minimum token length considered for entropy scanning |
+
+> **Note:** Redaction is a best-effort safety net. Do not rely on it as a substitute for proper secret management (e.g. environment variables, secret managers). The git diff captured in checkpoints may contain other sensitive data depending on your code.
+
 ## License
 
 MIT

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	LogLevel        string          `json:"log_level"`
 	CommitLinking   string          `json:"commit_linking"`
 	StrategyOptions StrategyOptions `json:"strategy_options"`
+	Redact          RedactOptions   `json:"redact"`
 }
 
 // CommitLinking values.
@@ -20,6 +21,19 @@ const (
 // StrategyOptions holds strategy-specific options.
 type StrategyOptions struct {
 	PushSessions bool `json:"push_sessions"`
+}
+
+// RedactOptions controls secret redaction in checkpoint data.
+type RedactOptions struct {
+	// Enabled toggles redaction. Defaults to true.
+	Enabled bool `json:"enabled"`
+	// EntropyThreshold is the minimum Shannon entropy (bits/char) at which a
+	// whitespace-delimited token is considered a potential secret and redacted.
+	// Defaults to 4.5.
+	EntropyThreshold float64 `json:"entropy_threshold"`
+	// EntropyMinLength is the minimum token length considered for entropy
+	// scanning. Defaults to 20.
+	EntropyMinLength int `json:"entropy_min_length"`
 }
 
 // PartioDir is the directory name for partio config within a repo.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -11,5 +11,10 @@ func Defaults() Config {
 		StrategyOptions: StrategyOptions{
 			PushSessions: true,
 		},
+		Redact: RedactOptions{
+			Enabled:          true,
+			EntropyThreshold: 4.5,
+			EntropyMinLength: 20,
+		},
 	}
 }

--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -16,6 +16,7 @@ import (
 	"github.com/partio-io/cli/internal/checkpoint"
 	"github.com/partio-io/cli/internal/config"
 	"github.com/partio-io/cli/internal/git"
+	"github.com/partio-io/cli/internal/redact"
 	"github.com/partio-io/cli/internal/session"
 )
 
@@ -179,6 +180,14 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 			sessionFiles.FullJSONL = string(rawJSONL)
 		}
 	}
+
+	// Redact secrets from session content before persisting to the metadata branch.
+	redactOpts := redact.Options{
+		Enabled:          cfg.Redact.Enabled,
+		EntropyThreshold: cfg.Redact.EntropyThreshold,
+		EntropyMinLength: cfg.Redact.EntropyMinLength,
+	}
+	redact.SessionFiles(sessionFiles, redactOpts)
 
 	// Write checkpoint to orphan branch
 	store := checkpoint.NewStore(repoRoot)

--- a/internal/redact/entropy.go
+++ b/internal/redact/entropy.go
@@ -1,0 +1,21 @@
+package redact
+
+import "math"
+
+// shannonEntropy calculates the Shannon entropy (bits per symbol) of s.
+func shannonEntropy(s string) float64 {
+	if len(s) == 0 {
+		return 0
+	}
+	freq := make(map[rune]float64)
+	for _, c := range s {
+		freq[c]++
+	}
+	n := float64(len([]rune(s)))
+	var h float64
+	for _, count := range freq {
+		p := count / n
+		h -= p * math.Log2(p)
+	}
+	return h
+}

--- a/internal/redact/patterns.go
+++ b/internal/redact/patterns.go
@@ -1,0 +1,76 @@
+package redact
+
+import "regexp"
+
+// secretPattern pairs a human-readable name with a compiled regex.
+// The regex must contain a named capture group "secret" for the value to redact,
+// or the entire match is replaced when no such group exists.
+type secretPattern struct {
+	name string
+	re   *regexp.Regexp
+}
+
+// patterns is the list of known secret formats, modelled after gitleaks rules.
+var patterns = []secretPattern{
+	{
+		name: "aws-access-key-id",
+		re:   regexp.MustCompile(`(?i)(AKIA|ASIA|AROA|AIDA|ANPA|ANVA|APKA)[A-Z0-9]{16}`),
+	},
+	{
+		name: "github-pat",
+		re:   regexp.MustCompile(`ghp_[A-Za-z0-9]{36}`),
+	},
+	{
+		name: "github-oauth",
+		re:   regexp.MustCompile(`gho_[A-Za-z0-9]{36}`),
+	},
+	{
+		name: "github-app-token",
+		re:   regexp.MustCompile(`(ghu_|ghs_|ghr_)[A-Za-z0-9]{36}`),
+	},
+	{
+		name: "github-fine-grained-pat",
+		re:   regexp.MustCompile(`github_pat_[A-Za-z0-9_]{82}`),
+	},
+	{
+		name: "generic-api-key",
+		// Matches key/token/secret/password assignments in common formats.
+		re: regexp.MustCompile(`(?i)(?:api[_-]?key|api[_-]?token|auth[_-]?token|access[_-]?token|secret[_-]?key|secret[_-]?token)\s*[:=]\s*['"]?([A-Za-z0-9\-_.+/]{20,})['"]?`),
+	},
+	{
+		name: "bearer-token",
+		re:   regexp.MustCompile(`(?i)bearer\s+([A-Za-z0-9\-_.+/]{20,})`),
+	},
+	{
+		name: "private-key-header",
+		re:   regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----`),
+	},
+	{
+		name: "slack-token",
+		re:   regexp.MustCompile(`xox[baprs]-[0-9A-Za-z\-]{10,}`),
+	},
+	{
+		name: "stripe-key",
+		re:   regexp.MustCompile(`(?:r|s)k_(?:live|test)_[0-9A-Za-z]{24}`),
+	},
+	{
+		name: "sendgrid-key",
+		re:   regexp.MustCompile(`SG\.[0-9A-Za-z\-_]{22}\.[0-9A-Za-z\-_]{43}`),
+	},
+	{
+		name: "twilio-key",
+		re:   regexp.MustCompile(`SK[0-9a-fA-F]{32}`),
+	},
+	{
+		name: "npm-token",
+		re:   regexp.MustCompile(`npm_[A-Za-z0-9]{36}`),
+	},
+	{
+		name: "pypi-token",
+		re:   regexp.MustCompile(`pypi-[A-Za-z0-9\-_]{50,}`),
+	},
+	{
+		name: "google-api-key",
+		re:   regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),
+	},
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,187 @@
+// Package redact provides two-layer secret detection and redaction:
+//  1. Pattern-based detection using gitleaks-compatible regexes for known secret formats.
+//  2. Entropy-based scanning to catch high-entropy strings that don't match known patterns.
+//
+// Call [Text] to redact a single string, or [SessionFiles] to redact all fields
+// of a checkpoint.SessionFiles value before it is written to the metadata branch.
+package redact
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/partio-io/cli/internal/checkpoint"
+)
+
+const (
+	// Redacted is the placeholder substituted for detected secrets.
+	Redacted = "[REDACTED]"
+
+	// DefaultEntropyThreshold is the minimum Shannon entropy (bits/char) at which
+	// a token is considered a potential secret. Strings at or above this threshold
+	// that also satisfy DefaultEntropyMinLength are redacted.
+	DefaultEntropyThreshold = 4.5
+
+	// DefaultEntropyMinLength is the minimum token length considered for entropy
+	// scanning. Short tokens produce unreliable entropy scores.
+	DefaultEntropyMinLength = 20
+)
+
+// Options controls the redaction behaviour.
+type Options struct {
+	// Enabled toggles redaction entirely. When false, Text returns its input unchanged.
+	Enabled bool
+
+	// EntropyThreshold is the Shannon entropy value (bits per character) above
+	// which a token is redacted. Defaults to DefaultEntropyThreshold.
+	EntropyThreshold float64
+
+	// EntropyMinLength is the minimum token length considered for entropy scanning.
+	// Defaults to DefaultEntropyMinLength.
+	EntropyMinLength int
+}
+
+// DefaultOptions returns Options with sensible defaults.
+func DefaultOptions() Options {
+	return Options{
+		Enabled:          true,
+		EntropyThreshold: DefaultEntropyThreshold,
+		EntropyMinLength: DefaultEntropyMinLength,
+	}
+}
+
+// Text applies pattern-based and entropy-based redaction to input and returns
+// the sanitised result. When opts.Enabled is false the input is returned as-is.
+func Text(input string, opts Options) string {
+	if !opts.Enabled || input == "" {
+		return input
+	}
+
+	// Layer 1 – pattern-based redaction.
+	result := applyPatterns(input)
+
+	// Layer 2 – entropy-based redaction.
+	result = applyEntropy(result, opts.EntropyThreshold, opts.EntropyMinLength)
+
+	return result
+}
+
+// SessionFiles redacts all user-visible text fields in sf in place and returns sf.
+// The ContentHash field is a git commit hash and is intentionally left untouched.
+func SessionFiles(sf *checkpoint.SessionFiles, opts Options) *checkpoint.SessionFiles {
+	if sf == nil || !opts.Enabled {
+		return sf
+	}
+	sf.Prompt = Text(sf.Prompt, opts)
+	sf.Context = Text(sf.Context, opts)
+	sf.Diff = Text(sf.Diff, opts)
+	sf.FullJSONL = Text(sf.FullJSONL, opts)
+	sf.Plan = Text(sf.Plan, opts)
+	return sf
+}
+
+// applyPatterns replaces all matches of known secret patterns with [REDACTED].
+func applyPatterns(s string) string {
+	for _, p := range patterns {
+		// If the pattern has a subgroup, replace only that subgroup; otherwise
+		// replace the full match. This preserves surrounding context (e.g. the
+		// "api_key=" prefix) while still hiding the value.
+		s = replaceSubgroups(p.re, s)
+	}
+	return s
+}
+
+// replaceSubgroups replaces all capturing subgroup matches (if any) within re
+// with [REDACTED]. When the regex has no subgroups the full match is replaced.
+func replaceSubgroups(re *regexp.Regexp, s string) string {
+	names := re.SubexpNames()
+	hasGroup := len(names) > 1 // index 0 is the whole match
+
+	return re.ReplaceAllStringFunc(s, func(match string) string {
+		if !hasGroup {
+			return Redacted
+		}
+		// Replace each subgroup match within the full match string.
+		submatches := re.FindStringSubmatchIndex(match)
+		if submatches == nil {
+			return Redacted
+		}
+		result := match
+		// Walk subgroups in reverse so offsets remain valid as we substitute.
+		for i := len(submatches)/2 - 1; i >= 1; i-- {
+			start, end := submatches[i*2], submatches[i*2+1]
+			if start < 0 {
+				continue
+			}
+			result = result[:start] + Redacted + result[end:]
+		}
+		return result
+	})
+}
+
+// tokenSplitter is a regexp that splits text into whitespace-delimited tokens.
+var tokenSplitter = regexp.MustCompile(`\S+`)
+
+// applyEntropy scans each whitespace-delimited token in s and replaces those
+// whose Shannon entropy exceeds threshold (and whose length meets minLen) with
+// [REDACTED], unless the token looks like a common non-secret (e.g. a URL, a
+// file path, or an already-redacted placeholder).
+func applyEntropy(s string, threshold float64, minLen int) string {
+	if threshold <= 0 {
+		return s
+	}
+	return tokenSplitter.ReplaceAllStringFunc(s, func(token string) string {
+		if len(token) < minLen {
+			return token
+		}
+		// Skip already-redacted placeholders.
+		if token == Redacted {
+			return token
+		}
+		// Skip URL-shaped tokens and common file paths – they're high-entropy
+		// but almost never secrets.
+		if looksLikeURL(token) || looksLikeFilePath(token) {
+			return token
+		}
+		// Only consider tokens that look like they could be keys: no spaces
+		// (already guaranteed by the splitter) and composed of base64/hex chars.
+		if !looksLikeEncodedString(token) {
+			return token
+		}
+		if shannonEntropy(token) >= threshold {
+			return Redacted
+		}
+		return token
+	})
+}
+
+func looksLikeURL(s string) bool {
+	return strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "ftp://") ||
+		strings.HasPrefix(s, "git@")
+}
+
+func looksLikeFilePath(s string) bool {
+	return strings.HasPrefix(s, "/") || strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../")
+}
+
+// looksLikeEncodedString returns true when s consists only of characters
+// commonly found in base64, hex, or JWT-style strings. This guards against
+// false-positives on natural-language tokens (which score low entropy anyway,
+// but filtering here avoids the entropy calculation entirely).
+func looksLikeEncodedString(s string) bool {
+	// Strip common wrapper punctuation (quotes, trailing comma/semicolon).
+	s = strings.Trim(s, `"';,`)
+	if len(s) == 0 {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) &&
+			r != '+' && r != '/' && r != '=' && r != '-' && r != '_' && r != '.' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,208 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/partio-io/cli/internal/checkpoint"
+)
+
+func TestText_Disabled(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Enabled = false
+	secret := "AKIAIOSFODNN7EXAMPLE"
+	if got := Text(secret, opts); got != secret {
+		t.Errorf("expected input unchanged when disabled, got %q", got)
+	}
+}
+
+func TestText_Empty(t *testing.T) {
+	opts := DefaultOptions()
+	if got := Text("", opts); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+// True-positive: known secret formats must be redacted.
+var truePositives = []struct {
+	name  string
+	input string
+}{
+	{"aws-access-key-id", "AKIAIOSFODNN7EXAMPLE"},
+	{"aws-asia-key", "ASIAIOSFODNN7EXAMPLE1"},
+	{"github-pat", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"},
+	{"github-oauth", "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"},
+	{"github-app-token-ghu", "ghu_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"},
+	{"github-app-token-ghs", "ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"},
+	{"github-fine-grained", "github_pat_" + strings.Repeat("A", 82)},
+	{"slack-token", "xoxb-1234567890-abcdefghijklmnop"},
+	{"stripe-live-key", "sk_live_abcdefghijklmnopqrstuvwx"},
+	{"stripe-test-key", "sk_test_abcdefghijklmnopqrstuvwx"},
+	{"google-api-key", "AIzaSyDabcdefghijklmnopqrstuvwxyz1234567"},
+	{"npm-token", "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"},
+	{"pypi-token", "pypi-" + strings.Repeat("A", 50)},
+	{"generic-api-key-assignment", "api_key=supersecretvaluehere1234567"},
+	{"bearer-token", "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9"},
+	{"private-key-header", "-----BEGIN RSA PRIVATE KEY-----"},
+}
+
+func TestText_TruePositives(t *testing.T) {
+	opts := DefaultOptions()
+	for _, tc := range truePositives {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Text(tc.input, opts)
+			if !strings.Contains(got, Redacted) {
+				t.Errorf("expected [REDACTED] in output for %q\ngot: %q", tc.input, got)
+			}
+		})
+	}
+}
+
+// False-positives: these should NOT be redacted.
+var falsePositives = []struct {
+	name  string
+	input string
+}{
+	{"plain-english", "The quick brown fox jumps over the lazy dog"},
+	{"short-word", "hello"},
+	{"commit-hash", "a3f1b2c4d5e6"},         // short, low-entropy
+	{"version-string", "v1.2.3-alpha"},       // short
+	{"url", "https://example.com/api/v1"},    // URL
+	{"local-path", "/usr/local/bin/partio"},  // file path
+	{"relative-path", "./internal/redact/"},  // relative path
+	{"go-import", "github.com/partio-io/cli"}, // looks like a path
+	{"markdown-header", "# Secret Detection"},
+	// [REDACTED] is intentionally excluded from this table because it always
+	// contains the placeholder — see TestText_AlreadyRedactedUnchanged.
+	{"log-line", "2024-01-01T00:00:00Z INFO checkpoint created id=abc123"},
+}
+
+func TestText_FalsePositives(t *testing.T) {
+	opts := DefaultOptions()
+	for _, tc := range falsePositives {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Text(tc.input, opts)
+			if strings.Contains(got, Redacted) {
+				t.Errorf("unexpected [REDACTED] for false-positive %q\ngot: %q", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestText_AlreadyRedactedUnchanged ensures the placeholder is not double-redacted.
+func TestText_AlreadyRedactedUnchanged(t *testing.T) {
+	opts := DefaultOptions()
+	input := "[REDACTED]"
+	got := Text(input, opts)
+	if got != input {
+		t.Errorf("expected [REDACTED] to pass through unchanged, got %q", got)
+	}
+}
+
+func TestText_PatternInContext(t *testing.T) {
+	opts := DefaultOptions()
+	input := `config file:
+api_key=supersecretvaluehere1234567
+other_setting=normal_value`
+	got := Text(input, opts)
+	if !strings.Contains(got, Redacted) {
+		t.Errorf("expected [REDACTED] in output\ngot: %q", got)
+	}
+	if !strings.Contains(got, "other_setting=normal_value") {
+		t.Errorf("expected non-secret lines preserved\ngot: %q", got)
+	}
+}
+
+func TestEntropyRedaction(t *testing.T) {
+	opts := DefaultOptions()
+	// A high-entropy base64-like string that doesn't match any known pattern.
+	highEntropy := "xK9mP2qR7sT4uV1wY6zA3bC8dE5fG0hI"
+	got := Text(highEntropy, opts)
+	if !strings.Contains(got, Redacted) {
+		t.Errorf("expected high-entropy string to be redacted\ngot: %q", got)
+	}
+}
+
+func TestEntropyThreshold(t *testing.T) {
+	opts := DefaultOptions()
+	opts.EntropyThreshold = 10.0 // impossibly high — nothing should be flagged
+	// A high-entropy base64-like string.
+	highEntropy := "xK9mP2qR7sT4uV1wY6zA3bC8dE5fG0hI"
+	got := Text(highEntropy, opts)
+	if strings.Contains(got, Redacted) {
+		t.Errorf("expected no redaction with very high threshold, got %q", got)
+	}
+}
+
+func TestSessionFiles_Redaction(t *testing.T) {
+	opts := DefaultOptions()
+	sf := &checkpoint.SessionFiles{
+		ContentHash: "deadbeefdeadbeef", // must NOT be redacted
+		Prompt:      "my api_key=supersecretvaluehere1234567 please help",
+		Context:     "user context",
+		Diff:        "diff content with AKIAIOSFODNN7EXAMPLE inside",
+		FullJSONL:   `{"role":"user","content":"token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"}`,
+		Plan:        "normal plan text",
+	}
+
+	result := SessionFiles(sf, opts)
+
+	if strings.Contains(result.Prompt, "supersecretvaluehere1234567") {
+		t.Errorf("prompt secret not redacted: %q", result.Prompt)
+	}
+	if strings.Contains(result.Diff, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("diff secret not redacted: %q", result.Diff)
+	}
+	if strings.Contains(result.FullJSONL, "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij") {
+		t.Errorf("full_jsonl secret not redacted: %q", result.FullJSONL)
+	}
+	// Content hash must be preserved.
+	if result.ContentHash != "deadbeefdeadbeef" {
+		t.Errorf("content hash must not be redacted, got %q", result.ContentHash)
+	}
+	// Normal plan text must be preserved.
+	if result.Plan != "normal plan text" {
+		t.Errorf("plan was unexpectedly modified: %q", result.Plan)
+	}
+}
+
+func TestSessionFiles_Nil(t *testing.T) {
+	opts := DefaultOptions()
+	if got := SessionFiles(nil, opts); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestSessionFiles_Disabled(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Enabled = false
+	sf := &checkpoint.SessionFiles{Prompt: "AKIAIOSFODNN7EXAMPLE"}
+	result := SessionFiles(sf, opts)
+	if result.Prompt != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("expected prompt unchanged when disabled, got %q", result.Prompt)
+	}
+}
+
+func TestShannonEntropy(t *testing.T) {
+	tests := []struct {
+		s    string
+		want float64 // approximate
+		desc string
+	}{
+		{"", 0, "empty string"},
+		{"aaaa", 0, "all same chars"},
+		{"ab", 1, "two distinct chars equally split"},
+	}
+	for _, tc := range tests {
+		got := shannonEntropy(tc.s)
+		if got != tc.want {
+			t.Errorf("shannonEntropy(%q) = %f, want %f (%s)", tc.s, got, tc.want, tc.desc)
+		}
+	}
+
+	// High-entropy string should score above 4.0.
+	h := shannonEntropy("xK9mP2qR7sT4uV1wY6zA3bC8dE5fG0hI")
+	if h < 4.0 {
+		t.Errorf("expected high entropy for random-looking string, got %f", h)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/redact` package with two-layer secret detection that runs before any data is written to the checkpoint metadata branch
- **Layer 1 (pattern-based):** gitleaks-compatible regexes covering AWS access keys, GitHub tokens (PAT/OAuth/App/fine-grained), Slack, Stripe, Google API, npm, PyPI, SendGrid, Twilio, generic `api_key=` assignments, and `Bearer` tokens
- **Layer 2 (entropy-based):** Shannon entropy scanning flags whitespace-delimited tokens ≥ 20 chars with entropy ≥ 4.5 bits/char; URLs, file paths, and already-redacted placeholders are excluded to minimise false positives
- Integrate redaction in the post-commit hook via `redact.SessionFiles()` before `checkpoint.Store.Write()`, covering prompt, context, diff, full JSONL transcript, and plan
- Expose `redact` settings in `Config` (`enabled`, `entropy_threshold`, `entropy_min_length`) with sensible defaults
- Document behaviour in README under a new Security & Privacy section

## Test plan

- [x] 16 true-positive test cases (AWS, GitHub, Slack, Stripe, Google, npm, PyPI, generic key assignments, Bearer tokens, PEM headers)
- [x] 10 false-positive test cases (plain English, short words, commit hashes, version strings, URLs, file paths, log lines)
- [x] Entropy boundary test — configuring a very high threshold suppresses entropy-based redaction
- [x] `SessionFiles` wrapper — verifies all text fields are redacted, `ContentHash` is untouched
- [x] Disabled mode — verifies no redaction occurs when `redact.enabled = false`
- [x] `make test` passes (all packages)
- [x] `golangci-lint` reports 0 new issues on changed packages

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #26