### PR TITLE
ci(doc-minion): authenticate git pushes to the docs repo

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -60,6 +60,11 @@ jobs:
           PR_REF: ${{ steps.src.outputs.pr_ref }}
           DRY_RUN: ${{ steps.src.outputs.dry_run }}
         run: |
+          # Authenticate git pushes to any github.com repo — including the docs
+          # repo minions clones as a secondary repo, which actions/checkout does
+          # not credential. The token is read from GH_TOKEN at call time and is
+          # never written into gitconfig.
+          git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
           if [ "$DRY_RUN" = "true" ]; then
             minions run .minions/programs/doc-update.md --pr "$PR_REF" --dry-run
           else


### PR DESCRIPTION
## What

The first real auto-triggered `doc-minion` run — fired by the **#498** merge — got 95% of the way: it installed minions, resolved `partio-io/cli#498`, fetched the diff, and the agent **correctly wrote the docs** (`cli/commands.mdx` + `cli/configuration.mdx` for `partio cleanup` and `stale_session_threshold`). It failed only on the final `git push` to the **docs** repo:

```
fatal: could not read Username for 'https://github.com'
```

## Why

`actions/checkout` only sets push credentials for the **checked-out** repo (cli). `doc-update` targets a **second** repo (`docs`) that minions clones into the workspace — that clone has no push credentials, so `git push` to it prompts for a username and dies in CI. (`GH_TOKEN` authenticates the `gh` API calls, but not raw `git push`.)

## Fix

Configure a git credential helper that serves `GH_TOKEN` for `github.com` pushes. The token is read from the environment **at call time**, so it is never written into gitconfig. Verified locally with `git credential fill` that the helper yields `x-access-token:$GH_TOKEN`.

```
git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
```

Workflow-only change — live on merge, no minions release. (A cleaner long-term home is minions itself authenticating secondary-repo pushes at clone time; this unblocks the pipeline now.)

## After merge

`partio-io/cli#498` is already merged, so the `pull_request` trigger won't re-fire. Re-run once to produce the #498 docs PR:

```
gh workflow run doc-minion.yml --repo partio-io/cli -f pr_ref=partio-io/cli#498 -f dry_run=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
