### PR TITLE
fix: prevent second rapid commit from losing its checkpoint trailer

### DIFF
--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -27,9 +27,10 @@ func (r *Runner) PostCommit() error {
 }
 
 func runPostCommit(repoRoot string, cfg config.Config) error {
-	// Read pre-commit state
+	// Read pre-commit state, tolerating a brief lag on fast
+	// follow-up commits where pre-commit's write is not yet visible.
 	stateFile := filepath.Join(repoRoot, config.PartioDir, "state", "pre-commit.json")
-	data, err := os.ReadFile(stateFile)
+	data, err := readStateWithRetry(stateFile, 5, 100*time.Millisecond)
 	if err != nil {
 		slog.Warn("post-commit: no checkpoint created", "reason", "no pre-commit state found", "state_file", stateFile)
 		return nil

--- a/internal/hooks/state_retry.go
+++ b/internal/hooks/state_retry.go
@@ -11,7 +11,7 @@ import (
 // it does not exist yet. Pre-commit writes the state and post-commit
 // consumes it; on a fast follow-up commit the second post-commit can
 // fire before the second pre-commit's write is visible, so a bounded
-// retry bridges the handoff instead of silently skipping the
+// retry bridges the handoff instead of silently dropping the
 // checkpoint.
 func readStateWithRetry(path string, attempts int, delay time.Duration) ([]byte, error) {
 	var lastErr error

--- a/internal/hooks/state_retry.go
+++ b/internal/hooks/state_retry.go
@@ -1,0 +1,30 @@
+package hooks
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"time"
+)
+
+// readStateWithRetry reads the pre-commit state file, retrying while
+// it does not exist yet. Pre-commit writes the state and post-commit
+// consumes it; on a fast follow-up commit the second post-commit can
+// fire before the second pre-commit's write is visible, so a bounded
+// retry bridges the handoff instead of silently skipping the
+// checkpoint.
+func readStateWithRetry(path string, attempts int, delay time.Duration) ([]byte, error) {
+	var lastErr error
+	for range attempts {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return data, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		lastErr = err
+		time.Sleep(delay)
+	}
+	return nil, lastErr
+}

--- a/internal/hooks/state_retry_test.go
+++ b/internal/hooks/state_retry_test.go
@@ -1,0 +1,61 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReadStateWithRetryReturnsDataOnceFileAppears(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pre-commit.json")
+
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		if err := os.WriteFile(path, []byte(`{"agent_active":true}`), 0o644); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	data, err := readStateWithRetry(path, 10, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected retry to pick up the late state file, got %v", err)
+	}
+	if string(data) != `{"agent_active":true}` {
+		t.Fatalf("unexpected state contents: %s", data)
+	}
+}
+
+func TestReadStateWithRetryGivesUpAfterAttempts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pre-commit.json")
+
+	start := time.Now()
+	_, err := readStateWithRetry(path, 3, 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error when the state file never appears")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("retry took too long: %v", elapsed)
+	}
+}
+
+func TestReadStateWithRetryPropagatesNonNotExistErrors(t *testing.T) {
+	dir := t.TempDir()
+	// A directory at the path makes ReadFile fail with a non-NotExist
+	// error, which must not be retried.
+	path := filepath.Join(dir, "state-as-dir")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	_, err := readStateWithRetry(path, 10, 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error reading a directory")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("non-NotExist error should fail fast, took %v", elapsed)
+	}
+}


### PR DESCRIPTION
Two rapid commits in one live session must both get trailers: pre-commit writes the agent state, post-commit consumes it, and on a fast follow-up commit the second post-commit could fire before the second state write was visible — silently skipping the checkpoint.

This bounds that race with a retrying state read (5 attempts, 100ms apart) in post-commit.

Verified with unit tests of the retry helper (late-appearing file picked up, bounded give-up, fast-fail on non-NotExist errors), alongside the existing pre-commit state-write tests.