### PR TITLE
docs: add staged-run verification note

### DIFF
--- a/docs/staged-run-verification.md
+++ b/docs/staged-run-verification.md
@@ -3,3 +3,11 @@
 ## Overview
 
 A staged minion run verifies that a slice-aware build produces the expected `minion:slice N/M` marker commits on a single `minion/implement-*` branch throughout the multi-slice execution. It confirms that each slice session completes independently, that all work lands on one branch with a single PR, and that the issue is closed by the normal done flow after all slices finish.
+
+## Checklist
+
+After a staged run, eyeball the following:
+
+- [ ] `minion:slice N/M` marker commits are present on the branch (one per slice)
+- [ ] All slice work landed on a single `minion/implement-<issue>` branch with one PR
+- [ ] The issue was closed by the normal done flow (not manually)

--- a/docs/staged-run-verification.md
+++ b/docs/staged-run-verification.md
@@ -1,0 +1,5 @@
+# Staged-run verification
+
+## Overview
+
+A staged minion run verifies that a slice-aware build produces the expected `minion:slice N/M` marker commits on a single `minion/implement-*` branch throughout the multi-slice execution. It confirms that each slice session completes independently, that all work lands on one branch with a single PR, and that the issue is closed by the normal done flow after all slices finish.


### PR DESCRIPTION
## Summary

- Creates `docs/staged-run-verification.md` with a `# Staged-run verification` title and `## Overview` section
- The overview describes what a staged minion run verifies: slice marker commits, single branch/PR, and clean done flow

## Why

Part of the staged minion build smoke test (issue #561, Slice 1/2). Adds contributor documentation explaining what to look for when verifying a staged per-slice minion run.

## Test plan

- [x] `make test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)