### PR TITLE
ci(doc-minion): auto-trigger docs on merged PRs via minions --pr

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -1,6 +1,7 @@
 name: Documentation Minion
 
 on:
+  # Manual / backfill: document a specific PR on demand.
   workflow_dispatch:
     inputs:
       pr_ref:
@@ -12,6 +13,14 @@ on:
         required: false
         default: false
         type: boolean
+  # Automatic: a merged PR that touched user-facing source.
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "README.md"
 
 permissions:
   contents: write
@@ -19,24 +28,40 @@ permissions:
 
 jobs:
   update-docs:
+    # Run on manual dispatch, or on a PR that actually merged (closed != merged).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
     runs-on: github-runner-partio-minion-ai-01
     timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
 
-
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.6
+          go install github.com/partio-io/minions/cmd/minions@v0.0.7
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Resolve source PR reference
+        id: src
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "pr_ref=${{ inputs.pr_ref }}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_ref=${{ github.repository }}#${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run doc-update program
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          PR_REF: ${{ steps.src.outputs.pr_ref }}
+          DRY_RUN: ${{ steps.src.outputs.dry_run }}
         run: |
-          ARGS="run .minions/programs/doc-update.md"
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS="${ARGS} --dry-run"
+          if [ "$DRY_RUN" = "true" ]; then
+            minions run .minions/programs/doc-update.md --pr "$PR_REF" --dry-run
+          else
+            minions run .minions/programs/doc-update.md --pr "$PR_REF"
           fi
-          minions $ARGS

--- a/.minions/programs/doc-update.md
+++ b/.minions/programs/doc-update.md
@@ -13,32 +13,34 @@ pr_labels:
 
 # Update documentation for a merged PR
 
-When a code PR merges on the cli repo, update the documentation to reflect the changes.
+A pull request merged on the cli repo. Update the documentation in the `docs`
+repo to reflect any user-facing changes it introduced.
+
+The source PR — its reference (`org/repo#number`), title, body, and full diff —
+is provided in the **## Pull Request** section of this prompt. Everything you
+need is already there; you do not need to fetch it.
 
 ## Steps
 
-1. **Identify the source PR.** The PR reference is passed as context. Read the PR title, body, and diff:
-   ```bash
-   gh pr view <number> --repo <repo> --json title,body,files
-   gh pr diff <number> --repo <repo>
-   ```
+1. **Understand what changed.** From the PR diff, determine what *user-facing*
+   behavior changed — new commands, changed flags, new config options, changed
+   output. Ignore internal-only changes (refactors, tests, CI).
 
-2. **Understand what changed.** Analyze the diff to determine what user-facing behavior changed — new commands, changed flags, new config options, etc.
+2. **If nothing user-facing changed, stop and make no edits.** A docs PR is only
+   opened when you change files, so finishing with no edits is the correct
+   "no update needed" outcome.
 
-3. **Read existing docs.** Check `docs/` for relevant pages that need updating. Look at the CLAUDE.md in the docs repo for structure guidance.
+3. **Read the existing docs.** Your working directory is the `docs` repo root.
+   Read its `CLAUDE.md` for structure guidance and find the pages affected.
 
-4. **Update the docs.** Edit the relevant MDX files to reflect the changes. Keep the existing style and structure.
+4. **Update the docs.** Edit the relevant MDX files to reflect the change. Match
+   the existing style and structure. Keep edits scoped to this PR.
 
-5. **Verify.** Ensure MDX frontmatter is valid and no broken references.
+5. **Verify.** Ensure MDX frontmatter is valid and there are no broken links or
+   references.
 
-6. **Create a PR** on the docs repo:
-   ```bash
-   git checkout -b minion/doc-update-<source-pr-number>
-   git add -A
-   git commit -m "docs: update for <repo>#<number>"
-   git push -u origin minion/doc-update-<source-pr-number>
-   gh pr create --repo <docs-repo> --title "[docs] Update for <repo>#<number>" --label minion --label documentation
-   ```
+Do **not** run `git`/`gh` or create a branch or PR yourself. The runtime commits
+your edits and opens the docs PR (labels `minion`, `documentation`) for you.
 
 ## Context
 


### PR DESCRIPTION
## What

Revives the dormant **Documentation Minion** so a merged cli PR automatically produces a docs PR on `partio-io/docs`. Two independent breakages, both fixed here:

1. **It never triggered.** `doc-minion.yml` was `workflow_dispatch`-only — nothing fired it on merge (0 runs, ever). → Adds a `pull_request: [closed]` trigger gated on `merged == true` and user-facing paths.
2. **It never passed the PR through.** The run step dropped the `pr_ref` input, so `minions run` received no context. → Resolves the source ref from either event and passes it via the new `minions --pr` flag.

It also rewrites `doc-update.md` to match how the runtime actually behaves: the PR (ref, title, body, full diff) is injected into the agent, and the **runtime** commits the edits and opens the docs PR — so the old manual `gh pr create` step (a leftover that would double-create) is removed.

## Depends on — merge order matters ⚠️

**partio-io/minions#135** adds the `--pr` flag. This PR bumps the install pin to `@v0.0.7`, so:

1. Merge minions#135.
2. Tag `v0.0.7` on minions `main`.
3. Merge this PR.

Until `v0.0.7` is tagged, the `go install ...@v0.0.7` step will fail — hold this PR until step 2 is done.

## Trigger scope

Fires only on PRs to `main` that **merged** and touched `cmd/**`, `internal/**`, or `README.md`. A test-only merge under those paths will start a run that finds no user-facing change and exits without a PR (cheap no-op). `workflow_dispatch` is retained for manual/backfill runs.

## Verification

- Workflow YAML parses; the `if` gate and `pull_request` filter are correct.
- The full runner path can't be exercised until `v0.0.7` is tagged. Once it is, smoke-test with a manual dispatch — dry run first (proves install + PR fetch), then a real run (opens a docs PR):
  ```
  gh workflow run doc-minion.yml --repo partio-io/cli -f pr_ref=partio-io/cli#488 -f dry_run=true
  gh workflow run doc-minion.yml --repo partio-io/cli -f pr_ref=partio-io/cli#488 -f dry_run=false
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
