### PR TITLE
Roll out per-slice minion builds (minions v0.0.11)

### DIFF
--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -31,7 +31,7 @@ jobs:
       (github.event_name == 'issues' && (github.event.label.name == 'minion-ready' || github.event.label.name == 'minion-approved')) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/minion build'))
     runs-on: github-runner-partio-minion-ai-01
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.10
+          go install github.com/partio-io/minions/cmd/minions@v0.0.11
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.minions/programs/implement.md
+++ b/.minions/programs/implement.md
@@ -2,6 +2,7 @@
 id: implement
 target_repos:
   - cli
+slices: true
 acceptance_criteria:
   - "All changes match what the issue describes"
   - "make test passes"
@@ -19,6 +20,15 @@ Read the issue provided as context and implement exactly what it describes.
 Follow existing code patterns and conventions. Read the relevant code before making changes. Keep changes minimal — implement what the issue asks for, nothing more.
 
 After implementation, run the appropriate checks (`make test`, `make lint`) and fix any failures.
+
+## Slice builds
+
+An issue that carries a slice plan (a `minion:research-slices` comment) is built one slice per session. Your prompt then names your slice under "Your Slice" — build only that slice: implement its acceptance criteria and nothing from any other slice, even when adjacent code invites it. Earlier slices are already committed on your branch — build on their work, never redo or undo it. Later slices belong to their own sessions.
+
+- The acceptance criteria above apply to your slice's changes, not the whole issue at once.
+- Leave the tree green at your boundary: checks (`make test`, `make lint`) run after every slice.
+- Commit your work with the same message quality as below; anything left uncommitted is swept into a generic `slice N/M` commit by the runtime.
+- The runtime pushes each slice and opens the single PR after the final slice — never open a PR yourself.
 
 ## PR and commit quality
 


### PR DESCRIPTION
Rollout PR for per-slice minion builds — exactly three changes, nothing else:

- `.minions/programs/implement.md` opts into slice-aware execution (`slices: true`) and gains a "Slice builds" section instructing agents to build only their assigned slice, consistent with the runtime's injected directive.
- `.github/workflows/minion.yml` raises `timeout-minutes` 30 → 60 so multi-slice builds fit.
- Same file bumps the pin `minions@v0.0.10` → `@v0.0.11`.

**Merge order — do not merge yet.** The pin must reference an existing tag:

1. Merge partio-io/minions#141 (the runtime feature).
2. Publish the [v0.0.11 draft release](https://github.com/partio-io/minions/releases) — publishing creates the tag on `main`.
3. Merge this PR.
4. Staged verification: add the `minion-approved` label to #561 (2-slice plan → expect two slice sessions, `minion:slice N/2` marker commits, one branch, one PR, normal done flow), then to #562 (plan-less control → expect today's single-session build).

Deliberately untouched: `plan.yml`, `doc-minion.yml`, `propose.yml`, and `research.yml` keep their v0.0.10 pins — out of scope for this rollout; v0.0.11 is backward compatible whenever they're bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)