### PR TITLE
feat: support checkpoint resume and rewind for squash-merged commits

### DIFF
--- a/cmd/partio/resume.go
+++ b/cmd/partio/resume.go
@@ -6,8 +6,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -17,17 +19,27 @@ import (
 
 func newResumeCmd() *cobra.Command {
 	var (
-		printFlag bool
-		copyFlag  bool
-		branchFlag bool
+		printFlag      bool
+		copyFlag       bool
+		branchFlag     bool
+		branchNameFlag string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "resume <checkpoint-id>",
+		Use:   "resume [<checkpoint-id>]",
 		Short: "Resume a session from a checkpoint",
-		Long:  `Read checkpoint data from the orphan branch and launch a new Claude Code session with the previous context.`,
-		Args:  cobra.ExactArgs(1),
+		Long: `Read checkpoint data from the orphan branch and launch a new Claude Code session with the previous context.
+
+When a feature branch has been squash-merged, use --branch <name> to locate the
+most recent checkpoint by branch name rather than by checkpoint ID.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if branchNameFlag != "" {
+				return runResumeByBranch(branchNameFlag, printFlag, copyFlag, branchFlag)
+			}
+			if len(args) == 0 {
+				return cmd.Help()
+			}
 			return runResume(args[0], printFlag, copyFlag, branchFlag)
 		},
 	}
@@ -35,8 +47,33 @@ func newResumeCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&printFlag, "print", false, "print the composed context prompt to stdout")
 	cmd.Flags().BoolVar(&copyFlag, "copy", false, "copy the context prompt to clipboard")
 	cmd.Flags().BoolVar(&branchFlag, "branch", false, "create a branch at the checkpoint's commit before launching")
+	cmd.Flags().StringVar(&branchNameFlag, "branch-name", "", "resume the most recent checkpoint for this branch name (recommended for squash-merged branches)")
 
 	return cmd
+}
+
+func runResumeByBranch(branchName string, printFlag, copyFlag, branchFlag bool) error {
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("must be run inside a git repository")
+	}
+
+	metas, err := checkpoint.FindByBranch(repoRoot, branchName)
+	if err != nil {
+		return fmt.Errorf("finding checkpoints for branch %q: %w", branchName, err)
+	}
+	if len(metas) == 0 {
+		return fmt.Errorf("no checkpoints found for branch %q", branchName)
+	}
+
+	// Sort by CreatedAt descending to pick the most recent checkpoint.
+	sort.Slice(metas, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, metas[i].CreatedAt)
+		tj, _ := time.Parse(time.RFC3339, metas[j].CreatedAt)
+		return ti.After(tj)
+	})
+
+	return runResume(metas[0].ID, printFlag, copyFlag, branchFlag)
 }
 
 func runResume(id string, printFlag, copyFlag, branchFlag bool) error {

--- a/cmd/partio/rewind.go
+++ b/cmd/partio/rewind.go
@@ -13,17 +13,21 @@ import (
 
 func newRewindCmd() *cobra.Command {
 	var (
-		list bool
-		toID string
+		list       bool
+		toID       string
+		branchName string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "rewind",
 		Short: "List or restore checkpoints",
-		Long:  `List all captured checkpoints or restore the repository state to a specific checkpoint.`,
+		Long: `List all captured checkpoints or restore the repository state to a specific checkpoint.
+
+Use --branch <name> with --list to filter checkpoints by branch name. This is
+the recommended approach for finding sessions whose branch was squash-merged.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if list {
-				return runRewindList()
+				return runRewindList(branchName)
 			}
 			if toID != "" {
 				return runRewindTo(toID)
@@ -34,26 +38,27 @@ func newRewindCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&list, "list", false, "list all checkpoints")
 	cmd.Flags().StringVar(&toID, "to", "", "restore to a specific checkpoint ID")
+	cmd.Flags().StringVar(&branchName, "branch", "", "filter listed checkpoints by branch name (recommended for squash-merged branches)")
 
 	return cmd
 }
 
-func runRewindList() error {
+func runRewindList(branchFilter string) error {
 	_, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("must be run inside a git repository")
 	}
 
-	const branch = "partio/checkpoints/v1"
+	const cpBranch = "partio/checkpoints/v1"
 
 	// Check branch exists
-	_, err = git.ExecGit("rev-parse", "--verify", branch)
+	_, err = git.ExecGit("rev-parse", "--verify", cpBranch)
 	if err != nil {
 		return fmt.Errorf("no checkpoint branch found - run 'partio enable' first")
 	}
 
 	// List top-level shard directories
-	shards, err := git.ExecGit("ls-tree", "--name-only", branch)
+	shards, err := git.ExecGit("ls-tree", "--name-only", cpBranch)
 	if err != nil || shards == "" {
 		fmt.Println("No checkpoints found.")
 		return nil
@@ -64,22 +69,30 @@ func runRewindList() error {
 
 	for _, shard := range strings.Split(shards, "\n") {
 		// List entries within each shard
-		entries, err := git.ExecGit("ls-tree", "--name-only", branch+":"+shard)
+		entries, err := git.ExecGit("ls-tree", "--name-only", cpBranch+":"+shard)
 		if err != nil {
 			continue
 		}
 		for _, entry := range strings.Split(entries, "\n") {
 			cpID := shard + entry
 			// Try to read metadata
-			metaJSON, err := git.ExecGit("show", branch+":"+shard+"/"+entry+"/metadata.json")
+			metaJSON, err := git.ExecGit("show", cpBranch+":"+shard+"/"+entry+"/metadata.json")
 			if err != nil {
-				fmt.Printf("  %s  (metadata unavailable)\n", cpID)
+				if branchFilter == "" {
+					fmt.Printf("  %s  (metadata unavailable)\n", cpID)
+				}
 				continue
 			}
 
 			var meta checkpoint.Metadata
 			if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
-				fmt.Printf("  %s  (invalid metadata)\n", cpID)
+				if branchFilter == "" {
+					fmt.Printf("  %s  (invalid metadata)\n", cpID)
+				}
+				continue
+			}
+
+			if branchFilter != "" && meta.Branch != branchFilter {
 				continue
 			}
 
@@ -92,7 +105,7 @@ func runRewindList() error {
 }
 
 func runRewindTo(id string) error {
-	_, err := git.RepoRoot()
+	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("must be run inside a git repository")
 	}
@@ -101,12 +114,12 @@ func runRewindTo(id string) error {
 		return fmt.Errorf("checkpoint ID must be 12 characters (got %d)", len(id))
 	}
 
-	const branch = "partio/checkpoints/v1"
+	const cpBranch = "partio/checkpoints/v1"
 	shard := id[:2]
 	rest := id[2:]
 
 	// Read metadata
-	metaJSON, err := git.ExecGit("show", branch+":"+shard+"/"+rest+"/metadata.json")
+	metaJSON, err := git.ExecGit("show", cpBranch+":"+shard+"/"+rest+"/metadata.json")
 	if err != nil {
 		return fmt.Errorf("checkpoint %s not found", id)
 	}
@@ -117,13 +130,29 @@ func runRewindTo(id string) error {
 	}
 
 	// Read session context
-	context, _ := git.ExecGit("show", branch+":"+shard+"/"+rest+"/0/context.md")
+	context, _ := git.ExecGit("show", cpBranch+":"+shard+"/"+rest+"/0/context.md")
 
 	fmt.Printf("Rewinding to checkpoint %s\n", id)
 	fmt.Printf("  Commit: %s\n", meta.CommitHash)
 	fmt.Printf("  Branch: %s\n", meta.Branch)
 	if context != "" {
 		fmt.Printf("  Context:\n%s\n", context)
+	}
+
+	// Check whether the original commit is still reachable (it may not be after
+	// a squash-merge followed by branch deletion and/or gc).
+	reachable, err := git.CommitReachable(repoRoot, meta.CommitHash)
+	if err != nil {
+		return fmt.Errorf("checking commit reachability: %w", err)
+	}
+
+	if !reachable {
+		shortSHA := meta.CommitHash
+		if len(shortSHA) > 8 {
+			shortSHA = shortSHA[:8]
+		}
+		fmt.Printf("Warning: original commit %s is no longer reachable (likely squash-merged or gc'd); session context is still available but branch checkout is skipped.\n", shortSHA)
+		return nil
 	}
 
 	// Create a new branch at the checkpoint's commit

--- a/internal/checkpoint/find_by_branch.go
+++ b/internal/checkpoint/find_by_branch.go
@@ -1,0 +1,55 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// FindByBranch returns all checkpoints whose Branch field exactly matches the
+// given branch name. The returned slice is unsorted. An empty slice (not an
+// error) is returned when no checkpoints match.
+func FindByBranch(repoDir, branch string) ([]Metadata, error) {
+	s := NewStore(repoDir)
+
+	// Check branch exists
+	_, err := s.git("rev-parse", "--verify", checkpointBranch)
+	if err != nil {
+		return nil, nil
+	}
+
+	// List all shard directories
+	shards, err := s.git("ls-tree", "--name-only", checkpointBranch)
+	if err != nil || shards == "" {
+		return nil, nil
+	}
+
+	var matches []Metadata
+
+	for _, shard := range strings.Split(shards, "\n") {
+		if shard == "" {
+			continue
+		}
+		entries, err := s.git("ls-tree", "--name-only", checkpointBranch+":"+shard)
+		if err != nil {
+			continue
+		}
+		for _, entry := range strings.Split(entries, "\n") {
+			if entry == "" {
+				continue
+			}
+			metaJSON, err := s.git("show", checkpointBranch+":"+shard+"/"+entry+"/metadata.json")
+			if err != nil {
+				continue
+			}
+			var meta Metadata
+			if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+				continue
+			}
+			if meta.Branch == branch {
+				matches = append(matches, meta)
+			}
+		}
+	}
+
+	return matches, nil
+}

--- a/internal/checkpoint/find_by_branch_test.go
+++ b/internal/checkpoint/find_by_branch_test.go
@@ -1,0 +1,211 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// initTestRepo initialises a bare git repo in dir and returns a Store pointing
+// at it.  It creates the orphan checkpoint branch and writes the given metadata
+// entries so that FindByBranch can walk them.
+func initTestRepo(t *testing.T, metas []Metadata) (string, *Store) {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+
+	// Create an initial commit so we have a valid repo
+	run("commit", "--allow-empty", "-m", "init")
+
+	s := NewStore(dir)
+
+	for _, meta := range metas {
+		// Write each checkpoint to the orphan branch via the same git-plumbing
+		// path that the real store uses: hash-object the JSON then build the
+		// shard/rest/metadata.json tree.
+		metaBytes, err := json.Marshal(meta)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		shard := Shard(meta.ID)
+		rest := Rest(meta.ID)
+
+		// hash-object the metadata JSON
+		metaHash, err := s.hashObject(string(metaBytes))
+		if err != nil {
+			t.Fatalf("hash-object metadata: %v", err)
+		}
+
+		// Build the checkpoint subtree (just metadata.json for the test)
+		cpTree, err := s.mktree([]treeEntry{
+			{mode: "100644", typ: "blob", hash: metaHash, name: "metadata.json"},
+		})
+		if err != nil {
+			t.Fatalf("mktree checkpoint: %v", err)
+		}
+
+		// Build the shard tree
+		shardTree, err := s.mktree([]treeEntry{
+			{mode: "040000", typ: "tree", hash: cpTree, name: rest},
+		})
+		if err != nil {
+			t.Fatalf("mktree shard: %v", err)
+		}
+
+		// Check if checkpoint branch already exists
+		_, branchExists := s.git("rev-parse", "--verify", checkpointBranch)
+
+		var rootTree string
+		if branchExists == nil {
+			// Merge the new shard into the existing root tree
+			currentTree, err := s.getCurrentTree()
+			if err != nil {
+				t.Fatalf("getCurrentTree: %v", err)
+			}
+			rootTree, err = s.addToTree(currentTree, shard, rest, cpTree)
+			if err != nil {
+				t.Fatalf("addToTree: %v", err)
+			}
+		} else {
+			// First checkpoint – root tree is just the one shard
+			rootTree, err = s.mktree([]treeEntry{
+				{mode: "040000", typ: "tree", hash: shardTree, name: shard},
+			})
+			if err != nil {
+				t.Fatalf("mktree root: %v", err)
+			}
+		}
+
+		// Create or update the checkpoint commit
+		var commitArgs []string
+		if branchExists == nil {
+			parent, _ := s.git("rev-parse", checkpointBranch)
+			commitArgs = []string{"commit-tree", rootTree, "-p", parent, "-m", "test checkpoint " + meta.ID}
+		} else {
+			commitArgs = []string{"commit-tree", rootTree, "-m", "test checkpoint " + meta.ID}
+		}
+
+		commitHash, err := s.git(commitArgs...)
+		if err != nil {
+			t.Fatalf("commit-tree: %v", err)
+		}
+
+		_, err = s.git("update-ref", "refs/heads/"+checkpointBranch, commitHash)
+		if err != nil {
+			t.Fatalf("update-ref: %v", err)
+		}
+	}
+
+	return dir, s
+}
+
+func makeID(prefix string) string {
+	// Pad to 12 hex chars for a valid checkpoint ID
+	return fmt.Sprintf("%s%s", prefix, strings.Repeat("0", 12-len(prefix)))
+}
+
+func TestFindByBranch(t *testing.T) {
+	id1 := makeID("aabbcc")
+	id2 := makeID("ddeeff")
+	id3 := makeID("112233")
+
+	metas := []Metadata{
+		{ID: id1, Branch: "feature/foo", CommitHash: "abc", CreatedAt: "2024-01-01T00:00:00Z"},
+		{ID: id2, Branch: "feature/foo", CommitHash: "def", CreatedAt: "2024-01-02T00:00:00Z"},
+		{ID: id3, Branch: "main", CommitHash: "ghi", CreatedAt: "2024-01-03T00:00:00Z"},
+	}
+
+	tests := []struct {
+		name     string
+		branch   string
+		wantIDs  []string
+		wantNone bool
+	}{
+		{
+			name:    "single match",
+			branch:  "main",
+			wantIDs: []string{id3},
+		},
+		{
+			name:    "multiple matches",
+			branch:  "feature/foo",
+			wantIDs: []string{id1, id2},
+		},
+		{
+			name:     "no match",
+			branch:   "nonexistent",
+			wantNone: true,
+		},
+		{
+			name:     "partial name does not match",
+			branch:   "feature",
+			wantNone: true,
+		},
+	}
+
+	dir, _ := initTestRepo(t, metas)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FindByBranch(dir, tt.branch)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantNone {
+				if len(got) != 0 {
+					t.Errorf("expected no matches, got %d", len(got))
+				}
+				return
+			}
+
+			// Build a set of returned IDs for order-independent comparison
+			gotIDs := make(map[string]bool)
+			for _, m := range got {
+				gotIDs[m.ID] = true
+			}
+
+			if len(got) != len(tt.wantIDs) {
+				t.Errorf("expected %d matches, got %d", len(tt.wantIDs), len(got))
+			}
+			for _, wantID := range tt.wantIDs {
+				if !gotIDs[wantID] {
+					t.Errorf("expected ID %s in results, but not found", wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestFindByBranchNoBranch(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "-b", "main")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	got, err := FindByBranch(dir, "anything")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result when no checkpoint branch, got %d", len(got))
+	}
+}

--- a/internal/git/commit_reachable.go
+++ b/internal/git/commit_reachable.go
@@ -1,0 +1,23 @@
+package git
+
+import "os/exec"
+
+// CommitReachable reports whether the given SHA refers to a reachable git
+// object. It returns (true, nil) when the object exists, (false, nil) when it
+// does not, and (false, err) only when the subprocess itself fails in an
+// unexpected way.
+func CommitReachable(repoDir, sha string) (bool, error) {
+	cmd := exec.Command("git", "cat-file", "-e", sha)
+	cmd.Dir = repoDir
+	err := cmd.Run()
+	if err != nil {
+		// exit status 1 means the object does not exist – not an error for our
+		// purposes.
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			_ = exitErr
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/git/commit_reachable_test.go
+++ b/internal/git/commit_reachable_test.go
@@ -1,0 +1,71 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func initRepo(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("commit", "--allow-empty", "-m", "init")
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+
+	sha := strings.TrimSpace(string(out))
+	return dir, sha
+}
+
+func TestCommitReachable(t *testing.T) {
+	dir, existingSHA := initRepo(t)
+
+	tests := []struct {
+		name      string
+		sha       string
+		wantFound bool
+	}{
+		{
+			name:      "existing commit is reachable",
+			sha:       existingSHA,
+			wantFound: true,
+		},
+		{
+			name:      "unknown sha is not reachable",
+			sha:       "0000000000000000000000000000000000000000",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CommitReachable(dir, tt.sha)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantFound {
+				t.Errorf("CommitReachable(%q) = %v, want %v", tt.sha, got, tt.wantFound)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `FindByBranch(repoDir, branch string) ([]Metadata, error)` to `internal/checkpoint` — walks the shard tree on the orphan checkpoint branch and returns all metadata entries matching the given branch name (exact string equality)
- Add `CommitReachable(repoDir, sha string) (bool, error)` to `internal/git` — uses `git cat-file -e` to check whether a commit SHA is still reachable
- Extend `partio resume` with a `--branch-name <name>` flag that resolves the most recent checkpoint for that branch and resumes it; intended for squash-merged workflows
- Extend `partio rewind` with a `--branch <name>` flag on `--list` to filter by branch, and graceful degradation in `--to <id>`: when the original commit is unreachable (squash-merged/gc'd) a human-readable warning is printed and the command exits 0 instead of failing

## Test plan

- [x] `internal/checkpoint/find_by_branch_test.go` — table-driven: single match, multiple matches, no match, partial-name non-match, no checkpoint branch
- [x] `internal/git/commit_reachable_test.go` — existing SHA reachable, unknown SHA not reachable
- [x] `make test` passes (all existing tests unchanged)
- [x] `make lint` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)