### PR TITLE
Bump minions pin to v0.0.13 across all workflows

### DIFF
--- a/.github/workflows/doc-minion.yml
+++ b/.github/workflows/doc-minion.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.12
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Resolve source PR reference

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.12
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.12
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Determine program

--- a/.github/workflows/propose.yml
+++ b/.github/workflows/propose.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.12
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run propose program

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install minions
         run: |
-          go install github.com/partio-io/minions/cmd/minions@v0.0.12
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run program


### PR DESCRIPTION
Ships the stale-push-lease fix ([minions v0.0.13](https://github.com/partio-io/minions/releases/tag/v0.0.13), partio-io/minions#144): re-running an issue whose `minion/*` branch was deleted server-side no longer dies with `--force-with-lease ... (stale info)` — the runtime refreshes the lease before every push. All five workflows move v0.0.12 → v0.0.13.

Tag exists and the Go proxy + checksum DB already serve v0.0.13 (verified 200), so the first build after merge won't hit the fresh-tag lag.

After merging, the cheap production regression test: re-trigger #561 by cycling `minion-approved` — its deleted branch + the runner clone's stale tracking ref are exactly the fixed scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)