### PR TITLE
ci: bump minions pin v0.0.9 -> v0.0.10

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.9
+          go install github.com/partio-io/minions/cmd/minions@v0.0.10
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Resolve source PR reference

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.9
+          go install github.com/partio-io/minions/cmd/minions@v0.0.10
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.9
+          go install github.com/partio-io/minions/cmd/minions@v0.0.10
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.9
+          go install github.com/partio-io/minions/cmd/minions@v0.0.10
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.9
+          go install github.com/partio-io/minions/cmd/minions@v0.0.10
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program


### PR DESCRIPTION
Points all five minion workflows at [minions v0.0.10](https://github.com/partio-io/minions/releases/tag/v0.0.10) (partio-io/minions#138).

v0.0.10 fixes the issue-context bug: minions fetched `--json title,body`, so
every comment was dropped before the prompt was built. Research, design
decisions and scope boundaries all live in comments, so every minion build has
been implementing blind.

On #28 the agent received 2,879 chars and never saw the 13,736 chars of
research — including *"Out of scope: squash-merge auto-detection
(`--commit <sha>`)"*, which it then implemented anyway, twice (#515). With
v0.0.10 the same issue yields 16,693 chars.

Until this pin moves, the workflows keep installing v0.0.9 and the fix is not
live. Mechanical bump — the five `go install` lines and nothing else.

Files: `minion.yml`, `research.yml`, `plan.yml`, `propose.yml`, `doc-minion.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)