### PR TITLE
ci: bump minions pin v0.0.6 → v0.0.8 (minion, plan, propose, research)

### DIFF
--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.6
+          go install github.com/partio-io/minions/cmd/minions@v0.0.8
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.6
+          go install github.com/partio-io/minions/cmd/minions@v0.0.8
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.6
+          go install github.com/partio-io/minions/cmd/minions@v0.0.8
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.6
+          go install github.com/partio-io/minions/cmd/minions@v0.0.8
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program


### PR DESCRIPTION
Follow-up to #513. These four workflows create worktrees the same way `doc-minion` does, off the same persistent runner checkouts, so on `v0.0.6` they branch implementation/plan PRs from **stale local main** — the same conflict class fixed in [minions#136](https://github.com/partio-io/minions/pull/136). This brings them in line with `doc-minion.yml` so the whole minion loop branches from the latest `origin/<default>`.

`v0.0.8` = `v0.0.6` + the additive `--pr` flag (unused by these) + the worktree fix. All five workflows are now on `v0.0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)