### PR TITLE
[minion] Add staged-run verification note for minion slice builds

### DIFF
--- a/docs/staged-run-verification.md
+++ b/docs/staged-run-verification.md
@@ -1,0 +1,5 @@
+# Staged-run verification
+
+## Overview
+
+A staged minion run verifies that a slice-aware build correctly produces `minion:slice N/M` marker commits on a single branch across multiple independent sessions. Each slice session builds its assigned slice and commits with the appropriate marker, ensuring all work lands on one branch with a single PR and closes through the normal done flow.

--- a/docs/staged-run-verification.md
+++ b/docs/staged-run-verification.md
@@ -3,3 +3,11 @@
 ## Overview
 
 A staged minion run verifies that a slice-aware build correctly produces `minion:slice N/M` marker commits on a single branch across multiple independent sessions. Each slice session builds its assigned slice and commits with the appropriate marker, ensuring all work lands on one branch with a single PR and closes through the normal done flow.
+
+## Checklist
+
+After a staged run, eyeball the following:
+
+- [ ] `minion:slice N/M` marker commits are present — one per slice, in order, on the branch.
+- [ ] All work is on a single minion branch with one PR (no extra branches or duplicate PRs).
+- [ ] The issue is closed by the normal done flow (not manually).


### PR DESCRIPTION
## Objective

Adds `docs/staged-run-verification.md` with an overview and checklist for verifying staged minion runs. The doc explains what a slice-aware build should produce (marker commits, single branch, clean done flow) and lists three things to eyeball after a run: `minion:slice N/M` commits present, all work on one branch with one PR, and issue closed via normal done flow.

Implemented in two slices per the issue plan — slice 1 created the file with the overview, slice 2 appended the checklist section.

To verify: check that `docs/staged-run-verification.md` exists with both `## Overview` and `## Checklist` sections, and that `make test` and `make lint` pass.

## Acceptance Criteria

- [ ] All changes match what the issue describes
- [ ] make test passes
- [ ] make lint passes
- [ ] PR description clearly explains what changed and why
- [ ] Commit messages are meaningful and describe the change

---

Automated PR by [partio-io/cli](https://github.com/partio-io/cli) · Task: `implement-implement-581`

*Created by an unattended coding agent. Please review carefully.*

Closes #581