### PR TITLE
Bump minions pin to v0.0.12 across all workflows

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.10
+          go install github.com/partio-io/minions/cmd/minions@v0.0.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Resolve source PR reference

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.11
+          go install github.com/partio-io/minions/cmd/minions@v0.0.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.10
+          go install github.com/partio-io/minions/cmd/minions@v0.0.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.10
+          go install github.com/partio-io/minions/cmd/minions@v0.0.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.10
+          go install github.com/partio-io/minions/cmd/minions@v0.0.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program


### PR DESCRIPTION
Ships the post-rollout hardening ([minions v0.0.12](https://github.com/partio-io/minions/releases/tag/v0.0.12), partio-io/minions#143): sessions can no longer `git push` or `gh pr create` themselves, and the runtime adopts an existing open PR instead of failing with "already exists".

All five workflows move to v0.0.12 — `minion.yml` from v0.0.11; `plan.yml`, `doc-minion.yml`, `propose.yml`, `research.yml` from v0.0.10, ending the pin drift. The v0.0.11 slice support they pick up on the way is opt-in per program (`slices: true`) and only `implement.md` opts in, so their behavior is unchanged apart from the hardening.

Tag exists and the Go proxy + checksum DB already serve v0.0.12 (both verified 200), so the first build after merge won't hit the fresh-tag install lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)