### PR TITLE
feat: support checkpoint resume and rewind for squash-merged commits

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Resolve source PR reference

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/cmd/partio/resume.go
+++ b/cmd/partio/resume.go
@@ -17,8 +17,8 @@ import (
 
 func newResumeCmd() *cobra.Command {
 	var (
-		printFlag bool
-		copyFlag  bool
+		printFlag  bool
+		copyFlag   bool
 		branchFlag bool
 	)
 

--- a/cmd/partio/resume.go
+++ b/cmd/partio/resume.go
@@ -52,7 +52,8 @@ func runResume(id string, printFlag, copyFlag, branchFlag bool) error {
 
 	if branchFlag {
 		branchName := fmt.Sprintf("partio/resume/%s", id)
-		_, err := git.ExecGit("checkout", "-b", branchName, data.Metadata.CommitHash)
+		commitHash := checkpoint.ResolveCommitHash(id, data.Metadata.CommitHash)
+		_, err := git.ExecGit("checkout", "-b", branchName, commitHash)
 		if err != nil {
 			return fmt.Errorf("creating resume branch: %w", err)
 		}

--- a/cmd/partio/rewind.go
+++ b/cmd/partio/rewind.go
@@ -13,8 +13,9 @@ import (
 
 func newRewindCmd() *cobra.Command {
 	var (
-		list bool
-		toID string
+		list      bool
+		toID      string
+		commitSHA string
 	)
 
 	cmd := &cobra.Command{
@@ -28,12 +29,16 @@ func newRewindCmd() *cobra.Command {
 			if toID != "" {
 				return runRewindTo(toID)
 			}
+			if commitSHA != "" {
+				return runRewindByCommit(commitSHA)
+			}
 			return cmd.Help()
 		},
 	}
 
 	cmd.Flags().BoolVar(&list, "list", false, "list all checkpoints")
 	cmd.Flags().StringVar(&toID, "to", "", "restore to a specific checkpoint ID")
+	cmd.Flags().StringVar(&commitSHA, "commit", "", "find and restore the checkpoint for the given commit SHA (supports squash-merged commits)")
 
 	return cmd
 }
@@ -83,8 +88,17 @@ func runRewindList() error {
 				continue
 			}
 
-			fmt.Printf("  %s  branch=%s  agent=%d%%  created=%s\n",
-				cpID, meta.Branch, meta.AgentPercent, meta.CreatedAt)
+			reachabilityNote := ""
+			if !git.CommitReachable(meta.CommitHash) {
+				if git.CommitExists(meta.CommitHash) {
+					reachabilityNote = "  [squash-merged]"
+				} else {
+					reachabilityNote = "  [commit pruned]"
+				}
+			}
+
+			fmt.Printf("  %s  branch=%s  agent=%d%%  created=%s%s\n",
+				cpID, meta.Branch, meta.AgentPercent, meta.CreatedAt, reachabilityNote)
 		}
 	}
 
@@ -139,4 +153,57 @@ func runRewindTo(id string) error {
 
 	fmt.Printf("  Created branch: %s\n", branchName)
 	return nil
+}
+
+// runRewindByCommit finds checkpoints associated with the given commit SHA and presents
+// them to the user. Supports squash-merged commits by also checking the equivalent
+// squash commit in the current branch history when the given SHA is unreachable.
+func runRewindByCommit(sha string) error {
+	_, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("must be run inside a git repository")
+	}
+
+	// Search checkpoints for the given SHA directly
+	ids, err := checkpoint.FindByCommit(sha)
+	if err != nil {
+		return fmt.Errorf("searching checkpoints: %w", err)
+	}
+
+	// If not found and the commit exists but is unreachable, check for a squash-merge equivalent
+	if len(ids) == 0 && git.CommitExists(sha) && !git.CommitReachable(sha) {
+		squash, findErr := git.FindSquashCommit(sha)
+		if findErr == nil && squash != "" {
+			fmt.Printf("Commit %s is not reachable (squash-merged). Searching checkpoints for equivalent squash commit %s...\n",
+				shortSHA(sha), shortSHA(squash))
+			ids, err = checkpoint.FindByCommit(squash)
+			if err != nil {
+				return fmt.Errorf("searching checkpoints for squash commit: %w", err)
+			}
+		}
+	}
+
+	if len(ids) == 0 {
+		return fmt.Errorf("no checkpoint found for commit %s", shortSHA(sha))
+	}
+
+	if len(ids) == 1 {
+		fmt.Printf("Found checkpoint %s for commit %s.\n", ids[0], shortSHA(sha))
+		return runRewindTo(ids[0])
+	}
+
+	fmt.Printf("Found %d checkpoints for commit %s:\n", len(ids), shortSHA(sha))
+	for _, id := range ids {
+		fmt.Printf("  %s\n", id)
+	}
+	fmt.Println("Use 'partio rewind --to <id>' to restore a specific checkpoint.")
+	return nil
+}
+
+// shortSHA returns the first 8 characters of a SHA for display purposes.
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
 }

--- a/cmd/partio/rewind.go
+++ b/cmd/partio/rewind.go
@@ -119,16 +119,20 @@ func runRewindTo(id string) error {
 	// Read session context
 	context, _ := git.ExecGit("show", branch+":"+shard+"/"+rest+"/0/context.md")
 
+	// Resolve the commit hash: if the original was squash-merged it may no
+	// longer exist, so fall back to the commit that carries the trailer.
+	commitHash := checkpoint.ResolveCommitHash(id, meta.CommitHash)
+
 	fmt.Printf("Rewinding to checkpoint %s\n", id)
-	fmt.Printf("  Commit: %s\n", meta.CommitHash)
+	fmt.Printf("  Commit: %s\n", commitHash)
 	fmt.Printf("  Branch: %s\n", meta.Branch)
 	if context != "" {
 		fmt.Printf("  Context:\n%s\n", context)
 	}
 
-	// Create a new branch at the checkpoint's commit
+	// Create a new branch at the resolved commit.
 	branchName := fmt.Sprintf("partio/rewind/%s", id)
-	_, err = git.ExecGit("checkout", "-b", branchName, meta.CommitHash)
+	_, err = git.ExecGit("checkout", "-b", branchName, commitHash)
 	if err != nil {
 		return fmt.Errorf("creating rewind branch: %w", err)
 	}

--- a/internal/checkpoint/find_by_commit.go
+++ b/internal/checkpoint/find_by_commit.go
@@ -1,0 +1,47 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/partio-io/cli/internal/git"
+)
+
+// FindByCommit searches all stored checkpoints for those whose commit hash matches commitSHA.
+// Returns a slice of checkpoint IDs. Returns nil (no error) when the checkpoint branch is
+// absent or no checkpoints match.
+func FindByCommit(commitSHA string) ([]string, error) {
+	shards, err := git.ExecGit("ls-tree", "--name-only", git.CheckpointBranch)
+	if err != nil || strings.TrimSpace(shards) == "" {
+		return nil, nil
+	}
+
+	var ids []string
+	for _, shard := range strings.Split(strings.TrimSpace(shards), "\n") {
+		if shard == "" {
+			continue
+		}
+		entries, err := git.ExecGit("ls-tree", "--name-only", git.CheckpointBranch+":"+shard)
+		if err != nil {
+			continue
+		}
+		for _, entry := range strings.Split(strings.TrimSpace(entries), "\n") {
+			if entry == "" {
+				continue
+			}
+			metaJSON, err := git.ExecGit("show", git.CheckpointBranch+":"+shard+"/"+entry+"/metadata.json")
+			if err != nil {
+				continue
+			}
+			var meta Metadata
+			if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+				continue
+			}
+			if meta.CommitHash == commitSHA {
+				ids = append(ids, shard+entry)
+			}
+		}
+	}
+
+	return ids, nil
+}

--- a/internal/checkpoint/find_by_commit_test.go
+++ b/internal/checkpoint/find_by_commit_test.go
@@ -1,0 +1,152 @@
+package checkpoint
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runGit runs a git command in dir. Fatals on error.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// initCheckpointRepo creates a temp git repo with the checkpoint orphan branch initialized.
+func initCheckpointRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+
+	// Create an initial commit on the main branch so we have a valid repo
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "initial")
+
+	// Create the orphan checkpoint branch (mirrors createCheckpointBranch in enable.go)
+	treeHash := runGit(t, dir, "hash-object", "-t", "tree", "/dev/null")
+	commitHash := runGit(t, dir, "commit-tree", treeHash, "-m", "partio: initialize checkpoint storage")
+	runGit(t, dir, "update-ref", "refs/heads/partio/checkpoints/v1", commitHash)
+
+	return dir
+}
+
+func TestFindByCommit(t *testing.T) {
+	dir := initCheckpointRepo(t)
+	t.Chdir(dir)
+
+	targetCommit := "abcdef1234567890abcdef1234567890abcdef12"
+	otherCommit := "1111111111111111111111111111111111111111"
+
+	store := NewStore(dir)
+
+	// Write a checkpoint for targetCommit
+	cp := &Checkpoint{
+		ID:          "aabbcc112233",
+		CommitHash:  targetCommit,
+		Branch:      "feature",
+		CreatedAt:   time.Now(),
+		Agent:       "claude-code",
+		AgentPct:    100,
+		ContentHash: "deadbeef",
+	}
+	sf := &SessionFiles{
+		ContentHash: "deadbeef",
+		Context:     "test context",
+		Diff:        "test diff",
+		FullJSONL:   `{"sessionId":"s1"}`,
+		Prompt:      "test prompt",
+		Plan:        "test plan",
+	}
+	if err := store.Write(cp, sf); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Write a checkpoint for a different commit
+	cp2 := &Checkpoint{
+		ID:          "ddeeff445566",
+		CommitHash:  otherCommit,
+		Branch:      "main",
+		CreatedAt:   time.Now(),
+		Agent:       "claude-code",
+		AgentPct:    50,
+		ContentHash: "cafebabe",
+	}
+	sf2 := &SessionFiles{
+		ContentHash: "cafebabe",
+		Context:     "other context",
+		Diff:        "",
+		FullJSONL:   `{"sessionId":"s2"}`,
+		Prompt:      "other prompt",
+		Plan:        "",
+	}
+	if err := store.Write(cp2, sf2); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	t.Run("finds checkpoint by commit SHA", func(t *testing.T) {
+		ids, err := FindByCommit(targetCommit)
+		if err != nil {
+			t.Fatalf("FindByCommit() error: %v", err)
+		}
+		if len(ids) != 1 {
+			t.Fatalf("FindByCommit() returned %d IDs, want 1: %v", len(ids), ids)
+		}
+		if ids[0] != cp.ID {
+			t.Errorf("FindByCommit() = %q, want %q", ids[0], cp.ID)
+		}
+	})
+
+	t.Run("does not return checkpoint for different commit", func(t *testing.T) {
+		ids, err := FindByCommit(targetCommit)
+		if err != nil {
+			t.Fatalf("FindByCommit() error: %v", err)
+		}
+		for _, id := range ids {
+			if id == cp2.ID {
+				t.Errorf("FindByCommit(%s) returned %s which belongs to a different commit", targetCommit[:8], cp2.ID)
+			}
+		}
+	})
+
+	t.Run("returns empty for unknown commit", func(t *testing.T) {
+		ids, err := FindByCommit("9999999999999999999999999999999999999999")
+		if err != nil {
+			t.Fatalf("FindByCommit() error: %v", err)
+		}
+		if len(ids) != 0 {
+			t.Errorf("FindByCommit(unknown) = %v, want empty", ids)
+		}
+	})
+}
+
+func TestFindByCommit_NoBranch(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	// No checkpoint branch created
+	t.Chdir(dir)
+
+	ids, err := FindByCommit("abc123")
+	if err != nil {
+		t.Fatalf("FindByCommit() with no branch error: %v", err)
+	}
+	if ids != nil {
+		t.Errorf("FindByCommit() with no branch = %v, want nil", ids)
+	}
+}

--- a/internal/checkpoint/resolve_commit.go
+++ b/internal/checkpoint/resolve_commit.go
@@ -1,0 +1,26 @@
+package checkpoint
+
+import "github.com/partio-io/cli/internal/git"
+
+// ResolveCommitHash returns the best available commit hash for a checkpoint.
+//
+// It first checks whether the original commit still exists in the repository.
+// If it does not (e.g. the branch was squash-merged), it searches the git log
+// for a commit that references this checkpoint ID via the Partio-Checkpoint
+// trailer. This allows resume and rewind to function even after a squash merge
+// collapses the original commits into a new one.
+//
+// If no commit can be found via the trailer search either, the original hash
+// is returned as-is so callers can produce a meaningful error message.
+func ResolveCommitHash(id, originalHash string) string {
+	if git.CommitExists(originalHash) {
+		return originalHash
+	}
+	// Squash-merge scenario: the original commit no longer exists. Search the
+	// log for a commit whose message contains the Partio-Checkpoint trailer.
+	found, err := git.FindCommitByCheckpointID(id)
+	if err != nil || found == "" {
+		return originalHash
+	}
+	return found
+}

--- a/internal/checkpoint/resolve_commit_test.go
+++ b/internal/checkpoint/resolve_commit_test.go
@@ -1,0 +1,105 @@
+package checkpoint
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestRepo initialises a temporary git repo and returns its path along
+// with the hash of the single initial commit (which carries a
+// Partio-Checkpoint trailer so FindCommitByCheckpointID can locate it).
+func newTestRepo(t *testing.T, checkpointID string) (dir, hash string) {
+	t.Helper()
+
+	dir = t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "test")
+
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "feat: initial\n\nPartio-Checkpoint: "+checkpointID)
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, strings.TrimSpace(string(out))
+}
+
+func TestResolveCommitHash_existingCommit(t *testing.T) {
+	dir, hash := newTestRepo(t, "abcdef123456")
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	// When the original commit exists, ResolveCommitHash should return it unchanged.
+	got := ResolveCommitHash("abcdef123456", hash)
+	if got != hash {
+		t.Errorf("ResolveCommitHash with existing commit = %q, want %q", got, hash)
+	}
+}
+
+func TestResolveCommitHash_squashMerged(t *testing.T) {
+	const id = "abcdef123456"
+	dir, hash := newTestRepo(t, id)
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	// Simulate a squash-merge: the "original" commit SHA does not exist but the
+	// commit in the repo carries the checkpoint trailer.
+	fakeOriginal := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	got := ResolveCommitHash(id, fakeOriginal)
+	if got != hash {
+		t.Errorf("ResolveCommitHash (squash-merged) = %q, want %q (squash commit)", got, hash)
+	}
+}
+
+func TestResolveCommitHash_noFallback(t *testing.T) {
+	dir, _ := newTestRepo(t, "abcdef123456")
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	// Neither the original commit exists nor the trailer ID matches anything.
+	const unknownID = "000000000000"
+	fakeOriginal := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	got := ResolveCommitHash(unknownID, fakeOriginal)
+	// Should fall back to the original (unchanged) so callers can give a useful error.
+	if got != fakeOriginal {
+		t.Errorf("ResolveCommitHash (no fallback) = %q, want %q (original)", got, fakeOriginal)
+	}
+}

--- a/internal/git/squash.go
+++ b/internal/git/squash.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CommitReachable reports whether the commit exists and is reachable from any local branch.
+func CommitReachable(sha string) bool {
+	if !CommitExists(sha) {
+		return false
+	}
+	out, err := execGit("branch", "--contains", sha)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) != ""
+}
+
+// FindSquashCommit searches the recent git history (up to 200 commits from HEAD) for a commit
+// whose tree matches the tree of commitSHA, indicating it may have been squash-merged.
+// Returns the squash commit SHA, or an empty string if not found.
+func FindSquashCommit(commitSHA string) (string, error) {
+	origTree, err := execGit("rev-parse", commitSHA+"^{tree}")
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve commit %s: %w", commitSHA, err)
+	}
+
+	log, err := execGit("log", "--format=%H %T", "-n", "200")
+	if err != nil {
+		return "", fmt.Errorf("reading git log: %w", err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == origTree && parts[0] != commitSHA {
+			return parts[0], nil
+		}
+	}
+
+	return "", nil
+}

--- a/internal/git/squash_merge.go
+++ b/internal/git/squash_merge.go
@@ -1,0 +1,17 @@
+package git
+
+// CommitExists returns true if the given commit hash exists in the repository.
+func CommitExists(hash string) bool {
+	if hash == "" {
+		return false
+	}
+	_, err := execGit("cat-file", "-e", hash+"^{commit}")
+	return err == nil
+}
+
+// FindCommitByCheckpointID searches all reachable commits for one that has
+// a "Partio-Checkpoint: <id>" trailer. Returns the commit hash, or an empty
+// string if no matching commit is found.
+func FindCommitByCheckpointID(id string) (string, error) {
+	return execGit("log", "--all", "--grep=Partio-Checkpoint: "+id, "--format=%H", "-1")
+}

--- a/internal/git/squash_merge_test.go
+++ b/internal/git/squash_merge_test.go
@@ -1,0 +1,101 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupTestRepo initialises a temporary git repository with one commit and
+// returns the directory path and the commit hash.
+func setupTestRepo(t *testing.T) (dir string, commitHash string) {
+	t.Helper()
+
+	dir = t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "test")
+
+	// Write a file and commit with a Partio-Checkpoint trailer.
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "initial commit\n\nPartio-Checkpoint: abcdef123456")
+
+	// Capture the commit hash.
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := strings.TrimSpace(string(out))
+	return dir, hash
+}
+
+func TestCommitExists(t *testing.T) {
+	dir, hash := setupTestRepo(t)
+
+	// Change working dir so execGit operates on the test repo.
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	if !CommitExists(hash) {
+		t.Errorf("CommitExists(%q) = false, want true for existing commit", hash)
+	}
+
+	if CommitExists("0000000000000000000000000000000000000000") {
+		t.Error("CommitExists(zero SHA) = true, want false for non-existent commit")
+	}
+
+	if CommitExists("") {
+		t.Error("CommitExists(\"\") = true, want false")
+	}
+}
+
+func TestFindCommitByCheckpointID(t *testing.T) {
+	dir, hash := setupTestRepo(t)
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	got, err := FindCommitByCheckpointID("abcdef123456")
+	if err != nil {
+		t.Fatalf("FindCommitByCheckpointID: unexpected error: %v", err)
+	}
+	if got != hash {
+		t.Errorf("FindCommitByCheckpointID(%q) = %q, want %q", "abcdef123456", got, hash)
+	}
+
+	// ID that does not appear in any commit.
+	got2, _ := FindCommitByCheckpointID("000000000000")
+	if got2 != "" {
+		t.Errorf("FindCommitByCheckpointID(unknown ID) = %q, want empty", got2)
+	}
+}

--- a/internal/git/squash_test.go
+++ b/internal/git/squash_test.go
@@ -1,0 +1,154 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runGitInDir runs a git command in dir and returns trimmed stdout. Fatals on error.
+func runGitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// initTestRepo creates a temporary git repo and returns its path.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitInDir(t, dir, "init", "-b", "main")
+	runGitInDir(t, dir, "config", "user.email", "test@test.com")
+	runGitInDir(t, dir, "config", "user.name", "Test")
+	return dir
+}
+
+// makeTestCommit creates a file and commits it. Returns the commit SHA.
+func makeTestCommit(t *testing.T, dir, filename, content, msg string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", filename, err)
+	}
+	runGitInDir(t, dir, "add", ".")
+	runGitInDir(t, dir, "commit", "-m", msg)
+	return runGitInDir(t, dir, "rev-parse", "HEAD")
+}
+
+func TestCommitReachable(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Create an initial commit on the default branch
+	mainSHA := makeTestCommit(t, dir, "main.txt", "main", "main commit")
+
+	// Create a second branch, make a commit, then delete the branch
+	runGitInDir(t, dir, "checkout", "-b", "temp-branch")
+	tempSHA := makeTestCommit(t, dir, "temp.txt", "temp", "temp commit")
+	runGitInDir(t, dir, "checkout", "-") // go back to previous branch
+	runGitInDir(t, dir, "branch", "-D", "temp-branch")
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	if !CommitReachable(mainSHA) {
+		t.Errorf("CommitReachable(%s) = false, want true for reachable commit", mainSHA[:8])
+	}
+
+	if CommitReachable(tempSHA) {
+		t.Errorf("CommitReachable(%s) = true, want false for unreachable commit", tempSHA[:8])
+	}
+
+	const fakeSHA = "0000000000000000000000000000000000000000"
+	if CommitReachable(fakeSHA) {
+		t.Errorf("CommitReachable(nonexistent SHA) = true, want false")
+	}
+}
+
+func TestFindSquashCommit(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Create initial commit on main
+	makeTestCommit(t, dir, "base.txt", "base content", "initial commit")
+
+	// Create a feature branch with one commit
+	runGitInDir(t, dir, "checkout", "-b", "feature")
+	makeTestCommit(t, dir, "feature.txt", "feature content", "feature work")
+	featureSHA := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+	// Switch back and squash-merge the feature branch
+	runGitInDir(t, dir, "checkout", "main")
+	runGitInDir(t, dir, "merge", "--squash", "feature")
+	runGitInDir(t, dir, "commit", "-m", "squash: merge feature")
+	squashSHA := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+	// Delete feature branch so featureSHA is unreachable
+	runGitInDir(t, dir, "branch", "-D", "feature")
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	got, err := FindSquashCommit(featureSHA)
+	if err != nil {
+		t.Fatalf("FindSquashCommit() error: %v", err)
+	}
+	if got != squashSHA {
+		t.Errorf("FindSquashCommit() = %q, want %q", got, squashSHA)
+	}
+}
+
+func TestFindSquashCommit_NotFound(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Create two unrelated commits with different trees
+	sha1 := makeTestCommit(t, dir, "a.txt", "content a", "commit a")
+	makeTestCommit(t, dir, "b.txt", "content b", "commit b")
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	// sha1 is still reachable and its tree is not replicated anywhere else
+	got, err := FindSquashCommit(sha1)
+	if err != nil {
+		t.Fatalf("FindSquashCommit() error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("FindSquashCommit() = %q, want empty string for no match", got)
+	}
+}
+
+func TestFindSquashCommit_InvalidSHA(t *testing.T) {
+	dir := initTestRepo(t)
+	makeTestCommit(t, dir, "a.txt", "content", "initial")
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	_, err := FindSquashCommit("0000000000000000000000000000000000000000")
+	if err == nil {
+		t.Error("FindSquashCommit(invalid SHA) expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- When a branch is squash-merged, the original commit SHAs become unreachable. `partio resume --branch` and `partio rewind --to` both tried to check out the original commit hash stored in checkpoint metadata, causing a git error in this scenario.
- Added `git.CommitExists` and `git.FindCommitByCheckpointID` to detect whether a commit still exists and, if not, locate a squash-merge commit that carries the `Partio-Checkpoint: <id>` trailer via `git log --all --grep`.
- Added `checkpoint.ResolveCommitHash` which uses the original hash when it still exists (normal merges, fast-forwards — unchanged behavior), or falls back to the squash-merge commit found via trailer search.
- Updated `resume.go` and `rewind.go` to call `ResolveCommitHash` before branching.

## Test plan

- [ ] `TestCommitExists` — validates detection of existing vs. non-existent commits
- [ ] `TestFindCommitByCheckpointID` — validates trailer-based commit lookup
- [ ] `TestResolveCommitHash_existingCommit` — original commit exists → unchanged
- [ ] `TestResolveCommitHash_squashMerged` — original gone, trailer found → squash commit returned
- [ ] `TestResolveCommitHash_noFallback` — nothing found → original returned (caller produces error)
- [ ] Full test suite: `go test ./...` passes
- [ ] Lint: `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)