### PR TITLE
feat(session): automatic cleanup of stale session files

### DIFF
--- a/cmd/partio/cleanup_sessions.go
+++ b/cmd/partio/cleanup_sessions.go
@@ -37,7 +37,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	partioDir := filepath.Join(repoRoot, config.PartioDir)
 	mgr := session.NewManager(partioDir)
 
-	result, err := mgr.CleanupStale(cfg.StaleSessionThreshold)
+	result, err := mgr.CleanupStale(cfg.StaleSessionThreshold.Duration())
 	if err != nil {
 		return fmt.Errorf("cleanup failed: %w", err)
 	}

--- a/cmd/partio/cleanup_sessions.go
+++ b/cmd/partio/cleanup_sessions.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/partio-io/cli/internal/config"
+	"github.com/partio-io/cli/internal/git"
+	"github.com/partio-io/cli/internal/session"
+)
+
+func newCleanupCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cleanup",
+		Short: "Clean up stale session files",
+		Long: `Scan for session files left behind by crashed or improperly terminated agent
+processes and transition them to ENDED state.
+
+A session is considered stale when it is in ACTIVE or IDLE state, its state
+file has not been updated within the configured threshold (default: 10 minutes),
+and — when a process ID is recorded — the agent process is no longer alive.
+
+The threshold is configurable via .partio/settings.json ("stale_session_threshold")
+or the PARTIO_STALE_SESSION_THRESHOLD environment variable (e.g. "10m", "30m").`,
+		RunE: runCleanup,
+	}
+}
+
+func runCleanup(cmd *cobra.Command, args []string) error {
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("must be run inside a git repository")
+	}
+
+	partioDir := filepath.Join(repoRoot, config.PartioDir)
+	mgr := session.NewManager(partioDir)
+
+	result, err := mgr.CleanupStale(cfg.StaleSessionThreshold)
+	if err != nil {
+		return fmt.Errorf("cleanup failed: %w", err)
+	}
+
+	if result.Cleaned {
+		fmt.Printf("Cleaned up stale session: %s (agent=%s)\n", result.Session.ID, result.Session.Agent)
+	} else {
+		fmt.Println("No stale sessions found.")
+	}
+
+	return nil
+}

--- a/cmd/partio/main.go
+++ b/cmd/partio/main.go
@@ -67,6 +67,7 @@ func newRootCmd() *cobra.Command {
 		newRewindCmd(),
 		newResumeCmd(),
 		newPruneCmd(),
+		newCleanupCmd(),
 	)
 
 	return root

--- a/cmd/partio/status.go
+++ b/cmd/partio/status.go
@@ -46,7 +46,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	// Clean up stale sessions before reporting status.
 	mgr := session.NewManager(partioDir)
-	if result, err := mgr.CleanupStale(cfg.StaleSessionThreshold); err != nil {
+	if result, err := mgr.CleanupStale(cfg.StaleSessionThreshold.Duration()); err != nil {
 		slog.Debug("stale session cleanup failed", "error", err)
 	} else if result.Cleaned {
 		slog.Info("stale session cleaned up", "id", result.Session.ID)

--- a/cmd/partio/status.go
+++ b/cmd/partio/status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/partio-io/cli/internal/config"
 	"github.com/partio-io/cli/internal/git"
+	"github.com/partio-io/cli/internal/session"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -40,6 +42,14 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if !enabled {
 		fmt.Println("Status:     not enabled (run 'partio enable' to set up)")
 		return nil
+	}
+
+	// Clean up stale sessions before reporting status.
+	mgr := session.NewManager(partioDir)
+	if result, err := mgr.CleanupStale(cfg.StaleSessionThreshold); err != nil {
+		slog.Debug("stale session cleanup failed", "error", err)
+	} else if result.Cleaned {
+		slog.Info("stale session cleaned up", "id", result.Session.ID)
 	}
 
 	fmt.Println("Status:     enabled")

--- a/internal/agent/claude/process.go
+++ b/internal/agent/claude/process.go
@@ -3,6 +3,8 @@ package claude
 import (
 	"os/exec"
 	"strings"
+
+	"github.com/partio-io/cli/internal/agent"
 )
 
 // IsRunning checks if a Claude Code process is currently running.
@@ -16,4 +18,10 @@ func (d *Detector) IsRunning() (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(string(out)) != "", nil
+}
+
+// AgentPID returns the PID of a running Claude Code process, or (0, false) when
+// none is found.
+func (d *Detector) AgentPID() (int, bool) {
+	return agent.PgrepFirst("claude")
 }

--- a/internal/agent/codex/parse_jsonl.go
+++ b/internal/agent/codex/parse_jsonl.go
@@ -43,7 +43,7 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening codex session: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	data := &agent.SessionData{
 		Agent: "codex",
@@ -144,7 +144,7 @@ func PeekSessionID(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	if scanner.Scan() {
@@ -165,7 +165,7 @@ func PeekCWD(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	if scanner.Scan() {

--- a/internal/agent/codex/process.go
+++ b/internal/agent/codex/process.go
@@ -3,6 +3,8 @@ package codex
 import (
 	"os/exec"
 	"strings"
+
+	"github.com/partio-io/cli/internal/agent"
 )
 
 // IsRunning checks if a Codex CLI process is currently running.
@@ -16,4 +18,10 @@ func (d *Detector) IsRunning() (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(string(out)) != "", nil
+}
+
+// AgentPID returns the PID of a running Codex CLI process, or (0, false) when
+// none is found.
+func (d *Detector) AgentPID() (int, bool) {
+	return agent.PgrepFirst("codex")
 }

--- a/internal/agent/detector.go
+++ b/internal/agent/detector.go
@@ -19,3 +19,10 @@ type SessionParser interface {
 	// and the parsed session data for the given repo.
 	FindLatestSession(repoRoot string) (path string, data *SessionData, err error)
 }
+
+// PIDProvider is implemented by detectors that can report the OS process ID of
+// the running agent. The value is recorded on the session and used to verify
+// process liveness during stale-session cleanup.
+type PIDProvider interface {
+	AgentPID() (int, bool)
+}

--- a/internal/agent/pgrep.go
+++ b/internal/agent/pgrep.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// PgrepFirst runs `pgrep -f pattern` and returns the first matching PID and
+// whether any process matched. Any error (including "no process found") yields
+// (0, false).
+func PgrepFirst(pattern string) (int, bool) {
+	out, err := exec.Command("pgrep", "-f", pattern).Output()
+	if err != nil {
+		return 0, false
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
+}

--- a/internal/agent/pgrep_test.go
+++ b/internal/agent/pgrep_test.go
@@ -1,0 +1,10 @@
+package agent
+
+import "testing"
+
+func TestPgrepFirst_NoMatch(t *testing.T) {
+	// A pattern that no real process should match must yield (0, false).
+	if pid, ok := PgrepFirst("zzzz-partio-no-such-process-zzzz"); ok || pid != 0 {
+		t.Errorf("PgrepFirst(no match) = (%d, %v), want (0, false)", pid, ok)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,17 +1,46 @@
 package config
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
+
+// Duration is a time.Duration that marshals to and from a human-readable string
+// (e.g. "10m") in JSON, rather than an integer number of nanoseconds.
+type Duration time.Duration
+
+// MarshalJSON encodes the duration as a string such as "10m0s".
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON parses a duration string such as "10m".
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = Duration(v)
+	return nil
+}
+
+// Duration returns the value as a time.Duration.
+func (d Duration) Duration() time.Duration { return time.Duration(d) }
 
 // Config holds all partio configuration.
 type Config struct {
-	Enabled                bool            `json:"enabled"`
-	Strategy               string          `json:"strategy"`
-	Agent                  string          `json:"agent"`
-	LogLevel               string          `json:"log_level"`
-	CommitLinking          string          `json:"commit_linking"`
-	StrategyOptions        StrategyOptions `json:"strategy_options"`
-	Redact                 RedactOptions   `json:"redact"`
-	StaleSessionThreshold  time.Duration   `json:"stale_session_threshold"`
+	Enabled               bool            `json:"enabled"`
+	Strategy              string          `json:"strategy"`
+	Agent                 string          `json:"agent"`
+	LogLevel              string          `json:"log_level"`
+	CommitLinking         string          `json:"commit_linking"`
+	StrategyOptions       StrategyOptions `json:"strategy_options"`
+	Redact                RedactOptions   `json:"redact"`
+	StaleSessionThreshold Duration        `json:"stale_session_threshold"`
 }
 
 // CommitLinking values.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,14 +1,17 @@
 package config
 
+import "time"
+
 // Config holds all partio configuration.
 type Config struct {
-	Enabled         bool            `json:"enabled"`
-	Strategy        string          `json:"strategy"`
-	Agent           string          `json:"agent"`
-	LogLevel        string          `json:"log_level"`
-	CommitLinking   string          `json:"commit_linking"`
-	StrategyOptions StrategyOptions `json:"strategy_options"`
-	Redact          RedactOptions   `json:"redact"`
+	Enabled                bool            `json:"enabled"`
+	Strategy               string          `json:"strategy"`
+	Agent                  string          `json:"agent"`
+	LogLevel               string          `json:"log_level"`
+	CommitLinking          string          `json:"commit_linking"`
+	StrategyOptions        StrategyOptions `json:"strategy_options"`
+	Redact                 RedactOptions   `json:"redact"`
+	StaleSessionThreshold  time.Duration   `json:"stale_session_threshold"`
 }
 
 // CommitLinking values.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -18,6 +18,6 @@ func Defaults() Config {
 			EntropyThreshold: 4.5,
 			EntropyMinLength: 20,
 		},
-		StaleSessionThreshold: 10 * time.Minute,
+		StaleSessionThreshold: Duration(10 * time.Minute),
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Defaults returns a Config with default values.
 func Defaults() Config {
 	return Config{
@@ -16,5 +18,6 @@ func Defaults() Config {
 			EntropyThreshold: 4.5,
 			EntropyMinLength: 20,
 		},
+		StaleSessionThreshold: 10 * time.Minute,
 	}
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -24,7 +24,7 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("PARTIO_STALE_SESSION_THRESHOLD"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
-			cfg.StaleSessionThreshold = d
+			cfg.StaleSessionThreshold = Duration(d)
 		}
 	}
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"strings"
+	"time"
 )
 
 func applyEnv(cfg *Config) {
@@ -20,5 +21,10 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("PARTIO_COMMIT_LINKING"); v != "" {
 		cfg.CommitLinking = v
+	}
+	if v := os.Getenv("PARTIO_STALE_SESSION_THRESHOLD"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.StaleSessionThreshold = d
+		}
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // Load reads config from all layers and merges them (lowest to highest priority):
@@ -62,5 +63,13 @@ func mergeFromFile(dst *Config, path string) {
 	}
 	if v, ok := raw["strategy_options"]; ok {
 		_ = json.Unmarshal(v, &dst.StrategyOptions)
+	}
+	if v, ok := raw["stale_session_threshold"]; ok {
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil {
+			if d, err := time.ParseDuration(s); err == nil {
+				dst.StaleSessionThreshold = d
+			}
+		}
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 // Load reads config from all layers and merges them (lowest to highest priority):
@@ -65,11 +64,6 @@ func mergeFromFile(dst *Config, path string) {
 		_ = json.Unmarshal(v, &dst.StrategyOptions)
 	}
 	if v, ok := raw["stale_session_threshold"]; ok {
-		var s string
-		if err := json.Unmarshal(v, &s); err == nil {
-			if d, err := time.ParseDuration(s); err == nil {
-				dst.StaleSessionThreshold = d
-			}
-		}
+		_ = json.Unmarshal(v, &dst.StaleSessionThreshold)
 	}
 }

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -102,6 +102,21 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 		agentActive = false
 	}
 
+	// Record an ACTIVE session with the agent's PID so a crashed or abandoned
+	// agent leaves a session that stale-cleanup can later detect and end.
+	if agentActive {
+		pid := 0
+		if pp, ok := detector.(agent.PIDProvider); ok {
+			if p, found := pp.AgentPID(); found {
+				pid = p
+			}
+		}
+		mgr := session.NewManager(filepath.Join(repoRoot, config.PartioDir))
+		if recErr := mgr.RecordActive(detector.Name(), branch, repoRoot, pid); recErr != nil {
+			slog.Debug("could not record active session", "error", recErr)
+		}
+	}
+
 	state := preCommitState{
 		AgentActive:   agentActive,
 		AgentName:     detector.Name(),

--- a/internal/session/cleanup.go
+++ b/internal/session/cleanup.go
@@ -1,0 +1,87 @@
+package session
+
+import (
+	"log/slog"
+	"os"
+	"syscall"
+	"time"
+)
+
+// CleanupResult holds the outcome of a stale-session cleanup run.
+type CleanupResult struct {
+	// Cleaned is true when a stale session was found and transitioned to ENDED.
+	Cleaned bool
+	// Session is the session that was cleaned up, or nil if none.
+	Session *Session
+}
+
+// CleanupStale checks the current session and, if it is stale, transitions it
+// to ENDED state. A session is considered stale when:
+//   - Its state is ACTIVE or IDLE, and
+//   - The session state file has not been updated within threshold, and
+//   - If AgentPID is non-zero, the associated process is no longer alive.
+//
+// Returns a CleanupResult describing what happened.
+func (m *Manager) CleanupStale(threshold time.Duration) (CleanupResult, error) {
+	s, err := m.Current()
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	if s == nil {
+		return CleanupResult{}, nil
+	}
+
+	// Only clean ACTIVE or IDLE sessions — ENDED sessions are already done.
+	if s.State != StateActive && s.State != StateIdle {
+		return CleanupResult{}, nil
+	}
+
+	if !isStale(m.currentPath(), s, threshold) {
+		return CleanupResult{}, nil
+	}
+
+	slog.Info("cleaning up stale session",
+		"id", s.ID,
+		"agent", s.Agent,
+		"state", s.State,
+		"pid", s.AgentPID,
+	)
+
+	s.State = StateEnded
+	s.EndedAt = time.Now()
+	if err := m.save(s); err != nil {
+		return CleanupResult{}, err
+	}
+
+	return CleanupResult{Cleaned: true, Session: s}, nil
+}
+
+// isStale returns true when the session file is old enough AND (if PID is known)
+// the agent process is no longer alive.
+func isStale(path string, s *Session, threshold time.Duration) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	age := time.Since(info.ModTime())
+	if age < threshold {
+		// File was updated recently — session is not stale yet.
+		return false
+	}
+
+	// File is old enough. If we have a PID, require the process to be gone too.
+	if s.AgentPID > 0 {
+		return !isProcessAlive(s.AgentPID)
+	}
+
+	// No PID recorded — rely on timestamp alone.
+	return true
+}
+
+// isProcessAlive returns true if the process with the given PID is still alive.
+// Uses signal 0, which checks process existence without sending an actual signal.
+func isProcessAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil
+}

--- a/internal/session/cleanup_test.go
+++ b/internal/session/cleanup_test.go
@@ -1,0 +1,209 @@
+package session
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestCleanupStale_NoSession(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	result, err := mgr.CleanupStale(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Cleaned {
+		t.Error("expected no cleanup when there is no session")
+	}
+}
+
+func TestCleanupStale_EndedSession(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	_, err := mgr.Start("claude-code", "main", "/tmp/test")
+	if err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	if err := mgr.End(); err != nil {
+		t.Fatalf("end error: %v", err)
+	}
+
+	// Backdate the file so it looks old.
+	past := time.Now().Add(-20 * time.Minute)
+	if err := os.Chtimes(mgr.currentPath(), past, past); err != nil {
+		t.Fatalf("chtimes error: %v", err)
+	}
+
+	result, err := mgr.CleanupStale(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Cleaned {
+		t.Error("should not clean up an already-ended session")
+	}
+}
+
+func TestCleanupStale_RecentActiveSession(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	_, err := mgr.Start("claude-code", "main", "/tmp/test")
+	if err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+
+	// File is fresh — should not be cleaned up.
+	result, err := mgr.CleanupStale(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Cleaned {
+		t.Error("should not clean up a recently updated session")
+	}
+
+	cur, _ := mgr.Current()
+	if cur.State != StateActive {
+		t.Errorf("expected state=active, got %s", cur.State)
+	}
+}
+
+func TestCleanupStale_OldActiveSession_NoPID(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	_, err := mgr.Start("claude-code", "main", "/tmp/test")
+	if err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+
+	// Backdate the state file so it appears stale.
+	past := time.Now().Add(-20 * time.Minute)
+	if err := os.Chtimes(mgr.currentPath(), past, past); err != nil {
+		t.Fatalf("chtimes error: %v", err)
+	}
+
+	result, err := mgr.CleanupStale(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Cleaned {
+		t.Error("expected stale session to be cleaned up")
+	}
+	if result.Session == nil {
+		t.Fatal("expected session to be set in result")
+	}
+
+	cur, _ := mgr.Current()
+	if cur.State != StateEnded {
+		t.Errorf("expected state=ended after cleanup, got %s", cur.State)
+	}
+	if cur.EndedAt.IsZero() {
+		t.Error("expected ended_at to be set")
+	}
+}
+
+func TestCleanupStale_OldIdleSession_NoPID(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	s, err := mgr.Start("claude-code", "main", "/tmp/test")
+	if err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	s.State = StateIdle
+	if err := mgr.save(s); err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	past := time.Now().Add(-20 * time.Minute)
+	if err := os.Chtimes(mgr.currentPath(), past, past); err != nil {
+		t.Fatalf("chtimes error: %v", err)
+	}
+
+	result, err := mgr.CleanupStale(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Cleaned {
+		t.Error("expected stale idle session to be cleaned up")
+	}
+
+	cur, _ := mgr.Current()
+	if cur.State != StateEnded {
+		t.Errorf("expected state=ended after cleanup, got %s", cur.State)
+	}
+}
+
+func TestCleanupStale_OldActiveSession_AlivePID(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	// Use current process PID — we know it's alive.
+	pid := os.Getpid()
+	s, err := mgr.Start("claude-code", "main", "/tmp/test")
+	if err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	s.AgentPID = pid
+	if err := mgr.save(s); err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	past := time.Now().Add(-20 * time.Minute)
+	if err := os.Chtimes(mgr.currentPath(), past, past); err != nil {
+		t.Fatalf("chtimes error: %v", err)
+	}
+
+	result, err := mgr.CleanupStale(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Cleaned {
+		t.Error("should not clean up a session whose process is still alive")
+	}
+
+	cur, _ := mgr.Current()
+	if cur.State != StateActive {
+		t.Errorf("expected state=active (process still alive), got %s", cur.State)
+	}
+}
+
+func TestCleanupStale_OldActiveSession_DeadPID(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	// PID 1 is init — always alive; use a clearly dead PID instead.
+	// On Linux, PIDs > /proc/sys/kernel/pid_max don't exist.
+	// Use a very high number unlikely to be running.
+	const deadPID = 999999999
+
+	s, err := mgr.Start("claude-code", "main", "/tmp/test")
+	if err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	s.AgentPID = deadPID
+	if err := mgr.save(s); err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	past := time.Now().Add(-20 * time.Minute)
+	if err := os.Chtimes(mgr.currentPath(), past, past); err != nil {
+		t.Fatalf("chtimes error: %v", err)
+	}
+
+	result, err := mgr.CleanupStale(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Cleaned {
+		t.Error("expected session with dead PID to be cleaned up")
+	}
+
+	cur, _ := mgr.Current()
+	if cur.State != StateEnded {
+		t.Errorf("expected state=ended, got %s", cur.State)
+	}
+}

--- a/internal/session/record.go
+++ b/internal/session/record.go
@@ -1,0 +1,28 @@
+package session
+
+import (
+	"fmt"
+	"os"
+)
+
+// RecordActive persists the current agent session in ACTIVE state, refreshing
+// the state file (and therefore its modification time) and recording the agent
+// PID for later liveness checks. A non-ended session is refreshed in place
+// (keeping its ID and start time); otherwise a new session is created.
+func (m *Manager) RecordActive(agentName, branch, sourceDir string, pid int) error {
+	if err := os.MkdirAll(m.stateDir, 0o755); err != nil {
+		return fmt.Errorf("creating session directory: %w", err)
+	}
+
+	s, err := m.Current()
+	if err != nil || s == nil || s.State == StateEnded {
+		s = New(agentName, branch, sourceDir)
+	} else {
+		s.Agent = agentName
+		s.Branch = branch
+		s.SourceDir = sourceDir
+		s.State = StateActive
+	}
+	s.AgentPID = pid
+	return m.save(s)
+}

--- a/internal/session/record_test.go
+++ b/internal/session/record_test.go
@@ -1,0 +1,74 @@
+package session
+
+import "testing"
+
+func TestRecordActive_CreatesActiveSessionWithPID(t *testing.T) {
+	mgr := NewManager(t.TempDir())
+
+	if err := mgr.RecordActive("claude-code", "main", "/tmp/repo", 4242); err != nil {
+		t.Fatalf("RecordActive: %v", err)
+	}
+
+	s, err := mgr.Current()
+	if err != nil || s == nil {
+		t.Fatalf("Current: %v (s=%v)", err, s)
+	}
+	if s.State != StateActive {
+		t.Errorf("state = %s, want active", s.State)
+	}
+	if s.AgentPID != 4242 {
+		t.Errorf("AgentPID = %d, want 4242", s.AgentPID)
+	}
+	if s.Agent != "claude-code" {
+		t.Errorf("Agent = %q, want claude-code", s.Agent)
+	}
+}
+
+func TestRecordActive_RefreshesExistingSession(t *testing.T) {
+	mgr := NewManager(t.TempDir())
+
+	if err := mgr.RecordActive("claude-code", "main", "/tmp/repo", 1); err != nil {
+		t.Fatalf("first RecordActive: %v", err)
+	}
+	first, _ := mgr.Current()
+
+	if err := mgr.RecordActive("claude-code", "main", "/tmp/repo", 2); err != nil {
+		t.Fatalf("second RecordActive: %v", err)
+	}
+	second, _ := mgr.Current()
+
+	if second.ID != first.ID {
+		t.Errorf("session ID changed on refresh: %s -> %s", first.ID, second.ID)
+	}
+	if second.AgentPID != 2 {
+		t.Errorf("AgentPID = %d, want 2 (refreshed)", second.AgentPID)
+	}
+	if second.State != StateActive {
+		t.Errorf("state = %s, want active", second.State)
+	}
+}
+
+func TestRecordActive_ReplacesEndedSession(t *testing.T) {
+	mgr := NewManager(t.TempDir())
+
+	// A previously ended/condensed session must not be refreshed — new agent
+	// activity should start a fresh ACTIVE session.
+	if err := mgr.MarkCondensed("sess-1"); err != nil {
+		t.Fatalf("MarkCondensed: %v", err)
+	}
+
+	if err := mgr.RecordActive("claude-code", "main", "/tmp/repo", 7); err != nil {
+		t.Fatalf("RecordActive: %v", err)
+	}
+
+	s, _ := mgr.Current()
+	if s.State != StateActive {
+		t.Errorf("state = %s, want active", s.State)
+	}
+	if s.AgentPID != 7 {
+		t.Errorf("AgentPID = %d, want 7", s.AgentPID)
+	}
+	if s.Condensed {
+		t.Error("expected Condensed to be reset on a fresh active session")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -16,6 +16,10 @@ type Session struct {
 	Branch    string    `json:"branch"`
 	SourceDir string    `json:"source_dir"`
 
+	// AgentPID is the OS process ID of the agent. When non-zero it is used during
+	// stale-session cleanup to verify whether the process is still alive.
+	AgentPID int `json:"agent_pid,omitempty"`
+
 	// Condensed is true when the session has been fully captured in a checkpoint
 	// and has ended. Post-commit sets this after creating a checkpoint so future
 	// commits with the same session can be skipped.


### PR DESCRIPTION
## Summary

- Adds `CleanupStale()` to `session.Manager` — detects sessions in ACTIVE or IDLE state whose state file is older than the configured threshold and (when `AgentPID` is set) whose associated process is no longer alive, then transitions them to ENDED
- `partio status` runs stale cleanup before displaying results
- New `partio cleanup` command for manual invocation
- `StaleSessionThreshold` config field (default: 10 minutes) controllable via `PARTIO_STALE_SESSION_THRESHOLD` env var or `.partio/settings.json`
- Added `AgentPID int` field to `Session` struct for process liveness checks
- Fixed pre-existing `errcheck` lint issues in `internal/agent/codex/parse_jsonl.go`

## Test plan

- [ ] `TestCleanupStale_NoSession` — no-op when no session file exists
- [ ] `TestCleanupStale_EndedSession` — skips already-ended sessions even if old
- [ ] `TestCleanupStale_RecentActiveSession` — skips sessions updated recently
- [ ] `TestCleanupStale_OldActiveSession_NoPID` — cleans up old ACTIVE session with no PID recorded
- [ ] `TestCleanupStale_OldIdleSession_NoPID` — cleans up old IDLE session with no PID recorded
- [ ] `TestCleanupStale_OldActiveSession_AlivePID` — skips session whose process is still running
- [ ] `TestCleanupStale_OldActiveSession_DeadPID` — cleans up session with a dead PID
- [ ] `make test` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #27