### PR TITLE
ci(doc-minion): bump minions pin v0.0.7 → v0.0.8

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.7
+          go install github.com/partio-io/minions/cmd/minions@v0.0.8
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Resolve source PR reference


### PR DESCRIPTION
Picks up [partio-io/minions#136](https://github.com/partio-io/minions/pull/136) (released as `v0.0.8`): minion worktrees now branch from the latest `origin/<default>` instead of the runner checkout's stale local `HEAD`. That stale-clone bug is why doc-minion's first real run branched from a months-old docs `main` and produced a CONFLICTING PR ([docs#14](https://github.com/partio-io/docs/pull/14)). `v0.0.8` = `v0.0.7` + that fix (verified: `@v0.0.8` resolves, worktree tests pass).

Only `doc-minion.yml` is bumped here. `minion.yml`, `plan.yml`, `propose.yml`, `research.yml` are still on `v0.0.6` and share the same stale-clone bug — worth a follow-up bump to `v0.0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)