### PR TITLE
chore: bump minions to v0.0.9

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Resolve source PR reference

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.8
+          go install github.com/partio-io/minions/cmd/minions@v0.0.9
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program


### PR DESCRIPTION
Bumps all 5 minion workflows from `minions@v0.0.8` to `v0.0.9`.

| workflow | line |
|---|---|
| `minion.yml` | 58 |
| `research.yml` | 32 |
| `plan.yml` | 31 |
| `propose.yml` | 29 |
| `doc-minion.yml` | 43 |

## Why

`v0.0.9` carries partio-io/minions#137, which stops the check runner from throwing away the error returned by `checks.Run`. On an exec-level failure (e.g. `make` not resolvable on the runner) `CombinedOutput` returns **empty** output with the real cause living only in `err` — which was discarded. Failures therefore surfaced as `checks still failing` with no reason logged and an **empty** retry prompt, so the retry agent concluded "nothing to fix" and the job died undiagnosably.

## Context

This is what killed the #28 build ([run 29255539850](https://github.com/partio-io/cli/actions/runs/29255539850)): the Go checks failed in **under a millisecond with zero output**, and nothing in the log said why.

## Effect

This does not by itself make #28 pass — it makes the failure legible. After this merges, re-running the minion on #28 will print the actual check error (expected: `make` not resolvable on `github-runner-partio-minion-ai-01`) instead of nothing, so the underlying runner problem can be confirmed rather than guessed at.

Verified `go list -m github.com/partio-io/minions@v0.0.9` resolves before bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)