### PR TITLE
docs: add staged-run-control.md to verify plan-less single-session builds

### DIFF
--- a/docs/staged-run-control.md
+++ b/docs/staged-run-control.md
@@ -1,0 +1,1 @@
+This file verifies plan-less minion builds still run single-session.


### PR DESCRIPTION
## Summary

- Creates `docs/staged-run-control.md` with the required one-line verification note
- This file serves as a control artifact for the per-slice minion builds rollout (minions v0.0.11), confirming that plan-less issues (no `minion:slice` marker) still run as a single session

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [ ] Safe to close and revert after verification per issue description

🤖 Generated with [Claude Code](https://claude.com/claude-code)