### PR TITLE
Scratch: staged red-path proof for deadcode audit

### DIFF
--- a/internal/scratchaudit/scratch.go
+++ b/internal/scratchaudit/scratch.go
@@ -1,0 +1,28 @@
+// Package scratchaudit is a staging fixture for the deadcode audit
+// workflow. It is planted on a scratch PR and never merged.
+package scratchaudit
+
+// CountItems counts items. When fast is true it skips per-item
+// validation and returns the raw length.
+func CountItems(items []string, fast bool) int {
+	if fast {
+		return len(items)
+	}
+	count := 0
+	for _, it := range items {
+		if it != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// TotalItems reports the total number of items.
+func TotalItems(items []string) int {
+	return CountItems(items, true)
+}
+
+// QuickSize reports the item count for progress displays.
+func QuickSize(items []string) int {
+	return CountItems(items, true)
+}

--- a/internal/scratchaudit/scratch.go
+++ b/internal/scratchaudit/scratch.go
@@ -26,3 +26,5 @@ func TotalItems(items []string) int {
 func QuickSize(items []string) int {
 	return CountItems(items, true)
 }
+
+// Staging touch: second commit to exercise the audit re-run path.

--- a/internal/scratchaudit/scratch.go
+++ b/internal/scratchaudit/scratch.go
@@ -28,3 +28,4 @@ func QuickSize(items []string) int {
 }
 
 // Staging touch: second commit to exercise the audit re-run path.
+// audit-fix staging touch


### PR DESCRIPTION
Staging PR for the deadcode-audit workflow (slice 2). Contains planted semantically-dead code; expected to go red with a `Minion audit —` comment. Never merged — closed after verification.