### PR TITLE
[minion] fix: prevent second commit in active session from being skipped

### DIFF
--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -99,10 +99,15 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		)
 	}
 
+	// Determine whether the agent is still running at the time post-commit fires.
+	// This governs both the skip check and whether MarkCondensed transitions the
+	// session to StateEnded.
+	agentStillRunning, _ := detector.IsRunning()
+
 	// Skip if this session is already fully condensed and ended — re-processing
 	// it produces a redundant checkpoint with no new content.
 	if sessionData != nil && sessionData.SessionID != "" {
-		if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sessionData.SessionID, sessionPath) {
+		if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sessionData.SessionID, sessionPath, agentStillRunning) {
 			slog.Warn("post-commit: no checkpoint created", "reason", "session already condensed", "commit", commitHash, "session_id", sessionData.SessionID)
 			return nil
 		}
@@ -196,10 +201,12 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 	}
 
 	// Mark the session as condensed so subsequent commits with the same session
-	// are skipped. This is best-effort; failure is non-fatal.
+	// are skipped. Pass agentStillRunning so MarkCondensed can avoid setting
+	// StateEnded while the agent is still active — that would cause the next
+	// commit in the same session to be incorrectly skipped.
 	if sessionData != nil && sessionData.SessionID != "" {
 		mgr := session.NewManager(filepath.Join(repoRoot, config.PartioDir))
-		if markErr := mgr.MarkCondensed(sessionData.SessionID); markErr != nil {
+		if markErr := mgr.MarkCondensed(sessionData.SessionID, agentStillRunning); markErr != nil {
 			slog.Debug("could not mark session as condensed", "error", markErr)
 		}
 	}

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -60,12 +60,15 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 	}
 
 	// Check for condensed sessions (Claude-specific optimisation).
+	// Pass agentRunning=true because we already confirmed the agent is active;
+	// shouldSkipSession will return false immediately and we will not suppress
+	// the checkpoint for a second commit made during the same live session.
 	if running {
 		if cd, ok := detector.(*claude.Detector); ok {
 			latestPath, pathErr := cd.FindLatestJSONLPath(repoRoot)
 			if pathErr == nil {
 				sid := claude.PeekSessionID(latestPath)
-				if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sid, latestPath) {
+				if shouldSkipSession(filepath.Join(repoRoot, config.PartioDir), sid, latestPath, true) {
 					slog.Debug("skipping already-condensed ended session", "session_id", sid)
 					running = false
 				}
@@ -143,7 +146,12 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 // sessionID has already been fully captured (condensed + ended) and the JSONL
 // at sessionPath has not been modified since the capture time. Both ENDED and
 // Condensed must be set; IDLE or ACTIVE sessions are never skipped.
-func shouldSkipSession(partioDir, sessionID, sessionPath string) bool {
+// When agentRunning is true the function always returns false — an active agent
+// may make additional commits that each deserve their own checkpoint.
+func shouldSkipSession(partioDir, sessionID, sessionPath string, agentRunning bool) bool {
+	if agentRunning {
+		return false
+	}
 	if sessionID == "" || sessionPath == "" {
 		return false
 	}

--- a/internal/hooks/precommit_test.go
+++ b/internal/hooks/precommit_test.go
@@ -14,6 +14,7 @@ func TestShouldSkipSession(t *testing.T) {
 		name         string
 		setup        func(t *testing.T, partioDir, jsonlPath string)
 		sessionID    string
+		agentRunning bool
 		modifyJSONL  bool // touch JSONL after marking condensed to simulate new content
 		wantSkip     bool
 	}{
@@ -21,7 +22,7 @@ func TestShouldSkipSession(t *testing.T) {
 			name: "skip when ended and condensed with matching session ID",
 			setup: func(t *testing.T, partioDir, jsonlPath string) {
 				mgr := session.NewManager(partioDir)
-				if err := mgr.MarkCondensed("sess-123"); err != nil {
+				if err := mgr.MarkCondensed("sess-123", false); err != nil {
 					t.Fatalf("MarkCondensed: %v", err)
 				}
 			},
@@ -29,10 +30,22 @@ func TestShouldSkipSession(t *testing.T) {
 			wantSkip:  true,
 		},
 		{
+			name: "do not skip when agent is still running even if session is condensed",
+			setup: func(t *testing.T, partioDir, jsonlPath string) {
+				mgr := session.NewManager(partioDir)
+				if err := mgr.MarkCondensed("sess-123", false); err != nil {
+					t.Fatalf("MarkCondensed: %v", err)
+				}
+			},
+			sessionID:    "sess-123",
+			agentRunning: true,
+			wantSkip:     false,
+		},
+		{
 			name: "do not skip when session ID does not match",
 			setup: func(t *testing.T, partioDir, jsonlPath string) {
 				mgr := session.NewManager(partioDir)
-				if err := mgr.MarkCondensed("sess-other"); err != nil {
+				if err := mgr.MarkCondensed("sess-other", false); err != nil {
 					t.Fatalf("MarkCondensed: %v", err)
 				}
 			},
@@ -61,7 +74,7 @@ func TestShouldSkipSession(t *testing.T) {
 			name: "do not skip when JSONL was modified after capture",
 			setup: func(t *testing.T, partioDir, jsonlPath string) {
 				mgr := session.NewManager(partioDir)
-				if err := mgr.MarkCondensed("sess-123"); err != nil {
+				if err := mgr.MarkCondensed("sess-123", false); err != nil {
 					t.Fatalf("MarkCondensed: %v", err)
 				}
 			},
@@ -98,7 +111,7 @@ func TestShouldSkipSession(t *testing.T) {
 				}
 			}
 
-			got := shouldSkipSession(partioDir, tt.sessionID, jsonlPath)
+			got := shouldSkipSession(partioDir, tt.sessionID, jsonlPath, tt.agentRunning)
 			if got != tt.wantSkip {
 				t.Errorf("shouldSkipSession() = %v, want %v", got, tt.wantSkip)
 			}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -32,10 +32,12 @@ func (m *Manager) currentPath() string {
 	return filepath.Join(m.stateDir, "current.json")
 }
 
-// MarkCondensed marks the current session as ended and fully condensed with the
-// given Claude session ID. Future hook runs that see the same session ID and an
-// unmodified JSONL file will skip checkpoint creation.
-func (m *Manager) MarkCondensed(capturedSessionID string) error {
+// MarkCondensed marks the current session as fully condensed with the given
+// agent session ID. When agentRunning is false, the session state is also
+// transitioned to StateEnded so future hook runs can skip it. When
+// agentRunning is true, StateEnded is not set — the agent may still make
+// additional commits in this session that should receive checkpoints.
+func (m *Manager) MarkCondensed(capturedSessionID string, agentRunning bool) error {
 	s, err := m.Current()
 	if err != nil {
 		return err
@@ -47,7 +49,9 @@ func (m *Manager) MarkCondensed(capturedSessionID string) error {
 		}
 		s = &Session{}
 	}
-	s.State = StateEnded
+	if !agentRunning {
+		s.State = StateEnded
+	}
 	s.Condensed = true
 	s.CapturedSessionID = capturedSessionID
 	s.CapturedAt = time.Now()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -69,7 +69,7 @@ func TestManagerEnd(t *testing.T) {
 }
 
 func TestManagerMarkCondensed(t *testing.T) {
-	t.Run("marks existing session as condensed and ended", func(t *testing.T) {
+	t.Run("marks existing session as condensed and ended when agent not running", func(t *testing.T) {
 		dir := t.TempDir()
 		mgr := NewManager(dir)
 
@@ -78,7 +78,7 @@ func TestManagerMarkCondensed(t *testing.T) {
 			t.Fatalf("start error: %v", err)
 		}
 
-		if err := mgr.MarkCondensed("sess-abc"); err != nil {
+		if err := mgr.MarkCondensed("sess-abc", false); err != nil {
 			t.Fatalf("mark condensed error: %v", err)
 		}
 
@@ -100,11 +100,39 @@ func TestManagerMarkCondensed(t *testing.T) {
 		}
 	})
 
+	t.Run("does not set StateEnded when agent is still running", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+
+		_, err := mgr.Start("claude-code", "main", "/tmp/test")
+		if err != nil {
+			t.Fatalf("start error: %v", err)
+		}
+
+		if err := mgr.MarkCondensed("sess-abc", true); err != nil {
+			t.Fatalf("mark condensed error: %v", err)
+		}
+
+		cur, err := mgr.Current()
+		if err != nil {
+			t.Fatalf("current error: %v", err)
+		}
+		if cur.State == StateEnded {
+			t.Errorf("expected state to not be ended while agent is running, got %s", cur.State)
+		}
+		if !cur.Condensed {
+			t.Error("expected condensed=true")
+		}
+		if cur.CapturedSessionID != "sess-abc" {
+			t.Errorf("expected captured_session_id=sess-abc, got %s", cur.CapturedSessionID)
+		}
+	})
+
 	t.Run("creates session entry when none exists", func(t *testing.T) {
 		dir := t.TempDir()
 		mgr := NewManager(dir)
 
-		if err := mgr.MarkCondensed("sess-xyz"); err != nil {
+		if err := mgr.MarkCondensed("sess-xyz", false); err != nil {
 			t.Fatalf("mark condensed error: %v", err)
 		}
 

--- a/internal/session/record_test.go
+++ b/internal/session/record_test.go
@@ -53,7 +53,7 @@ func TestRecordActive_ReplacesEndedSession(t *testing.T) {
 
 	// A previously ended/condensed session must not be refreshed — new agent
 	// activity should start a fresh ACTIVE session.
-	if err := mgr.MarkCondensed("sess-1"); err != nil {
+	if err := mgr.MarkCondensed("sess-1", false); err != nil {
 		t.Fatalf("MarkCondensed: %v", err)
 	}
 


### PR DESCRIPTION
## Objective

`MarkCondensed` was unconditionally setting `State = StateEnded`, which caused `shouldSkipSession` to skip checkpoint creation for any subsequent commit made before the agent wrote new JSONL content. This meant only the first commit per Claude Code session received a `Partio-Checkpoint` trailer.

**Changes:**
- `MarkCondensed(id string, agentRunning bool)` — only transitions to `StateEnded` when `agentRunning` is false
- `shouldSkipSession(..., agentRunning bool)` — returns false immediately when the agent is active, bypassing all other skip logic
- `postcommit.go` calls `detector.IsRunning()` once and passes the result to both `shouldSkipSession` and `MarkCondensed`
- `precommit.go` passes `agentRunning=true` to `shouldSkipSession` (agent already confirmed running at that point)

**Testing:**
- New test case in `precommit_test.go`: condensed session with `agentRunning=true` returns `wantSkip=false`
- New test case in `manager_test.go`: `MarkCondensed` with `agentRunning=true` leaves state as non-ended
- Existing skip behaviour preserved: agent exited + unmodified JSONL still skips

## Acceptance Criteria

- [ ] All changes match what the issue describes
- [ ] make test passes
- [ ] make lint passes
- [ ] PR description clearly explains what changed and why
- [ ] Commit messages are meaningful and describe the change

---

Automated PR by [partio-io/cli](https://github.com/partio-io/cli) · Task: `implement-implement-577`

*Created by an unattended coding agent. Please review carefully.*

Closes #577