### PR TITLE
[minion] docs: add staged-run-control verification file

### DIFF
--- a/docs/staged-run-control.md
+++ b/docs/staged-run-control.md
@@ -1,0 +1,1 @@
+This file verifies plan-less minion builds still run single-session.


### PR DESCRIPTION
## Objective

Adds `docs/staged-run-control.md` as a control artifact to verify that plan-less minion builds (issues without a slice plan comment) still execute single-session without `minion:slice` marker commits after the per-slice builds rollout in minions v0.0.11.

This file can be reverted once verification is complete.

## Acceptance Criteria

- [ ] All changes match what the issue describes
- [ ] make test passes
- [ ] make lint passes
- [ ] PR description clearly explains what changed and why
- [ ] Commit messages are meaningful and describe the change

---

Automated PR by [partio-io/cli](https://github.com/partio-io/cli) · Task: `implement-implement-562`

*Created by an unattended coding agent. Please review carefully.*

Closes #562