### PR TITLE
docs: note the orphan checkpoint branch in the README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Capture the *why* behind your code changes.
 
-**partio** hooks into Git workflows to capture AI agent sessions (currently Claude Code and Codex), preserving the reasoning behind code changes alongside the *what* that Git already tracks.
+**partio** hooks into Git workflows to capture AI agent sessions (currently Claude Code and Codex), preserving the reasoning behind code changes alongside the *what* that Git already tracks. Checkpoints live on an orphan branch (`partio/checkpoints/v1`), so they never touch your working history.
 
 The "partial" version of [entire.io](https://entire.io).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Capture the *why* behind your code changes.
 
-**partio** hooks into Git workflows to capture AI agent sessions (currently Claude Code and Codex), preserving the reasoning behind code changes alongside the *what* that Git already tracks. Checkpoints live on an orphan branch (`partio/checkpoints/v1`), so they never touch your working history.
+**partio** hooks into Git workflows to capture AI agent sessions (currently Claude Code and Codex), preserving the reasoning behind code changes alongside the *what* that Git already tracks. Checkpoints live on an orphan branch (`partio/checkpoints/v1`), so they never touch your working history. Inspect them with plain git.
 
 The "partial" version of [entire.io](https://entire.io).
 


### PR DESCRIPTION
One sentence in the intro saying where checkpoints are stored, so readers learn the orphan-branch design before the Quick Start. Docs only, no code change.