### PR TITLE
Minion PR audits: lint gate, deadcode + e2e-need audits, liveness proposal

### DIFF
--- a/.github/workflows/deadcode-audit.yml
+++ b/.github/workflows/deadcode-audit.yml
@@ -1,0 +1,96 @@
+name: Deadcode Audit
+
+on:
+  pull_request:
+    types: [opened, labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_ref:
+        description: "PR reference to audit (e.g., 123 or org/repo#123)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (prompt generation only)"
+        required: false
+        default: false
+        type: boolean
+
+# One live audit per PR; a newer head supersedes the run in flight.
+concurrency:
+  group: deadcode-audit-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'minion') &&
+       !contains(github.event.pull_request.labels.*.name, 'no-audit'))
+    runs-on: github-runner-partio-minion-ai-01
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve PR reference
+        id: src
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            REF="${{ inputs.pr_ref }}"
+            echo "pr_ref=${REF}" >> "$GITHUB_OUTPUT"
+            echo "pr_num=${REF##*#}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_ref=${{ github.repository }}#${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "pr_num=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Loop guard
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.src.outputs.pr_num }}" --jq .head.sha)
+          SUBJECT=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}" --jq .commit.message | head -n1)
+          case "$SUBJECT" in
+            "audit:"*)
+              echo "Head commit is an audit fix ('${SUBJECT}'); skipping to avoid an audit loop."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Install minions
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Run deadcode audit
+        if: steps.guard.outputs.skip != 'true'
+        # On real runs the verdict gate owns the outcome, so a crashed
+        # audit session must not end the job before the gate fails it
+        # closed. Dry runs have no gate and fail here normally.
+        continue-on-error: ${{ steps.src.outputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          # The audit session runs in an isolated minions worktree, so
+          # the verdict must be written to an absolute path in this
+          # workspace for the gate step to find it.
+          MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-audit
+        run: |
+          rm -rf .minion-audit
+          ARGS="run .minions/programs/deadcode-audit.md --pr ${{ steps.src.outputs.pr_ref }}"
+          if [ "${{ steps.src.outputs.dry_run }}" = "true" ]; then
+            ARGS="${ARGS} --dry-run"
+          fi
+          minions $ARGS
+
+      - name: Verdict gate
+        if: steps.guard.outputs.skip != 'true' && steps.src.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: go run ./cmd/minion-audit-gate --pr ${{ steps.src.outputs.pr_num }} --audit dead-code

--- a/.github/workflows/deadcode-audit.yml
+++ b/.github/workflows/deadcode-audit.yml
@@ -15,23 +15,26 @@ on:
         default: false
         type: boolean
 
-# One live audit per PR; a newer head supersedes the run in flight.
-concurrency:
-  group: deadcode-audit-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+# Concurrency lives on the audit job, not the workflow: the fix
+# round's own push triggers a guard-skipped run, and a workflow-level
+# group would let that run cancel the in-flight job doing the fixing.
+# A skipped audit job never enters the group, so only runs that will
+# actually audit supersede each other.
 
 jobs:
-  audit:
+  guard:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (contains(github.event.pull_request.labels.*.name, 'minion') &&
        !contains(github.event.pull_request.labels.*.name, 'no-audit'))
     runs-on: github-runner-partio-minion-ai-01
-    timeout-minutes: 30
+    timeout-minutes: 5
+    outputs:
+      pr_ref: ${{ steps.src.outputs.pr_ref }}
+      pr_num: ${{ steps.src.outputs.pr_num }}
+      dry_run: ${{ steps.src.outputs.dry_run }}
+      skip: ${{ steps.guard.outputs.skip }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Resolve PR reference
         id: src
         run: |
@@ -63,18 +66,39 @@ jobs:
               ;;
           esac
 
+  audit:
+    needs: guard
+    if: needs.guard.outputs.skip != 'true'
+    concurrency:
+      group: deadcode-audit-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
+    runs-on: github-runner-partio-minion-ai-01
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # The apply step pushes with the PAT explicitly: a push with
+          # the checkout-persisted GITHUB_TOKEN would not trigger the
+          # guard-skipped follow-up run the loop guard exists for.
+          persist-credentials: false
+
       - name: Install minions
-        if: steps.guard.outputs.skip != 'true'
         run: |
           go install github.com/partio-io/minions/cmd/minions@v0.0.13
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      # The fix session proves its repair with the repo's own checks;
+      # make lint needs the binary on the runner's PATH.
+      - name: Install golangci-lint
+        if: needs.guard.outputs.dry_run != 'true'
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
       - name: Run deadcode audit
-        if: steps.guard.outputs.skip != 'true'
         # On real runs the verdict gate owns the outcome, so a crashed
         # audit session must not end the job before the gate fails it
         # closed. Dry runs have no gate and fail here normally.
-        continue-on-error: ${{ steps.src.outputs.dry_run != 'true' }}
+        continue-on-error: ${{ needs.guard.outputs.dry_run != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           # The audit session runs in an isolated minions worktree, so
@@ -83,14 +107,102 @@ jobs:
           MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-audit
         run: |
           rm -rf .minion-audit
-          ARGS="run .minions/programs/deadcode-audit.md --pr ${{ steps.src.outputs.pr_ref }}"
-          if [ "${{ steps.src.outputs.dry_run }}" = "true" ]; then
+          ARGS="run .minions/programs/deadcode-audit.md --pr ${{ needs.guard.outputs.pr_ref }}"
+          if [ "${{ needs.guard.outputs.dry_run }}" = "true" ]; then
             ARGS="${ARGS} --dry-run"
           fi
           minions $ARGS
 
-      - name: Verdict gate
-        if: steps.guard.outputs.skip != 'true' && steps.src.outputs.dry_run != 'true'
+      # Branch point for the fix round. Parsed with plain shell — the
+      # runner is minimal Debian and jq is not a given. An absent or
+      # malformed verdict yields an empty status: no fix round, and
+      # the gate fails it closed at the end.
+      - name: Read verdict
+        id: verdict
+        if: needs.guard.outputs.dry_run != 'true'
+        run: |
+          STATUS=""
+          if [ -f .minion-audit/verdict.json ]; then
+            STATUS=$(tr -d ' \n\t' < .minion-audit/verdict.json | grep -o '"status":"[a-z]*"' | head -n1 | cut -d'"' -f4 || true)
+          fi
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+          echo "Verdict status: '${STATUS}'"
+
+      # Exactly one fix attempt, ever: this step has no retry and the
+      # loop guard keeps the pushed commit from starting a new round.
+      # The session only emits a checked patch to .minion-audit/ — it
+      # never commits or pushes; the apply step below owns that.
+      - name: Fix round
+        if: steps.verdict.outputs.status == 'fail'
+        # A crashed fix session is a failed fix round, not a broken
+        # job — the re-audit or the gate still owns the outcome.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: go run ./cmd/minion-audit-gate --pr ${{ steps.src.outputs.pr_num }} --audit dead-code
+          MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-audit
+        run: minions run .minions/programs/deadcode-audit-fix.md --pr ${{ needs.guard.outputs.pr_ref }}
+
+      # Deterministic half of the fix round: apply the session's
+      # patch to the true PR head, prove it with the repo's own
+      # checks, and push one audit-prefixed commit with the PAT (a
+      # GITHUB_TOKEN push would suppress the follow-up run). Any
+      # failure leaves pushed=false and the first verdict stands.
+      - name: Apply fix
+        id: fixpush
+        if: steps.verdict.outputs.status == 'fail'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PUSHED=false
+          PATCH="${{ github.workspace }}/.minion-audit/fix.patch"
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          if [ -s "$PATCH" ]; then
+            HEAD_REF=$(gh api "repos/${{ github.repository }}/pulls/${{ needs.guard.outputs.pr_num }}" --jq .head.ref)
+            HEAD_REPO=$(gh api "repos/${{ github.repository }}/pulls/${{ needs.guard.outputs.pr_num }}" --jq .head.repo.full_name)
+            if [ "$HEAD_REPO" = "${{ github.repository }}" ]; then
+              git fetch --no-tags "$REMOTE" "$HEAD_REF"
+              WT="${RUNNER_TEMP}/audit-fixwt"
+              git worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
+              git worktree add --detach "$WT" FETCH_HEAD
+              BODY=""
+              if [ -f .minion-audit/fix-summary.txt ]; then
+                BODY=$(head -c 300 .minion-audit/fix-summary.txt)
+              fi
+              if git -C "$WT" apply --index "$PATCH" \
+                && (cd "$WT" && make lint && make test); then
+                git -C "$WT" -c user.name="minion audit" -c user.email="minions@partio.io" \
+                  commit -m "audit: fix dead-code findings (#${{ needs.guard.outputs.pr_num }})" -m "$BODY"
+                if git -C "$WT" push "$REMOTE" HEAD:"$HEAD_REF"; then
+                  PUSHED=true
+                fi
+              else
+                echo "Patch did not apply or failed checks; pushing nothing."
+              fi
+              git worktree remove --force "$WT" || true
+            else
+              echo "PR head lives in a fork; the fix round cannot push there."
+            fi
+          else
+            echo "Fix session exported no patch; the first verdict stands."
+          fi
+          echo "pushed=${PUSHED}" >> "$GITHUB_OUTPUT"
+
+      # Fresh session, final verdict. Only runs when the fix round
+      # actually moved the branch — an unchanged head would re-derive
+      # the verdict the gate already holds.
+      - name: Re-audit
+        if: steps.fixpush.outputs.pushed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-audit
+        run: |
+          rm -rf .minion-audit
+          minions run .minions/programs/deadcode-audit.md --pr ${{ needs.guard.outputs.pr_ref }}
+
+      - name: Verdict gate
+        if: needs.guard.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: go run ./cmd/minion-audit-gate --pr ${{ needs.guard.outputs.pr_num }} --audit dead-code

--- a/.github/workflows/deadcode-audit.yml
+++ b/.github/workflows/deadcode-audit.yml
@@ -140,6 +140,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-audit
+          # Fresh lint cache per step: the shared cache replays issues
+          # recorded under other (since-deleted) worktrees, whose
+          # unreadable paths defeat the test-file exclusion rules.
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-cache-fix
         run: minions run .minions/programs/deadcode-audit-fix.md --pr ${{ needs.guard.outputs.pr_ref }}
 
       # Deterministic half of the fix round: apply the session's
@@ -153,6 +157,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-cache-apply
         run: |
           PUSHED=false
           PATCH="${{ github.workspace }}/.minion-audit/fix.patch"

--- a/.github/workflows/e2e-audit.yml
+++ b/.github/workflows/e2e-audit.yml
@@ -1,0 +1,112 @@
+name: E2e-need Audit
+
+on:
+  pull_request:
+    types: [opened, labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_ref:
+        description: "PR reference to audit (e.g., 123 or org/repo#123)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (prompt generation only)"
+        required: false
+        default: false
+        type: boolean
+
+# Concurrency lives on the audit job, not the workflow: the deadcode
+# audit's fix push triggers a guard-skipped run here too, and a
+# workflow-level group would let that run cancel an in-flight audit.
+# A skipped audit job never enters the group.
+
+jobs:
+  guard:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'minion') &&
+       !contains(github.event.pull_request.labels.*.name, 'no-audit'))
+    runs-on: github-runner-partio-minion-ai-01
+    timeout-minutes: 5
+    outputs:
+      pr_ref: ${{ steps.src.outputs.pr_ref }}
+      pr_num: ${{ steps.src.outputs.pr_num }}
+      dry_run: ${{ steps.src.outputs.dry_run }}
+      skip: ${{ steps.guard.outputs.skip }}
+    steps:
+      - name: Resolve PR reference
+        id: src
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            REF="${{ inputs.pr_ref }}"
+            echo "pr_ref=${REF}" >> "$GITHUB_OUTPUT"
+            echo "pr_num=${REF##*#}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_ref=${{ github.repository }}#${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "pr_num=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Loop guard
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.src.outputs.pr_num }}" --jq .head.sha)
+          SUBJECT=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}" --jq .commit.message | head -n1)
+          case "$SUBJECT" in
+            "audit:"*)
+              echo "Head commit is an audit fix ('${SUBJECT}'); skipping to avoid an audit loop."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  audit:
+    needs: guard
+    if: needs.guard.outputs.skip != 'true'
+    concurrency:
+      group: e2e-audit-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
+    runs-on: github-runner-partio-minion-ai-01
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # This checkout only runs the gate; the session's proposal
+          # push happens in the minions workspace with the PAT.
+          persist-credentials: false
+
+      - name: Install minions
+        run: |
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Run e2e-need audit
+        # On real runs the verdict gate owns the outcome, so a crashed
+        # audit session must not end the job before the gate fails it
+        # closed. Dry runs have no gate and fail here normally.
+        continue-on-error: ${{ needs.guard.outputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          # The audit session runs in an isolated minions worktree, so
+          # the verdict must be written to an absolute path in this
+          # workspace for the gate step to find it.
+          MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-audit
+        run: |
+          rm -rf .minion-audit
+          ARGS="run .minions/programs/e2e-audit.md --pr ${{ needs.guard.outputs.pr_ref }}"
+          if [ "${{ needs.guard.outputs.dry_run }}" = "true" ]; then
+            ARGS="${ARGS} --dry-run"
+          fi
+          minions $ARGS
+
+      - name: Verdict gate
+        if: needs.guard.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: go run ./cmd/minion-audit-gate --pr ${{ needs.guard.outputs.pr_num }} --audit e2e-need

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .partio/settings.local.json
 /partio
+.minion-audit/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,14 @@ linters:
     - govet
     - staticcheck
     - unused
-
-linters-settings:
-  errcheck:
-    check-blank: false
+  settings:
+    errcheck:
+      check-blank: true
+  exclusions:
+    rules:
+      # Tests may blank-discard errors (cleanup noise); the source match
+      # keeps errcheck's plain unchecked-call rule active in tests.
+      - path: _test\.go
+        linters:
+          - errcheck
+        source: '(^|[ \t,(])_(\s*[,=]|\s*:=)'

--- a/.minions/programs/deadcode-audit-fix.md
+++ b/.minions/programs/deadcode-audit-fix.md
@@ -1,0 +1,99 @@
+---
+id: deadcode-audit-fix
+target_repos:
+  - cli
+acceptance_criteria:
+  - "Every change in the exported patch addresses a specific finding in $MINION_AUDIT_DIR/verdict.json; no unrelated changes"
+  - "make lint and make test pass in the patched tree before the patch is exported"
+  - "The session runs no git write commands: no commit, no push, no branches, no PRs, no comments"
+  - "A patch is exported only when at least one finding was safely fixable and checks pass; otherwise nothing is exported"
+  - "The skip marker file is written as the session's final act on every path"
+---
+
+# Fix the dead code a minion audit found
+
+A dead-code audit just failed on a pull request of the cli repo. You
+get exactly one attempt to repair what it found: fix the findings in
+your worktree, prove the tree still passes the repo's own checks, and
+export the result as a patch. You do not commit or push — the
+workflow applies your patch, re-runs the checks, and pushes the fix
+commit deterministically. A re-audit with a fresh session judges the
+result — not you. There is no second attempt, so a fix you cannot
+verify is worse than no fix at all.
+
+The PR — its reference (`org/repo#number`), title, body, and full
+diff — is provided in the **## Pull Request** section of this prompt.
+The audit's findings are in `$MINION_AUDIT_DIR/verdict.json`: a
+`findings` list where each entry has a `location` (path:line at the
+PR head) and `reasoning` naming the chain that proves the code inert.
+
+## Agents
+
+### deadcode-audit-fix
+
+```capabilities
+max_turns: 50
+skip_marker: .minion-fix-done
+```
+
+Work through the repair in this order:
+
+1. **Read the findings.** Parse `$MINION_AUDIT_DIR/verdict.json`. If
+   it is missing, malformed, or its `findings` list is empty, write
+   the skip marker (step 6) and end without touching the repo.
+
+2. **Move to the PR head — your worktree is based on origin's
+   default branch, not the PR.** Resolve the head and detach onto
+   it before editing anything:
+
+   ```
+   gh pr view <pr-ref> --json headRefName,headRefOid
+   git fetch origin <head-ref-name>
+   git checkout --detach <head-ref-oid>
+   ```
+
+3. **Fix only what the reasoning proves.** For each finding, apply
+   the minimal repair that follows from its reasoning — usually
+   deleting the unreachable branch, the constant parameter, or the
+   never-called path, and simplifying the call sites the reasoning
+   names. Rules:
+
+   - Do not guess. If a repair requires a decision the finding does
+     not settle — choosing between two plausible behaviors, changing
+     a public contract, resurrecting the dead path instead of
+     removing it — leave that finding unfixed. A surviving finding
+     is the correct outcome for a fix that needs a human.
+   - No opportunistic edits. Style, naming, or refactors beyond the
+     findings are out of scope, however tempting.
+   - Keep each repair coherent: removing a branch that orphans a
+     variable means removing the variable too — the checks below
+     must pass.
+
+4. **Prove the tree with the repo's own checks.** Run `make lint`
+   and `make test` from the worktree root. Both must pass. If they
+   fail because of your edits, repair your edits and rerun. If you
+   cannot get both green, restore the tree (`git checkout -- .` and
+   delete files you added) and skip step 5 — exporting nothing is
+   the correct failed-round outcome.
+
+5. **Export the patch — only when checks pass and something was
+   fixed.**
+
+   ```
+   git add -A
+   git diff --cached --binary > "$MINION_AUDIT_DIR/fix.patch"
+   ```
+
+   Also write one plain-text line describing the repair to
+   `$MINION_AUDIT_DIR/fix-summary.txt` — it becomes the fix
+   commit's body.
+
+6. **Write the skip marker — always your final act.** Create the
+   empty file `.minion-fix-done` at the worktree root. This tells
+   the runtime the session's output is the exported patch, not a
+   branch: without it, leftover edits would be auto-committed to a
+   stray `minion/*` pull request.
+
+Never run `git commit`, `git push`, `gh pr create`, or post
+comments, on any path. Write outside the worktree only under
+`$MINION_AUDIT_DIR`.

--- a/.minions/programs/deadcode-audit-fix.md
+++ b/.minions/programs/deadcode-audit-fix.md
@@ -63,6 +63,13 @@ Work through the repair in this order:
      a public contract, resurrecting the dead path instead of
      removing it — leave that finding unfixed. A surviving finding
      is the correct outcome for a fix that needs a human.
+   - Hard rule, no judgment: never change or remove an exported
+     identifier — function, method, type, field, or any signature —
+     even when the finding proves part of it inert, and even if
+     that means fixing nothing. An exported contract is a design
+     decision by definition; a comment marking the choice as open
+     (a TODO, a "decide later") makes this absolute. Export-level
+     repairs always go to a human.
    - No opportunistic edits. Style, naming, or refactors beyond the
      findings are out of scope, however tempting.
    - Keep each repair coherent: removing a branch that orphans a

--- a/.minions/programs/deadcode-audit.md
+++ b/.minions/programs/deadcode-audit.md
@@ -1,0 +1,80 @@
+---
+id: deadcode-audit
+target_repos:
+  - cli
+acceptance_criteria:
+  - "The verdict file exists at $MINION_AUDIT_DIR/verdict.json and is valid JSON"
+  - "Verdict status is pass or fail; a fail carries at least one finding, each with location and reasoning"
+  - "The working tree is untouched: no edits, no commits, no branches, no PRs, no comments"
+---
+
+# Audit a PR for semantically dead code
+
+A pull request on the cli repo is under audit. Judge whether its diff
+introduces or reveals *semantically dead code*, then record your
+verdict. You change nothing: the workflow turns your verdict into the
+check outcome and the PR comment.
+
+The PR — its reference (`org/repo#number`), title, body, and full
+diff — is provided in the **## Pull Request** section of this prompt.
+
+Semantically dead code is code that is still invoked but provably
+inert. The canonical exemplar: a callee whose first branch
+short-circuits on a parameter that every remaining call site
+hardcodes, leaving the rest of the block unreachable. No
+deterministic tool flags this; your job is to reason about the diff
+and catch it.
+
+## Agents
+
+### deadcode-audit
+
+```capabilities
+max_turns: 40
+```
+
+Work through the audit in this order:
+
+1. **Read the diff.** For each hunk, ask what the change makes
+   unreachable, uncalled, or constant-folded — in the changed code
+   itself or in code it calls.
+
+2. **Verify against the PR's head state, not just the diff.** Your
+   working directory is a cli checkout, useful for structure and
+   grep, but it may lag the PR. For anything decisive — call sites,
+   callee bodies, who else passes this parameter — read files at the
+   PR head via `gh` (e.g. `gh api repos/<org>/<repo>/contents/<path>?ref=<head-sha>`
+   with header `Accept: application/vnd.github.raw+json`). A finding
+   must hold against the head state.
+
+3. **Judge conservatively.** Report only provable inertness — where
+   you can name the branch, the parameter, and every call site that
+   seals it. Style, duplication, and "probably unused" suspicions are
+   not findings. When you cannot prove it, it is a pass.
+
+4. **Write the verdict — your final act.** Create the directory and
+   write `$MINION_AUDIT_DIR/verdict.json`:
+
+   ```json
+   {
+     "status": "fail",
+     "findings": [
+       {
+         "location": "internal/foo/bar.go:42",
+         "reasoning": "callers X and Y both hardcode force=true, so the branch below the early return is unreachable"
+       }
+     ]
+   }
+   ```
+
+   `status` is `pass` or `fail`. A pass has `"findings": []`. A fail
+   has at least one finding; every finding needs a non-empty
+   `location` (path:line as in the head state) and `reasoning` naming
+   the exact chain that proves inertness. A missing or malformed file
+   is treated as a failed audit, so write it even when everything
+   passes.
+
+Do **not** edit files, run `git` write commands, open PRs, or post
+comments. Read-only `git`/`gh` is fine. The verdict file lives
+outside your checkout on purpose — leave the working tree exactly as
+you found it.

--- a/.minions/programs/e2e-audit.md
+++ b/.minions/programs/e2e-audit.md
@@ -69,7 +69,11 @@ Work through the audit in this order:
      `gh issue list --repo <org>/<repo> --label minion-proposal --state open --search "<id>" --limit 5`,
      and also scan the open proposals' titles for the same gap under
      a different id. If one already covers it, reuse it — record the
-     existing issue in your verdict reasoning and file nothing.
+     existing issue in your verdict reasoning and file nothing. One
+     repair applies: when the covering proposal's `<!-- program: ... -->`
+     file does not exist on `origin/main`, write that file (step
+     above) and push it (step 5) so the proposal stays buildable —
+     still without filing a new issue.
    - Write a program file to `.minions/programs/<id>.md` with
      frontmatter (`id`, `target_repos`, `acceptance_criteria`,
      `pr_labels`) and a body that tells a fresh minion session
@@ -84,17 +88,22 @@ Work through the audit in this order:
      file, and the marker
      `<!-- program: .minions/programs/<id>.md -->`.
 
-5. **Commit and push the program files** the way the propose program
-   does — only if step 4 wrote any:
+5. **Commit and push the program files** to `main`, the way the
+   propose program does — only if step 4 wrote any:
 
    ```bash
    git add .minions/programs/
    git commit -m "chore: add minion proposals"
-   git push
+   git push origin HEAD:main
    ```
 
-   If the push is rejected because the local branch is behind, run
-   `git pull --rebase origin main` and push once more.
+   Your worktree sits on a session branch, so a bare `git push` will
+   not reach `main` — push `HEAD:main` explicitly, and confirm it
+   succeeded. If it is rejected because your base is behind, run
+   `git fetch origin main && git rebase origin/main` and push once
+   more. Do not leave the commit unpushed for the runtime to turn
+   into a PR of its own: the proposal is unusable until its program
+   file is on `main`.
 
 6. **Write the verdict — your final act.** Create the directory and
    write `$MINION_AUDIT_DIR/verdict.json`:

--- a/.minions/programs/e2e-audit.md
+++ b/.minions/programs/e2e-audit.md
@@ -1,0 +1,126 @@
+---
+id: e2e-audit
+target_repos:
+  - cli
+acceptance_criteria:
+  - "The verdict file exists at $MINION_AUDIT_DIR/verdict.json, is valid JSON, and its status is pass whenever the audit ran to completion"
+  - "Each distinct e2e-coverage gap has exactly one open minion-proposal issue; pre-existing proposals are reused, never duplicated"
+  - "Filed proposals start with the Minion audit — body prefix and carry acceptance criteria plus a program-file reference a fresh session can build from"
+  - "The PR itself is untouched: no comments, no edits, no commits to its branch"
+---
+
+# Audit a PR for missing end-to-end coverage
+
+A pull request on the cli repo is under audit. Judge whether its
+change warrants an end-to-end test that does not exist yet. Findings
+never block the PR: each one becomes a `minion-proposal` issue so the
+test gets built through the normal minion flow, and your verdict is
+`pass` whenever you ran to completion.
+
+The PR — its reference (`org/repo#number`), title, body, and full
+diff — is provided in the **## Pull Request** section of this prompt.
+
+The canonical exemplar: a fix whose headline acceptance criterion —
+"two rapid commits in one live session both get trailers" — was
+verified only via unit tests of the two halves of the mechanism, with
+nothing driving both hooks through the real two-commit flow. Each
+half can pass while the whole still fails; that gap is what this
+audit names.
+
+## Agents
+
+### e2e-audit
+
+```capabilities
+max_turns: 50
+```
+
+Work through the audit in this order:
+
+1. **Name the headline behavior.** From the PR's title, body, and
+   diff, state what the change promises end to end. Ask whether that
+   promise spans multiple components run in sequence — git hooks
+   firing on real commits, session lifecycle across processes, push
+   and fetch against a real remote — or is fully contained in one
+   unit.
+
+2. **Check what the PR's tests actually drive.** Verify against the
+   PR's head state, not just the diff. Your working directory is a
+   cli checkout, useful for structure and grep, but it may lag the
+   PR. For anything decisive — which tests exist, what flow they
+   exercise — read files at the PR head via `gh` (e.g.
+   `gh api repos/<org>/<repo>/contents/<path>?ref=<head-sha>` with
+   header `Accept: application/vnd.github.raw+json`). A gap must
+   hold against the head state.
+
+3. **Judge conservatively.** A finding is a headline behavior that
+   only an end-to-end run can prove, where the PR's tests cover the
+   pieces but nothing drives the whole flow. Comment, docs, or other
+   cosmetic changes are never findings. Neither is a change whose
+   promise is genuinely unit-scoped and unit-tested. When in doubt,
+   it is not a finding.
+
+4. **File one proposal per distinct gap.** For each finding:
+
+   - Generate a kebab-case id for the missing test, prefixed `e2e-`
+     and named after the flow under test (e.g.
+     `e2e-two-commit-trailer-flow`).
+   - Check for an existing proposal first:
+     `gh issue list --repo <org>/<repo> --label minion-proposal --state open --search "<id>" --limit 5`,
+     and also scan the open proposals' titles for the same gap under
+     a different id. If one already covers it, reuse it — record the
+     existing issue in your verdict reasoning and file nothing.
+   - Write a program file to `.minions/programs/<id>.md` with
+     frontmatter (`id`, `target_repos`, `acceptance_criteria`,
+     `pr_labels`) and a body that tells a fresh minion session
+     exactly what end-to-end test to build: the flow to drive, where
+     the test lives, and what it asserts. The acceptance criteria
+     must be concrete enough to build from the issue alone.
+   - Create the issue:
+     `gh issue create --repo <org>/<repo> --label minion-proposal --title "e2e: <flow under test>" --body <body>`.
+     The body starts with `Minion audit — ` followed by the PR
+     reference that triggered it, then the gap and why unit tests
+     cannot close it, the acceptance criteria, a link to the program
+     file, and the marker
+     `<!-- program: .minions/programs/<id>.md -->`.
+
+5. **Commit and push the program files** the way the propose program
+   does — only if step 4 wrote any:
+
+   ```bash
+   git add .minions/programs/
+   git commit -m "chore: add minion proposals"
+   git push
+   ```
+
+   If the push is rejected because the local branch is behind, run
+   `git pull --rebase origin main` and push once more.
+
+6. **Write the verdict — your final act.** Create the directory and
+   write `$MINION_AUDIT_DIR/verdict.json`:
+
+   ```json
+   {
+     "status": "pass",
+     "findings": [
+       {
+         "location": "internal/hooks/post_commit.go:88",
+         "reasoning": "trailer stamping is only proven by unit tests of each hook; no test drives two rapid commits through both hooks — filed e2e-two-commit-trailer-flow"
+       }
+     ]
+   }
+   ```
+
+   `status` is `pass` whenever you ran to completion — findings do
+   not make it `fail`. List every gap (filed or deduplicated) with a
+   non-empty `location` (path:line anchoring the flow in the head
+   state) and `reasoning` naming why only an e2e test proves it plus
+   the proposal id it maps to. No gaps means `"findings": []`. A
+   missing or malformed file is treated as a crashed audit and fails
+   the workflow, so write it even when there are no findings.
+
+Do **not** comment on the PR, edit files in its branch, or run any
+`git` write command other than the program-file commit in step 5.
+Read-only `git`/`gh` is otherwise fine. The verdict file lives
+outside your checkout on purpose — leave the working tree exactly as
+you found it.

--- a/.minions/programs/session-pid-liveness.md
+++ b/.minions/programs/session-pid-liveness.md
@@ -1,0 +1,91 @@
+---
+id: session-pid-liveness
+target_repos: [cli]
+acceptance_criteria:
+  - "Session-end and condensed-session skip decisions consult the liveness of the agent PID recorded in the session state, not a machine-global process-name grep"
+  - "When the session record carries no PID, the decision falls back to the current global detection, so capture never regresses"
+  - "Unit tests cover the liveness decision with a live PID, a dead PID, and an absent PID"
+  - "A second commit during a still-live session still receives its Partio-Checkpoint trailer (the PR #586 behavior is preserved)"
+  - "The pre-commit condensed-session block is either revived by the real liveness signal or deleted outright, and the PR states which and why"
+  - "make test passes"
+  - "make lint passes"
+pr_labels:
+  - minion
+---
+
+# Use the recorded agent PID for session-end and skip decisions
+
+Hook liveness currently asks "is any process with `claude` in its command line
+running anywhere on this machine?" — `(*claude.Detector).IsRunning()` in
+`internal/agent/claude/process.go` shells out to `pgrep -f claude`. On a
+workstation where some Claude session is nearly always running (another repo,
+another terminal), that answer is effectively always yes. Session-end is never
+observed, the condensed-session skip never engages, and a manual commit made
+after a session ended is rewritten with agent-attribution trailers and a
+redundant checkpoint — false data in the product's core promise.
+
+The information needed for a correct answer is already recorded: pre-commit
+resolves the owning agent's PID through the `agent.PIDProvider` seam
+(`internal/agent/detector.go`) and persists it as `agent_pid` in
+`.partio/sessions/current.json` via `session.Manager.RecordActive`
+(`internal/session/record.go`; the `Session` struct with `AgentPID` lives in
+`internal/session/session.go`). Make session-end and skip decisions consult
+that PID's liveness instead of the global grep. Strictly the session-end/skip
+decision: agent detection for attribution percentages is out of scope and
+unchanged.
+
+## Agents
+
+### session-pid-liveness
+
+```capabilities
+max_turns: 100
+checks: true
+retry_on_fail: true
+retry_max_turns: 20
+```
+
+Work through the change in this order:
+
+1. **Lift the existing liveness seam.** `internal/session/cleanup.go`
+   already implements exactly this decision for stale-session cleanup:
+   `isStale` checks `Session.AgentPID` with `isProcessAlive(pid)`
+   (`syscall.Kill(pid, 0)`). Expose it as a reusable method on
+   `session.Manager` (e.g. `AgentAlive() bool`) instead of
+   re-implementing it. The method answers "is the PID that owns this
+   repo's session alive?" and must fall back to the caller's global
+   detection when the record carries no PID (`agent_pid` 0 or missing —
+   an older record, a detector without `PIDProvider`, a pgrep miss at
+   record time). Prefer today's over-capturing to new under-capturing.
+
+2. **Switch the decision sites in the hooks.** In
+   `internal/hooks/precommit.go` and `internal/hooks/postcommit.go`,
+   wherever session end or the condensed-session skip is decided by the
+   detector's machine-global `IsRunning()` — the `shouldSkipSession`
+   predicate and the `MarkCondensed` call — consult the recorded PID's
+   liveness instead, with the no-PID fallback from step 1.
+
+3. **Resolve the pre-commit condensed-session block.** PR #586 fixed a
+   live session's second commit losing its trailer by threading an
+   `agentRunning` flag through `MarkCondensed` and `shouldSkipSession`;
+   pre-commit passes `agentRunning=true`, which leaves the pre-commit
+   condensed-session block (`internal/hooks/precommit.go`, the
+   `// Check for condensed sessions` block) structurally unable to
+   fire. With a real per-session liveness signal available, either
+   revive that block by passing the actual PID liveness instead of a
+   literal `true`, or delete it if the post-commit skip alone suffices.
+   State in the PR description which you chose and why. Whichever way,
+   the #586 guarantee stays: a second commit in a still-live session
+   gets its trailer. If #586 is not yet merged when you build, apply
+   the same PID-liveness replacement to the current call sites and say
+   so in the PR.
+
+4. **Test the liveness decision.** Unit tests must cover: a live PID
+   (use the test process's own PID), a dead PID (a spawned-and-waited
+   child), and an absent PID (record with `agent_pid` 0 falls back to
+   global detection). Mirror the table-driven patterns in
+   `internal/session/cleanup_test.go`. Add a hook-level test proving a
+   second commit during a still-live session still receives its
+   Partio-Checkpoint trailer.
+
+5. **Run `make test` and `make lint`** and fix what they surface.

--- a/cmd/minion-audit-gate/main.go
+++ b/cmd/minion-audit-gate/main.go
@@ -1,0 +1,53 @@
+// Command minion-audit-gate maps a minion audit verdict file to a CI
+// outcome. It exits 0 only for a valid pass verdict; anything else —
+// fail verdict, missing or malformed file — exits 1 (fail-closed)
+// after upserting the single audit comment on the PR.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/partio-io/cli/internal/auditgate"
+)
+
+func main() {
+	var (
+		pr      = flag.Int("pr", 0, "pull request number (required)")
+		audit   = flag.String("audit", "", "audit name for the comment, e.g. dead-code (required)")
+		verdict = flag.String("verdict", ".minion-audit/verdict.json", "path to the verdict file")
+	)
+	flag.Parse()
+	if *pr == 0 || *audit == "" {
+		fmt.Fprintln(os.Stderr, "usage: minion-audit-gate --pr <number> --audit <name> [--verdict <path>]")
+		os.Exit(2)
+	}
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	token := os.Getenv("GH_TOKEN")
+	if repo == "" || token == "" {
+		fmt.Fprintln(os.Stderr, "minion-audit-gate: GITHUB_REPOSITORY and GH_TOKEN must be set")
+		os.Exit(2)
+	}
+	api := os.Getenv("GITHUB_API_URL")
+	if api == "" {
+		api = "https://api.github.com"
+	}
+
+	res, err := auditgate.Run(auditgate.Config{
+		VerdictPath: *verdict,
+		Repo:        repo,
+		PRNumber:    *pr,
+		AuditName:   *audit,
+		APIBaseURL:  api,
+		Token:       token,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "minion-audit-gate: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("minion-audit-gate:", res.Reason)
+	if !res.Green {
+		os.Exit(1)
+	}
+}

--- a/cmd/partio/doctor.go
+++ b/cmd/partio/doctor.go
@@ -51,8 +51,11 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 			fmt.Printf("[WARN] %s hook missing\n", name)
 			issues++
 		} else {
-			data, _ := os.ReadFile(hookPath)
-			if strings.Contains(string(data), "partio _hook") {
+			data, readErr := os.ReadFile(hookPath)
+			if readErr != nil {
+				fmt.Printf("[WARN] %s hook unreadable: %v\n", name, readErr)
+				issues++
+			} else if strings.Contains(string(data), "partio _hook") {
 				fmt.Printf("[OK]   %s hook installed\n", name)
 			} else {
 				fmt.Printf("[WARN] %s hook exists but not managed by partio\n", name)

--- a/cmd/partio/enable.go
+++ b/cmd/partio/enable.go
@@ -27,7 +27,10 @@ func newEnableCmd() *cobra.Command {
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
-	absolutePath, _ := cmd.Flags().GetBool("absolute-path")
+	absolutePath, flagErr := cmd.Flags().GetBool("absolute-path")
+	if flagErr != nil {
+		slog.Debug("could not read --absolute-path flag", "error", flagErr)
+	}
 
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
@@ -140,8 +143,11 @@ func ensureSettingsEnabled(settingsPath string) error {
 func addToGitignore(repoRoot, entry string) {
 	gitignore := filepath.Join(repoRoot, ".gitignore")
 
-	// Read existing content
-	existing, _ := os.ReadFile(gitignore)
+	// Read existing content; a missing .gitignore is expected (created below).
+	existing, readErr := os.ReadFile(gitignore)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		slog.Debug("could not read .gitignore", "error", readErr)
+	}
 	content := string(existing)
 
 	// Check if already present
@@ -157,12 +163,20 @@ func addToGitignore(repoRoot, entry string) {
 		slog.Warn("could not update .gitignore", "error", err)
 		return
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			slog.Warn("could not update .gitignore", "error", closeErr)
+		}
+	}()
 
 	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
-		_, _ = f.WriteString("\n")
+		if _, writeErr := f.WriteString("\n"); writeErr != nil {
+			slog.Warn("could not write to .gitignore", "error", writeErr)
+		}
 	}
-	_, _ = f.WriteString(entry + "\n")
+	if _, writeErr := f.WriteString(entry + "\n"); writeErr != nil {
+		slog.Warn("could not write to .gitignore", "entry", entry, "error", writeErr)
+	}
 }
 
 func createCheckpointBranch() error {

--- a/cmd/partio/reset.go
+++ b/cmd/partio/reset.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/cobra"
 
@@ -25,8 +26,10 @@ func runReset(cmd *cobra.Command, args []string) error {
 
 	const branchName = "partio/checkpoints/v1"
 
-	// Delete existing branch
-	_, _ = git.ExecGit("branch", "-D", branchName)
+	// Delete existing branch; failure is expected when it does not exist yet.
+	if _, delErr := git.ExecGit("branch", "-D", branchName); delErr != nil {
+		slog.Debug("checkpoint branch not deleted", "branch", branchName, "error", delErr)
+	}
 
 	// Recreate
 	if err := createCheckpointBranch(); err != nil {

--- a/cmd/partio/rewind.go
+++ b/cmd/partio/rewind.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -116,8 +117,11 @@ func runRewindTo(id string) error {
 		return fmt.Errorf("invalid checkpoint metadata: %w", err)
 	}
 
-	// Read session context
-	context, _ := git.ExecGit("show", branch+":"+shard+"/"+rest+"/0/context.md")
+	// Read session context; the file is optional, so absence is expected.
+	context, ctxErr := git.ExecGit("show", branch+":"+shard+"/"+rest+"/0/context.md")
+	if ctxErr != nil {
+		slog.Debug("checkpoint context not read", "id", id, "error", ctxErr)
+	}
 
 	fmt.Printf("Rewinding to checkpoint %s\n", id)
 	fmt.Printf("  Commit: %s\n", meta.CommitHash)

--- a/cmd/partio/status.go
+++ b/cmd/partio/status.go
@@ -34,7 +34,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		enabled = true
 	}
 
-	branch, _ := git.CurrentBranch()
+	branch, branchErr := git.CurrentBranch()
+	if branchErr != nil {
+		branch = "(unknown)"
+		slog.Debug("could not resolve current branch", "error", branchErr)
+	}
 
 	fmt.Printf("Repository: %s\n", repoRoot)
 	fmt.Printf("Branch:     %s\n", branch)

--- a/docs/2026-08-03-minion-pr-audits/issues.md
+++ b/docs/2026-08-03-minion-pr-audits/issues.md
@@ -7,7 +7,7 @@ Source: [prd.md](./prd.md)
 | [x]  | 1 | [Lint gate for swallowed errors](./issues/01-lint-gate.md) | None |
 | [x]  | 2 | [Dead-code audit, read-only](./issues/02-deadcode-audit-readonly.md) | None |
 | [x]  | 3 | [Dead-code fix round](./issues/03-deadcode-fix-round.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
-| [ ]  | 4 | [E2e-need audit](./issues/04-e2e-need-audit.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
+| [x]  | 4 | [E2e-need audit](./issues/04-e2e-need-audit.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
 | [ ]  | 5 | [Session-liveness proposal](./issues/05-session-liveness-proposal.md) | None |
 
 Shared names all slices must agree on (defined in #2, reused everywhere):

--- a/docs/2026-08-03-minion-pr-audits/issues.md
+++ b/docs/2026-08-03-minion-pr-audits/issues.md
@@ -6,7 +6,7 @@ Source: [prd.md](./prd.md)
 |------|---|-------|------------|
 | [x]  | 1 | [Lint gate for swallowed errors](./issues/01-lint-gate.md) | None |
 | [x]  | 2 | [Dead-code audit, read-only](./issues/02-deadcode-audit-readonly.md) | None |
-| [ ]  | 3 | [Dead-code fix round](./issues/03-deadcode-fix-round.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
+| [x]  | 3 | [Dead-code fix round](./issues/03-deadcode-fix-round.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
 | [ ]  | 4 | [E2e-need audit](./issues/04-e2e-need-audit.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
 | [ ]  | 5 | [Session-liveness proposal](./issues/05-session-liveness-proposal.md) | None |
 

--- a/docs/2026-08-03-minion-pr-audits/issues.md
+++ b/docs/2026-08-03-minion-pr-audits/issues.md
@@ -5,7 +5,7 @@ Source: [prd.md](./prd.md)
 | Done | # | Title | Blocked by |
 |------|---|-------|------------|
 | [x]  | 1 | [Lint gate for swallowed errors](./issues/01-lint-gate.md) | None |
-| [ ]  | 2 | [Dead-code audit, read-only](./issues/02-deadcode-audit-readonly.md) | None |
+| [x]  | 2 | [Dead-code audit, read-only](./issues/02-deadcode-audit-readonly.md) | None |
 | [ ]  | 3 | [Dead-code fix round](./issues/03-deadcode-fix-round.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
 | [ ]  | 4 | [E2e-need audit](./issues/04-e2e-need-audit.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
 | [ ]  | 5 | [Session-liveness proposal](./issues/05-session-liveness-proposal.md) | None |

--- a/docs/2026-08-03-minion-pr-audits/issues.md
+++ b/docs/2026-08-03-minion-pr-audits/issues.md
@@ -8,7 +8,7 @@ Source: [prd.md](./prd.md)
 | [x]  | 2 | [Dead-code audit, read-only](./issues/02-deadcode-audit-readonly.md) | None |
 | [x]  | 3 | [Dead-code fix round](./issues/03-deadcode-fix-round.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
 | [x]  | 4 | [E2e-need audit](./issues/04-e2e-need-audit.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
-| [ ]  | 5 | [Session-liveness proposal](./issues/05-session-liveness-proposal.md) | None |
+| [x]  | 5 | [Session-liveness proposal](./issues/05-session-liveness-proposal.md) | None |
 
 Shared names all slices must agree on (defined in #2, reused everywhere):
 

--- a/docs/2026-08-03-minion-pr-audits/issues.md
+++ b/docs/2026-08-03-minion-pr-audits/issues.md
@@ -1,0 +1,19 @@
+# Issues — 2026-08-03-minion-pr-audits
+
+Source: [prd.md](./prd.md)
+
+| Done | # | Title | Blocked by |
+|------|---|-------|------------|
+| [x]  | 1 | [Lint gate for swallowed errors](./issues/01-lint-gate.md) | None |
+| [ ]  | 2 | [Dead-code audit, read-only](./issues/02-deadcode-audit-readonly.md) | None |
+| [ ]  | 3 | [Dead-code fix round](./issues/03-deadcode-fix-round.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
+| [ ]  | 4 | [E2e-need audit](./issues/04-e2e-need-audit.md) | [#2](./issues/02-deadcode-audit-readonly.md) |
+| [ ]  | 5 | [Session-liveness proposal](./issues/05-session-liveness-proposal.md) | None |
+
+Shared names all slices must agree on (defined in #2, reused everywhere):
+
+- Skip label: `no-audit`
+- Audit comment body prefix: `Minion audit —`
+- Audit fix-commit subject prefix: `audit:`
+- Verdict file: `.minion-audit/verdict.json` in the workflow workspace
+  (never committed)

--- a/docs/2026-08-03-minion-pr-audits/issues/01-lint-gate.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/01-lint-gate.md
@@ -1,0 +1,62 @@
+# 01 — Lint gate for swallowed errors
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+Turn on errcheck's blank-discard rule so that assigning an error to
+`_` fails lint everywhere it runs — locally, in the minion's per-build
+check gate, and in the audit workflows' own checks — and clean up every
+existing violation so the gate starts green.
+
+The motivating instance: a hook resolved agent liveness with
+`agentStillRunning, _ := detector.IsRunning()`, silently degrading to
+the old buggy behavior whenever the check errors. After this slice,
+that line does not compile past lint without either handling the error
+or logging it deliberately.
+
+## User stories covered
+
+12, 13, 14.
+
+## Acceptance criteria
+
+- [x] The repo lint config enables errcheck's blank-discard checking,
+      and the setting demonstrably applies: a scratch blank-discarded
+      error fails `golangci-lint run` locally. (The existing config is
+      schema v2 — verify the settings block is actually honored, not
+      silently ignored; the current file carries a `linters-settings`
+      block whose placement may be inert in v2.)
+- [x] Test files (`_test.go`) are exempt via lint config exclusions,
+      not via code changes.
+- [x] Zero blank-discard violations remain in non-test code
+      (36 at PRD time; recount, the number may have drifted).
+      (Recounted 42 — fixed all 42.)
+- [x] Each fix handles the error meaningfully for its context — at
+      minimum a debug log naming the operation; no fix silences by
+      renaming or restructuring to dodge the linter.
+- [x] The liveness case in the post-commit hook logs its error, per the
+      PR #586 review recommendation.
+      (The surviving blank-discarded `IsRunning` was in the
+      pre-commit hook — `precommit.go:42`; the post-commit instance
+      no longer exists. Fixed there, logged at Warn.)
+- [x] `go test ./...` and `golangci-lint run` both pass.
+
+## Modules touched
+
+- lint tightening (PRD Implementation Decisions).
+
+## Test prior art
+
+- Table-driven unit tests throughout `internal/*/..._test.go` — any
+  fix that changes behavior (not just adds logging) extends the
+  nearest existing table.
+- The lint gate itself is the test for the rule; prove it with a
+  deliberate violation before removing it.
+
+## Out of scope
+
+- Any audit workflow or program (issues 02–04).
+- Changing what `IsRunning` means — that is the session-liveness
+  proposal (issue 05).

--- a/docs/2026-08-03-minion-pr-audits/issues/02-deadcode-audit-readonly.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/02-deadcode-audit-readonly.md
@@ -30,14 +30,14 @@ Missing or malformed verdict fails the run (fail-closed).
 
 ## Acceptance criteria
 
-- [ ] Workflow triggers on pull-request opened/labeled/synchronize,
+- [x] Workflow triggers on pull-request opened/labeled/synchronize,
       proceeds only when the PR carries the `minion` label, and skips
       when the `no-audit` label is present.
-- [ ] A guard step exits early when the PR head commit subject starts
+- [x] A guard step exits early when the PR head commit subject starts
       with the `audit:` prefix (loop guard — consumed for real in
       issue 03), and concurrent runs on the same PR cancel superseded
       ones.
-- [ ] The audit session reviews the PR diff (fetching surrounding
+- [x] The audit session reviews the PR diff (fetching surrounding
       context as it judges necessary), and writes the verdict file as
       its final act.
 - [x] Gate step behavior, proven with fixture verdicts: `pass` →
@@ -46,11 +46,11 @@ Missing or malformed verdict fails the run (fail-closed).
       finding phrased with location and reasoning; re-runs update that
       comment in place rather than adding another.
 - [x] On pass, no comment at all.
-- [ ] `workflow_dispatch` dry-run renders the prompt (minions
+- [x] `workflow_dispatch` dry-run renders the prompt (minions
       dry-run path) and touches neither the PR nor the repo.
-- [ ] Workflow installs minions at the same version pin as the
+- [x] Workflow installs minions at the same version pin as the
       sibling workflows and runs on the same self-hosted runner.
-- [ ] Staged proof, then cleanup: a scratch PR with planted
+- [x] Staged proof, then cleanup: a scratch PR with planted
       semantically-dead code goes red with the comment; a clean
       scratch PR stays green and silent; an unlabeled PR triggers no
       audit; a `no-audit`-labeled one skips.

--- a/docs/2026-08-03-minion-pr-audits/issues/02-deadcode-audit-readonly.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/02-deadcode-audit-readonly.md
@@ -1,0 +1,80 @@
+# 02 — Dead-code audit, read-only
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+The complete trigger-to-verdict path for the dead-code audit, without
+the repair loop yet: a GitHub Action that fires on minion-labeled PRs,
+runs a minions prompt program on the self-hosted minion runner, and
+turns the program's verdict into the PR check's green/red plus at most
+one comment.
+
+"Semantically dead code" means code that is still invoked but provably
+inert — the canonical exemplar (from the PR #586 review) is a callee
+whose first branch short-circuits on a parameter that every remaining
+call site hardcodes, leaving the rest of the block unreachable. No
+deterministic tool flags this; the program's job is to reason about
+the PR diff and catch it.
+
+Shared contract established here (index lists the agreed names): the
+program's final act is writing a verdict file — status `pass` or
+`fail` plus a findings list with location and reasoning per finding —
+and a deterministic workflow step maps it to the check outcome.
+Missing or malformed verdict fails the run (fail-closed).
+
+## User stories covered
+
+1, 4, 5, 6, 7, 15, 17, 18, 19, 20, 21, 22.
+
+## Acceptance criteria
+
+- [ ] Workflow triggers on pull-request opened/labeled/synchronize,
+      proceeds only when the PR carries the `minion` label, and skips
+      when the `no-audit` label is present.
+- [ ] A guard step exits early when the PR head commit subject starts
+      with the `audit:` prefix (loop guard — consumed for real in
+      issue 03), and concurrent runs on the same PR cancel superseded
+      ones.
+- [ ] The audit session reviews the PR diff (fetching surrounding
+      context as it judges necessary), and writes the verdict file as
+      its final act.
+- [x] Gate step behavior, proven with fixture verdicts: `pass` →
+      green; `fail` → red; file absent or malformed → red.
+- [x] On red, exactly one PR comment prefixed `Minion audit —`, each
+      finding phrased with location and reasoning; re-runs update that
+      comment in place rather than adding another.
+- [x] On pass, no comment at all.
+- [ ] `workflow_dispatch` dry-run renders the prompt (minions
+      dry-run path) and touches neither the PR nor the repo.
+- [ ] Workflow installs minions at the same version pin as the
+      sibling workflows and runs on the same self-hosted runner.
+- [ ] Staged proof, then cleanup: a scratch PR with planted
+      semantically-dead code goes red with the comment; a clean
+      scratch PR stays green and silent; an unlabeled PR triggers no
+      audit; a `no-audit`-labeled one skips.
+
+## Modules touched
+
+- deadcode-audit program
+- deadcode-audit workflow
+- audit verdict gate
+
+## Test prior art
+
+- Workflow shape: the minion/propose workflows under
+  `.github/workflows/` (runner label, minions install step, PAT env,
+  dry-run input on propose).
+- Program shape: existing prompt programs under `.minions/programs/`
+  (frontmatter with id and target repos, numbered steps, gh commands
+  inline).
+- Staged verification: the per-slice staged smoke test run against the
+  slice pipeline (scratch issue/PR, verify, clean up).
+
+## Out of scope
+
+- Fixing anything the audit finds — issue 03 adds the bounded repair
+  round.
+- The e2e-need audit — issue 04 (it reuses this slice's verdict gate
+  and trigger gating).

--- a/docs/2026-08-03-minion-pr-audits/issues/03-deadcode-fix-round.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/03-deadcode-fix-round.md
@@ -23,22 +23,22 @@ head commit and exit early instead of auditing itself.
 
 ## Acceptance criteria
 
-- [ ] Fixable staged PR: planted dead code is repaired by a commit
+- [x] Fixable staged PR: planted dead code is repaired by a commit
       with the `audit:` prefix on the PR branch, the re-audit passes,
       the check ends green, and the PR carries at most the in-place
       audit comment (updated to reflect resolution or absent).
-- [ ] The workflow run triggered by the audit's own push exits early
+- [x] The workflow run triggered by the audit's own push exits early
       via the guard — observed on the staged PR, no self-audit.
-- [ ] Unfixable staged PR (a finding whose fix is deliberately out of
+- [x] Unfixable staged PR (a finding whose fix is deliberately out of
       a session's reach, e.g. requiring a design decision): exactly
       one fix attempt, then red with the surviving findings in the
       single comment.
-- [ ] Re-running the workflow on an unchanged PR converges: same
+- [x] Re-running the workflow on an unchanged PR converges: same
       verdict, no duplicate comments, no second fix commit.
-- [ ] Fix commits pass the repo's own checks (lint from issue 01
+- [x] Fix commits pass the repo's own checks (lint from issue 01
       included) before pushing — a fix that breaks the build is a
       failed fix round, red.
-- [ ] Dry-run still touches nothing.
+- [x] Dry-run still touches nothing.
 
 ## Modules touched
 

--- a/docs/2026-08-03-minion-pr-audits/issues/03-deadcode-fix-round.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/03-deadcode-fix-round.md
@@ -1,0 +1,60 @@
+# 03 — Dead-code fix round
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [02 — Dead-code audit, read-only](./02-deadcode-audit-readonly.md)
+
+## What to build
+
+The bounded repair loop on top of issue 02: when the audit's verdict
+is `fail`, run exactly one fix session against the findings, commit
+the result to the PR branch with the `audit:` subject prefix, push,
+and re-audit once with a fresh session. The re-audit's verdict is
+final — green if the branch came back clean (the operator then reviews
+a PR that is already fixed), red plus the surviving-findings comment
+if not. Never a second fix attempt, regardless of outcome.
+
+The loop guard installed in issue 02 now earns its keep: the audit's
+own push fires a new workflow run, which must recognize the `audit:`
+head commit and exit early instead of auditing itself.
+
+## User stories covered
+
+2, 3, 16, 25 (comment-convergence half; proposal half lives in 04).
+
+## Acceptance criteria
+
+- [ ] Fixable staged PR: planted dead code is repaired by a commit
+      with the `audit:` prefix on the PR branch, the re-audit passes,
+      the check ends green, and the PR carries at most the in-place
+      audit comment (updated to reflect resolution or absent).
+- [ ] The workflow run triggered by the audit's own push exits early
+      via the guard — observed on the staged PR, no self-audit.
+- [ ] Unfixable staged PR (a finding whose fix is deliberately out of
+      a session's reach, e.g. requiring a design decision): exactly
+      one fix attempt, then red with the surviving findings in the
+      single comment.
+- [ ] Re-running the workflow on an unchanged PR converges: same
+      verdict, no duplicate comments, no second fix commit.
+- [ ] Fix commits pass the repo's own checks (lint from issue 01
+      included) before pushing — a fix that breaks the build is a
+      failed fix round, red.
+- [ ] Dry-run still touches nothing.
+
+## Modules touched
+
+- deadcode-audit program (fix-round instructions and re-audit)
+- deadcode-audit workflow (fix/re-audit steps, guard consumption)
+- audit verdict gate (unchanged, consumed)
+
+## Test prior art
+
+- Issue 02's staged-scratch-PR pattern — extend the same staging with
+  the fixable and unfixable variants.
+- Check-before-push discipline: the minions runtime's per-slice
+  check-gate behavior (checks run, retry once, fail the slice) is the
+  conceptual model for "a fix that fails checks is a failed round".
+
+## Out of scope
+
+- Multi-round repair, escalation, or fix attempts on human PRs.
+- E2e-need findings — issue 04.

--- a/docs/2026-08-03-minion-pr-audits/issues/04-e2e-need-audit.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/04-e2e-need-audit.md
@@ -1,0 +1,70 @@
+# 04 — E2e-need audit
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [02 — Dead-code audit, read-only](./02-deadcode-audit-readonly.md)
+
+## What to build
+
+The second audit action, reusing issue 02's trigger gating and verdict
+contract: a program that judges whether the PR's change warrants an
+end-to-end test, and when it does, feeds that work back into the
+pipeline as a `minion-proposal` issue instead of blocking the PR.
+
+The judgment exemplar (from the PR #586 review): a fix whose headline
+acceptance criterion — "two rapid commits in one live session both get
+trailers" — was verified only via unit tests of the two halves of the
+mechanism, with nothing driving both hooks through the real two-commit
+flow. That gap is what this audit exists to name.
+
+A finding becomes one proposal per distinct gap, matching the propose
+program's issue format: kebab-case id, a program file committed and
+pushed the way propose already does it, and an issue whose body
+carries acceptance criteria concrete enough for a fresh minion session
+to build the test from the issue alone. Before filing, the program
+searches open proposals and skips ids that already exist.
+
+Findings never turn this check red — a completed run with findings is
+a `pass` verdict plus filed proposals. Only a missing or malformed
+verdict (a crashed session) fails the workflow.
+
+## User stories covered
+
+8, 9, 10, 11, 15, 17, 18, 19, 20, 21, 25 (proposal-dedup half).
+
+## Acceptance criteria
+
+- [ ] Same trigger surface as the dead-code audit: minion label
+      required, `no-audit` skip, `audit:` head-commit guard,
+      concurrency cancel, same runner, same minions pin, dry-run via
+      `workflow_dispatch` that touches nothing.
+- [ ] Staged PR that plainly deserves e2e coverage: exactly one
+      `minion-proposal` issue filed, body prefixed `Minion audit —`,
+      with buildable acceptance criteria and the program-file
+      reference; check green.
+- [ ] Re-run on the same staged PR: no duplicate proposal, still
+      green.
+- [ ] Staged cosmetic PR (comment/docs-only change): no proposal, no
+      comment, green.
+- [ ] Fixture-verdict proof that a missing or malformed verdict still
+      fails this workflow despite findings never doing so.
+- [ ] Staged artifacts cleaned up afterwards (scratch PRs closed,
+      scratch proposals closed and labeled `do-not-build`).
+
+## Modules touched
+
+- e2e-audit program
+- e2e-audit workflow
+- audit verdict gate (reused as-is)
+
+## Test prior art
+
+- Issue 02's workflow and staging patterns.
+- Proposal filing and dedup: the propose program under
+  `.minions/programs/` — reuse its id-generation, existence-check, and
+  issue-format conventions verbatim.
+
+## Out of scope
+
+- Building the e2e tests themselves — that is future minion work,
+  entering through the proposals this audit files.
+- Blocking merges on missing e2e coverage.

--- a/docs/2026-08-03-minion-pr-audits/issues/04-e2e-need-audit.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/04-e2e-need-audit.md
@@ -33,21 +33,21 @@ verdict (a crashed session) fails the workflow.
 
 ## Acceptance criteria
 
-- [ ] Same trigger surface as the dead-code audit: minion label
+- [x] Same trigger surface as the dead-code audit: minion label
       required, `no-audit` skip, `audit:` head-commit guard,
       concurrency cancel, same runner, same minions pin, dry-run via
       `workflow_dispatch` that touches nothing.
-- [ ] Staged PR that plainly deserves e2e coverage: exactly one
+- [x] Staged PR that plainly deserves e2e coverage: exactly one
       `minion-proposal` issue filed, body prefixed `Minion audit —`,
       with buildable acceptance criteria and the program-file
       reference; check green.
-- [ ] Re-run on the same staged PR: no duplicate proposal, still
+- [x] Re-run on the same staged PR: no duplicate proposal, still
       green.
-- [ ] Staged cosmetic PR (comment/docs-only change): no proposal, no
+- [x] Staged cosmetic PR (comment/docs-only change): no proposal, no
       comment, green.
-- [ ] Fixture-verdict proof that a missing or malformed verdict still
+- [x] Fixture-verdict proof that a missing or malformed verdict still
       fails this workflow despite findings never doing so.
-- [ ] Staged artifacts cleaned up afterwards (scratch PRs closed,
+- [x] Staged artifacts cleaned up afterwards (scratch PRs closed,
       scratch proposals closed and labeled `do-not-build`).
 
 ## Modules touched

--- a/docs/2026-08-03-minion-pr-audits/issues/05-session-liveness-proposal.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/05-session-liveness-proposal.md
@@ -33,21 +33,21 @@ that cleanup explicitly.
 
 ## Acceptance criteria
 
-- [ ] Program file exists under the programs directory with the
+- [x] Program file exists under the programs directory with the
       pipeline's standard frontmatter (id, target repo, acceptance
       criteria, PR labels).
-- [ ] `minion-proposal` issue filed on this repo, body carrying: the
+- [x] `minion-proposal` issue filed on this repo, body carrying: the
       defect description with the manual-commit misattribution
       scenario; the session-recorded-PID approach; a conservative
       fallback when no PID was recorded (fall back to current global
       detection rather than regressing capture); the dead
       condensed-session block's removal or revival; and the program
       file marker.
-- [ ] The issue's acceptance criteria explicitly require unit tests
+- [x] The issue's acceptance criteria explicitly require unit tests
       for the liveness decision (PID alive, PID dead, PID absent) and
       preservation of the PR #586 behavior: a live session's second
       commit still gets its trailer.
-- [ ] Issue body is buildable standalone: a fresh minion session given
+- [x] Issue body is buildable standalone: a fresh minion session given
       only the issue can locate the hooks, session state, and detector
       seams from the descriptions in the body.
 

--- a/docs/2026-08-03-minion-pr-audits/issues/05-session-liveness-proposal.md
+++ b/docs/2026-08-03-minion-pr-audits/issues/05-session-liveness-proposal.md
@@ -1,0 +1,70 @@
+# 05 — Session-liveness proposal
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+Not an implementation — a proposal that routes the F1 fix through the
+normal minion pipeline. Author the program file and file the
+`minion-proposal` issue; the build happens later, when the operator
+approves it.
+
+The defect being proposed away: hook liveness asks "is any process
+with 'claude' in its command line running anywhere on this machine?"
+(a global process-name grep) instead of "is the agent that owns this
+repo's session alive?". On a workstation where some agent is nearly
+always running, session-end is effectively never recorded, the
+condensed-session skip never engages, and a manual commit made after a
+session ended can be rewritten with agent-attribution trailers and a
+redundant checkpoint — false data in the product's core promise.
+
+The proposed fix: the pre-commit hook already records the owning
+agent's process ID in the session state. Session-end and skip
+decisions should consult that PID's liveness instead of the global
+grep. With the tautological check gone, the pre-commit
+condensed-session block (left dead by PR #586's fix) becomes
+meaningful again or is deleted outright — the proposal should name
+that cleanup explicitly.
+
+## User stories covered
+
+23, 24.
+
+## Acceptance criteria
+
+- [ ] Program file exists under the programs directory with the
+      pipeline's standard frontmatter (id, target repo, acceptance
+      criteria, PR labels).
+- [ ] `minion-proposal` issue filed on this repo, body carrying: the
+      defect description with the manual-commit misattribution
+      scenario; the session-recorded-PID approach; a conservative
+      fallback when no PID was recorded (fall back to current global
+      detection rather than regressing capture); the dead
+      condensed-session block's removal or revival; and the program
+      file marker.
+- [ ] The issue's acceptance criteria explicitly require unit tests
+      for the liveness decision (PID alive, PID dead, PID absent) and
+      preservation of the PR #586 behavior: a live session's second
+      commit still gets its trailer.
+- [ ] Issue body is buildable standalone: a fresh minion session given
+      only the issue can locate the hooks, session state, and detector
+      seams from the descriptions in the body.
+
+## Modules touched
+
+- session-liveness proposal (this PRD); the eventual implementation
+  touches the hooks and session-manager modules, but that lands via
+  the pipeline, not this slice.
+
+## Test prior art
+
+- Proposal format: recent `minion-proposal` issues on this repo and
+  the propose program's issue-creation steps — mirror their structure
+  so the parser-facing parts (labels, marker comment) match exactly.
+
+## Out of scope
+
+- Implementing the liveness change (later minion work via approval).
+- Any change to agent detection for attribution percentages —
+  strictly the session-end/skip liveness decision.

--- a/docs/2026-08-03-minion-pr-audits/prd.md
+++ b/docs/2026-08-03-minion-pr-audits/prd.md
@@ -1,0 +1,194 @@
+# Minion PR Audits
+
+## Problem Statement
+
+Minion-built PRs ship with quality defects that today only a careful
+human review catches. The review of PR #586 surfaced three recurring
+classes:
+
+- **Semantically dead code** — blocks that are still called but can no
+  longer do anything (a hardcoded argument makes a branch unreachable).
+  No deterministic tool flags these: the code is "used", so `unused`
+  and `deadcode` see it as live. Only reasoning catches it.
+- **Silently swallowed errors** — error returns discarded with a blank
+  identifier, so a failure path degrades behavior with no trace. The
+  repo's lint config currently permits this.
+- **Missing end-to-end coverage** — a change whose headline behavior is
+  only verified at the unit level, with nothing driving the full flow.
+
+Each defect class currently depends on the operator reading every diff
+line. That does not scale with the minion pipeline's throughput, and a
+defect that slips through merges silently.
+
+Separately, the same review found that agent-liveness detection is
+machine-global: the hooks ask "is any process with 'claude' in its
+command line running anywhere on this machine?" rather than "is the
+agent that owns this repo's session alive?". On a workstation where
+some agent is nearly always running, a manual commit can be rewritten
+with agent-attribution trailers and a redundant checkpoint — wrong data
+in the product whose core promise is accurate AI attribution.
+
+## Solution
+
+Give the pipeline its own reviewers, matched to the nature of each
+defect class:
+
+- **Deterministic class → lint gate.** Enable errcheck's blank-discard
+  option and fix the existing violations. From then on, every minion
+  build and every local run fails on a swallowed error — no new
+  workflow, no judgment, no noise.
+- **Judgment classes → two PR-time audit actions.** Each minion-labeled
+  PR gets two automated reviewers, each an independent GitHub Action
+  running a minions prompt program on the self-hosted minion runner:
+  - The **dead-code audit** reviews the PR diff for semantically dead
+    code. Findings trigger exactly one fix round on the PR branch
+    itself, followed by one re-audit. If the branch comes back clean,
+    the check is green and the PR the operator reviews is already
+    fixed. If findings survive, the check goes red with a comment
+    listing them — and it never loops.
+  - The **e2e-need audit** judges whether the change warrants an
+    end-to-end test. When it does, it files a `minion-proposal` issue
+    with acceptance criteria a fresh minion session can build from —
+    feeding the work back into the queue the operator already triages.
+    It never turns the PR red on findings.
+- **Attribution correctness → one proposal now.** File a
+  `minion-proposal` issue to replace machine-global process-name
+  liveness with a check of the session's own recorded agent process
+  ID. The implementation then flows through the normal
+  approve → build → PR pipeline.
+
+## User Stories
+
+1. As the pipeline operator, I want minion PRs automatically audited for dead code before I review them, so that called-but-inert blocks never reach main.
+2. As the pipeline operator, I want the dead-code audit to fix its findings on the PR branch itself, so that the PR I review is already clean instead of me round-tripping feedback.
+3. As the pipeline operator, I want the fix round strictly bounded to one attempt plus one re-audit, so that automated sessions can never ping-pong on a PR.
+4. As the pipeline operator, I want a red check plus one comment listing surviving findings when the fix round does not fully clean up, so that I know exactly what still needs a human call.
+5. As the pipeline operator, I want a quiet green check when an audit finds nothing, so that clean PRs gather no comment noise.
+6. As the pipeline operator, I want both audits to run only on minion-labeled PRs, so that my hand-written PRs are not taxed with agent sessions.
+7. As the pipeline operator, I want audits scoped to the PR's diff plus whatever surrounding code the session chooses to read, so that findings are attributable to the change under review rather than repo-wide archaeology.
+8. As the pipeline operator, I want an e2e-need audit that files a proposal issue when a change deserves end-to-end coverage, so that test debt enters the same queue I already triage.
+9. As the pipeline operator, I want the e2e-need audit to never turn a PR red on findings, so that missing future coverage does not block shipping the fix in front of me.
+10. As the pipeline operator, I want e2e proposals deduplicated against open proposals before filing, so that re-runs do not flood the queue with copies.
+11. As the pipeline operator, I want e2e proposals to carry acceptance criteria concrete enough for a fresh minion session, so that approving one is all I have to do to get the test built.
+12. As the pipeline operator, I want blank-discarded errors caught by lint on every build, so that a swallowed failure like the liveness check's can never merge silently again.
+13. As the pipeline operator, I want the existing blank-discard violations fixed in the same change that enables the rule, so that the gate starts green instead of permanently red.
+14. As the pipeline operator, I want test files exempt from the blank-discard rule, so that deliberate discards in tests stay idiomatic.
+15. As the pipeline operator, I want every audit comment to start with a fixed marker prefix, so that I can filter machine comments by body the way the rest of the pipeline already does.
+16. As the pipeline operator, I want the audit's own fix commits recognizable and ignored by audit triggers, so that an audit push can never re-trigger itself into a loop.
+17. As the pipeline operator, I want a dry-run mode on both audit workflows, so that I can see exactly what prompt would run without a PR being touched.
+18. As the pipeline operator, I want each audit proven on a staged scratch PR before it watches real PRs, so that the loop's behavior is verified the same way the slice pipeline was.
+19. As the pipeline operator, I want an escape-hatch label that makes both audits skip a PR, so that I can move urgently without editing workflows.
+20. As the pipeline operator, I want a crashed audit (one that produced no verdict) to fail visibly even for the never-blocking audit, so that an infra failure cannot masquerade as a pass.
+21. As the pipeline operator, I want both audit workflows pinned to the same minions version scheme as the existing workflows, so that upgrades stay one pin-bump PR across the board.
+22. As a reviewer of minion PRs, I want surviving findings phrased with location and reasoning, so that I can judge each one without re-deriving the analysis.
+23. As the pipeline operator, I want a session-scoped liveness proposal filed with clear acceptance criteria, so that the machine-global process grep gets replaced through the normal minion flow rather than a hand-patched hotfix.
+24. As a partio user, I want my manual commits never stamped with agent attribution just because some agent is running elsewhere on my machine, so that attribution data stays truthful.
+25. As the pipeline operator, I want re-running an audit on an unchanged PR to converge to the same verdict without duplicate comments or duplicate proposals, so that retries are safe.
+
+## Implementation Decisions
+
+- **Everything ships in the cli repo.** No changes to the minions
+  runtime or binary — this avoids the release-tag-plus-pin-bump deploy
+  chain entirely. The audit programs are prompt programs executed by
+  the already-pinned minions version.
+- **Two separate actions, not one combined audit** (operator's call
+  during research): independent cadence, independent evolution, at the
+  cost of two sessions per PR.
+- **Trigger:** pull-request events (opened, labeled, synchronize) gated
+  on the PR carrying the minion label. A skip label short-circuits both
+  audits. Both run on the existing self-hosted minion runner.
+- **Loop guard:** the dead-code audit's fix commits carry a fixed
+  commit-subject prefix; a guard step exits early when the PR head
+  commit carries it. Concurrency groups cancel superseded audit runs on
+  the same PR.
+- **Verdict contract (shared by both audits):** the audit session must
+  write a small verdict file — status plus a findings list — as its
+  final act. A deterministic workflow step turns the verdict into the
+  check outcome. A missing or malformed verdict fails the workflow for
+  both audits (fail-closed on infra); a well-formed verdict with
+  findings is red only for the dead-code audit.
+- **Dead-code fix round:** on findings, the same session (or an
+  immediately spawned fresh one) applies fixes, commits with the marker
+  prefix, pushes to the PR branch, and re-audits once. Findings that
+  survive go into the verdict and one PR comment. Hard bound: one
+  round, no exceptions.
+- **E2e-need flow:** findings become one `minion-proposal` issue per
+  distinct gap, deduplicated by searching open proposals first, each
+  carrying a program-file reference and acceptance criteria, matching
+  the propose program's issue format. The audit itself always reports a
+  passing verdict when it ran to completion.
+- **Comment authorship:** comments and issues are authored via the
+  pipeline's existing PAT and therefore appear as the operator;
+  machine-filtering relies on the fixed body prefix, never on author —
+  consistent with the pipeline's existing convention.
+- **Lint tightening:** enable errcheck's blank-discard option in the
+  repo lint config with test files excluded; fix all current
+  violations (36 at time of writing) in the same change. The minion's
+  per-build check gate and local runs pick the rule up with no further
+  wiring.
+- **Session-scoped liveness proposal (F1):** one `minion-proposal`
+  issue proposing that session-end and skip decisions consult the
+  liveness of the session's recorded agent process ID instead of a
+  machine-wide process-name grep, with a conservative fallback when no
+  PID was recorded. Implementation is deliberately left to the minion
+  pipeline; this PRD only files the proposal.
+- **Language:** the cli repo is Go and stays Go for any code touched;
+  the new surface area is workflow YAML and markdown prompt programs,
+  so no new-language decision arises.
+
+## Testing Decisions
+
+- Good tests assert external behavior — what a module produces given
+  inputs — never internal wiring. For this feature the external
+  behaviors are: the verdict file's effect on check status, the
+  presence/absence and content shape of comments and proposals, the
+  loop guard's short-circuit, and lint failing on a blank-discarded
+  error.
+- **Every module is tested.** Concretely:
+  - The lint change is tested by the lint itself plus the existing
+    suite staying green after the violation fixes.
+  - The verdict gate and loop guard are exercised with fixture verdicts
+    (pass, fail, missing, malformed) and a marker-prefixed head commit
+    in a staged run before the actions watch real PRs.
+  - Each audit program is validated first via the workflows' dry-run
+    path (prompt rendered, nothing touched), then via a staged scratch
+    PR — the same staged-run pattern the slice pipeline was verified
+    with (prior art: the per-slice staged smoke test).
+  - The F1 proposal's acceptance criteria require unit tests for the
+    liveness decision when it is implemented; that testing obligation
+    ships inside the proposal text.
+- **Deliberate gap, named:** the quality of the LLM's judgment inside
+  an audit session (does it spot real dead code, does it over-flag) is
+  not unit-testable and is not tested in CI. Mitigations: the strict
+  verdict schema, the one-round bound, staged runs before enablement,
+  and the operator reviewing every comment and proposal it produces.
+
+## Out of Scope
+
+- Whole-repo or scheduled audit sweeps — audits look at PR diffs only
+  (the scheduled-sweep option was explicitly declined).
+- Auditing human-authored PRs.
+- Wiring the auto-approve program to a schedule; proposals filed by the
+  e2e audit wait for the operator's label like every other proposal.
+- Any change to the minions runtime, its release, or its version pins
+  beyond adding the two workflows at the current pin.
+- Implementing the session-scoped liveness fix (only the proposal is in
+  scope here).
+- Extending any of this to repos other than cli.
+- Branch protection or required-check enforcement; check status stays
+  advisory signal for the operator.
+
+## Further Notes
+
+- Origin: findings F1–F4 from the operator review of PR #586
+  (2026-07-28). F2 (dead code), F3 (swallowed error), and F4 (missing
+  e2e) become the three loops above; F1 becomes the filed proposal.
+- Expected cost envelope: two audit sessions per minion PR, comparable
+  to the implement session itself (order of a dollar per PR at current
+  usage); dry-run and the skip label are the relief valves if this
+  proves noisy.
+- If PR-time auditing proves high-signal, a later iteration may add a
+  scheduled sweep for drift in code that predates the audits — kept out
+  of scope now by explicit decision.
+- The known EnsureRepos stale-checkout backlog item is unrelated and
+  untouched by this work.

--- a/internal/agent/claude/find_latest_session.go
+++ b/internal/agent/claude/find_latest_session.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,8 +36,14 @@ func (d *Detector) FindLatestJSONLPath(repoRoot string) (string, error) {
 	}
 
 	sort.Slice(jsonlFiles, func(i, j int) bool {
-		ii, _ := jsonlFiles[i].Info()
-		jj, _ := jsonlFiles[j].Info()
+		ii, iErr := jsonlFiles[i].Info()
+		jj, jErr := jsonlFiles[j].Info()
+		if iErr != nil || jErr != nil {
+			// A file that vanished between ReadDir and Info sinks to the
+			// end of the newest-first order instead of panicking on nil.
+			slog.Debug("could not stat session file while sorting", "dir", sessionDir, "i_error", iErr, "j_error", jErr)
+			return iErr == nil
+		}
 		return ii.ModTime().After(jj.ModTime())
 	})
 

--- a/internal/agent/claude/parse_jsonl.go
+++ b/internal/agent/claude/parse_jsonl.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
@@ -16,7 +17,11 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening JSONL file: %w", err)
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			slog.Debug("closing JSONL file", "path", path, "error", closeErr)
+		}
+	}()
 
 	var (
 		messages    []agent.Message

--- a/internal/agent/claude/peek_session_id.go
+++ b/internal/agent/claude/peek_session_id.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"bufio"
 	"encoding/json"
+	"log/slog"
 	"os"
 )
 
@@ -13,7 +14,11 @@ func PeekSessionID(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			slog.Debug("closing session file", "path", path, "error", closeErr)
+		}
+	}()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/internal/agent/codex/find_session_dir.go
+++ b/internal/agent/codex/find_session_dir.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -38,7 +39,13 @@ func (d *Detector) FindLatestSession(repoRoot string) (string, *agent.SessionDat
 	if err != nil {
 		absRepoRoot = repoRoot
 	}
-	absRepoRoot, _ = filepath.Abs(absRepoRoot)
+	// Keep the unresolved path on failure — filepath.Abs returns "" on error,
+	// which would clobber the fallback instead of degrading gracefully.
+	if abs, absErr := filepath.Abs(absRepoRoot); absErr == nil {
+		absRepoRoot = abs
+	} else {
+		slog.Debug("could not resolve absolute repo root", "path", absRepoRoot, "error", absErr)
+	}
 
 	// Collect all .jsonl files
 	var files []string
@@ -69,7 +76,11 @@ func (d *Detector) FindLatestSession(repoRoot string) (string, *agent.SessionDat
 		if err != nil {
 			absCWD = cwd
 		}
-		absCWD, _ = filepath.Abs(absCWD)
+		if abs, absErr := filepath.Abs(absCWD); absErr == nil {
+			absCWD = abs
+		} else {
+			slog.Debug("could not resolve absolute session cwd", "path", absCWD, "error", absErr)
+		}
 
 		// Check if the session cwd matches or is a parent of the repo root
 		if absCWD == absRepoRoot || strings.HasPrefix(absRepoRoot, absCWD+"/") {

--- a/internal/agent/codex/parse_jsonl.go
+++ b/internal/agent/codex/parse_jsonl.go
@@ -4,11 +4,20 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
 	"github.com/partio-io/cli/internal/agent"
 )
+
+// closeLogged closes a read-only session file, logging the error instead of
+// propagating it — a failed close after reading loses nothing.
+func closeLogged(f *os.File, path string) {
+	if err := f.Close(); err != nil {
+		slog.Debug("closing codex session file", "path", path, "error", err)
+	}
+}
 
 // jsonlLine is the top-level structure of a Codex JSONL line.
 type jsonlLine struct {
@@ -43,7 +52,7 @@ func ParseJSONL(path string) (*agent.SessionData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening codex session: %w", err)
 	}
-	defer func() { _ = f.Close() }()
+	defer closeLogged(f, path)
 
 	data := &agent.SessionData{
 		Agent: "codex",
@@ -144,7 +153,7 @@ func PeekSessionID(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer func() { _ = f.Close() }()
+	defer closeLogged(f, path)
 
 	scanner := bufio.NewScanner(f)
 	if scanner.Scan() {
@@ -165,7 +174,7 @@ func PeekCWD(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer func() { _ = f.Close() }()
+	defer closeLogged(f, path)
 
 	scanner := bufio.NewScanner(f)
 	if scanner.Scan() {

--- a/internal/auditgate/comment.go
+++ b/internal/auditgate/comment.go
@@ -1,0 +1,127 @@
+package auditgate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// commentPrefix is the shared body prefix for all minion audit
+// comments. The gate appends the audit name so different audits on
+// the same PR each keep their own comment.
+const commentPrefix = "Minion audit — "
+
+// failBody renders the single red-run comment from a fail verdict.
+func failBody(auditName string, v Verdict) string {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%s%s audit failed.\n", commentPrefix, auditName)
+	for i, f := range v.Findings {
+		fmt.Fprintf(&b, "\n%d. `%s` — %s\n", i+1, f.Location, f.Reasoning)
+	}
+	return b.String()
+}
+
+// failClosedBody renders the red-run comment for a run whose verdict
+// was missing or malformed: the audit produced nothing the gate can
+// trust, so the gate reports that instead of findings.
+func failClosedBody(auditName string, cause error) string {
+	return fmt.Sprintf("%s%s audit produced no usable verdict; failing closed.\n\nDetail: %v\n",
+		commentPrefix, auditName, cause)
+}
+
+type comment struct {
+	ID   int64  `json:"id"`
+	Body string `json:"body"`
+}
+
+// upsertComment creates the audit comment on the PR, or updates the
+// existing one in place. The existing comment is found by body
+// prefix, never by author: minion comments are posted with a human
+// token, so the author distinguishes nothing.
+func upsertComment(cfg Config, body string) error {
+	match := commentPrefix + cfg.AuditName
+	existing, err := findComment(cfg, match)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", cfg.APIBaseURL, cfg.Repo, cfg.PRNumber)
+		return sendComment(cfg, http.MethodPost, url, body)
+	}
+	url := fmt.Sprintf("%s/repos/%s/issues/comments/%d", cfg.APIBaseURL, cfg.Repo, existing.ID)
+	return sendComment(cfg, http.MethodPatch, url, body)
+}
+
+// findComment scans the PR's comments for one whose body starts with
+// match, following pagination so a busy PR cannot hide it.
+func findComment(cfg Config, match string) (*comment, error) {
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("%s/repos/%s/issues/%d/comments?per_page=100&page=%d",
+			cfg.APIBaseURL, cfg.Repo, cfg.PRNumber, page)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("list comments: %w", err)
+		}
+		var comments []comment
+		if err := doGitHub(cfg, req, &comments); err != nil {
+			return nil, fmt.Errorf("list comments: %w", err)
+		}
+		for _, c := range comments {
+			if len(c.Body) >= len(match) && c.Body[:len(match)] == match {
+				return &c, nil
+			}
+		}
+		if len(comments) < 100 {
+			return nil, nil
+		}
+	}
+}
+
+func sendComment(cfg Config, method, url, body string) error {
+	payload, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return fmt.Errorf("encode comment: %w", err)
+	}
+	req, err := http.NewRequest(method, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("send comment: %w", err)
+	}
+	if err := doGitHub(cfg, req, nil); err != nil {
+		return fmt.Errorf("send comment: %w", err)
+	}
+	return nil
+}
+
+// doGitHub executes one GitHub API request and decodes the response
+// into out when out is non-nil.
+func doGitHub(cfg Config, req *http.Request, out any) error {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			slog.Debug("closing response body", "url", req.URL.Path, "error", closeErr)
+		}
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		detail, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if readErr != nil {
+			detail = fmt.Appendf(nil, "(error body unreadable: %v)", readErr)
+		}
+		return fmt.Errorf("github: %s %s: %s: %s", req.Method, req.URL.Path, resp.Status, detail)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/auditgate/run.go
+++ b/internal/auditgate/run.go
@@ -1,0 +1,46 @@
+// Package auditgate turns a minion audit verdict file into a CI
+// outcome: green only for a valid pass verdict, red for everything
+// else (fail-closed). On red it maintains a single PR comment
+// describing the findings.
+package auditgate
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Config carries everything one gate run needs.
+type Config struct {
+	VerdictPath string       // path to the verdict JSON file
+	Repo        string       // owner/name
+	PRNumber    int          // pull request to comment on
+	AuditName   string       // names this audit in the comment, e.g. "dead-code"
+	APIBaseURL  string       // GitHub API root, e.g. https://api.github.com
+	Token       string       // token for the comment upsert
+	HTTPClient  *http.Client // nil means http.DefaultClient
+}
+
+// Result is the gate's outcome. Green maps to exit 0, red to exit 1.
+type Result struct {
+	Green  bool
+	Reason string
+}
+
+// Run maps the verdict file to a check outcome and maintains the PR
+// comment on red.
+func Run(cfg Config) (Result, error) {
+	v, err := loadVerdict(cfg.VerdictPath)
+	if err != nil {
+		if upErr := upsertComment(cfg, failClosedBody(cfg.AuditName, err)); upErr != nil {
+			return Result{}, upErr
+		}
+		return Result{Green: false, Reason: fmt.Sprintf("fail-closed: %v", err)}, nil
+	}
+	if v.Status == "pass" {
+		return Result{Green: true, Reason: "verdict: pass"}, nil
+	}
+	if err := upsertComment(cfg, failBody(cfg.AuditName, v)); err != nil {
+		return Result{}, err
+	}
+	return Result{Green: false, Reason: fmt.Sprintf("verdict: fail with %d finding(s)", len(v.Findings))}, nil
+}

--- a/internal/auditgate/run_test.go
+++ b/internal/auditgate/run_test.go
@@ -1,0 +1,239 @@
+package auditgate
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fakeGitHub is a minimal issues-comments API double. It serves the
+// comments it is seeded with and records every comment created or
+// updated through it.
+type fakeGitHub struct {
+	comments []map[string]any
+	created  []string
+	updated  map[int64]string
+}
+
+func newFakeGitHub(seed ...map[string]any) *fakeGitHub {
+	return &fakeGitHub{comments: seed, updated: map[int64]string{}}
+}
+
+func (f *fakeGitHub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/partio-io/cli/issues/41/comments", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(f.comments); err != nil {
+			t.Errorf("encode comments: %v", err)
+		}
+	})
+	mux.HandleFunc("POST /repos/partio-io/cli/issues/41/comments", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Body string `json:"body"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("decode created comment: %v", err)
+		}
+		f.created = append(f.created, payload.Body)
+		w.WriteHeader(http.StatusCreated)
+		if _, err := w.Write([]byte(`{"id":1}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+	mux.HandleFunc("PATCH /repos/partio-io/cli/issues/comments/{id}", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Body string `json:"body"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("decode updated comment: %v", err)
+		}
+		id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+		if err != nil {
+			t.Errorf("parse comment id: %v", err)
+		}
+		f.updated[id] = payload.Body
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeVerdict(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "verdict.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write verdict fixture: %v", err)
+	}
+	return path
+}
+
+func runGate(t *testing.T, gh *fakeGitHub, verdictPath string) Result {
+	t.Helper()
+	srv := gh.server(t)
+	res, err := Run(Config{
+		VerdictPath: verdictPath,
+		Repo:        "partio-io/cli",
+		PRNumber:    41,
+		AuditName:   "dead-code",
+		APIBaseURL:  srv.URL,
+		Token:       "test-token",
+		HTTPClient:  srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return res
+}
+
+// A pass verdict is the only green outcome, and it must leave the PR
+// untouched: no comment created, none updated.
+func TestRunPassVerdictStaysGreenAndSilent(t *testing.T) {
+	verdict := writeVerdict(t, `{"status": "pass", "findings": []}`)
+	gh := newFakeGitHub()
+
+	res := runGate(t, gh, verdict)
+
+	if !res.Green {
+		t.Fatalf("Run returned red for a pass verdict: %+v", res)
+	}
+	if len(gh.created) != 0 || len(gh.updated) != 0 {
+		t.Errorf("pass verdict touched comments: created=%q updated=%v", gh.created, gh.updated)
+	}
+}
+
+// A missing verdict file means the audit session never finished its
+// final act. The gate fails closed: red, with a comment saying the
+// verdict was unusable rather than silently swallowing the outage.
+func TestRunMissingVerdictFailsClosed(t *testing.T) {
+	gh := newFakeGitHub()
+
+	res := runGate(t, gh, filepath.Join(t.TempDir(), "never-written.json"))
+
+	if res.Green {
+		t.Fatalf("Run returned green for a missing verdict file")
+	}
+	if len(gh.created) != 1 {
+		t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+	}
+	if !strings.HasPrefix(gh.created[0], "Minion audit — dead-code") {
+		t.Errorf("fail-closed comment does not start with audit prefix: %q", gh.created[0])
+	}
+}
+
+// Malformed verdicts are as untrustworthy as missing ones: red, with
+// the fail-closed comment, never a green or a findings-style comment
+// built from garbage. A fail verdict with no findings is malformed
+// too — the repair round in issue 03 would have nothing to act on.
+func TestRunMalformedVerdictFailsClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		verdict string
+	}{
+		{"not json", `{"status": "fail",`},
+		{"unknown status", `{"status": "maybe", "findings": []}`},
+		{"fail without findings", `{"status": "fail", "findings": []}`},
+		{"finding with empty fields", `{"status": "fail", "findings": [{"location": "", "reasoning": ""}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gh := newFakeGitHub()
+
+			res := runGate(t, gh, writeVerdict(t, tc.verdict))
+
+			if res.Green {
+				t.Fatalf("Run returned green for malformed verdict %q", tc.verdict)
+			}
+			if len(gh.created) != 1 {
+				t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+			}
+			if !strings.Contains(gh.created[0], "no usable verdict") {
+				t.Errorf("comment is not the fail-closed body: %q", gh.created[0])
+			}
+		})
+	}
+}
+
+// A re-run on red updates the existing audit comment in place. The
+// comment is matched by body prefix including the audit name — never
+// by author, and never a comment belonging to a different audit.
+func TestRunRedRunUpdatesExistingCommentInPlace(t *testing.T) {
+	verdict := writeVerdict(t, `{
+		"status": "fail",
+		"findings": [{"location": "cmd/partio/status.go:7", "reasoning": "second run reasoning"}]
+	}`)
+	gh := newFakeGitHub(
+		map[string]any{"id": int64(7), "body": "just a human discussing the PR"},
+		map[string]any{"id": int64(8), "body": "Minion audit — e2e-need audit failed.\n\nother audit's comment"},
+		map[string]any{"id": int64(9), "body": "Minion audit — dead-code audit failed.\n\nfirst run body"},
+	)
+
+	res := runGate(t, gh, verdict)
+
+	if res.Green {
+		t.Fatalf("Run returned green for a fail verdict")
+	}
+	if len(gh.created) != 0 {
+		t.Fatalf("re-run created a second comment instead of updating: %q", gh.created)
+	}
+	if len(gh.updated) != 1 {
+		t.Fatalf("updated %d comments, want exactly 1: %v", len(gh.updated), gh.updated)
+	}
+	body, ok := gh.updated[9]
+	if !ok {
+		t.Fatalf("updated the wrong comment: %v", gh.updated)
+	}
+	if !strings.Contains(body, "second run reasoning") {
+		t.Errorf("updated body does not carry the new findings: %q", body)
+	}
+}
+
+// Tracer bullet: a fail verdict turns the gate red and posts exactly
+// one PR comment carrying the audit prefix, the finding location, and
+// the finding reasoning.
+func TestRunFailVerdictGoesRedAndPostsOneComment(t *testing.T) {
+	verdict := writeVerdict(t, `{
+		"status": "fail",
+		"findings": [
+			{
+				"location": "internal/hooks/precommit.go:42",
+				"reasoning": "first branch short-circuits on a parameter every remaining call site hardcodes"
+			}
+		]
+	}`)
+	gh := newFakeGitHub()
+
+	res := runGate(t, gh, verdict)
+
+	if res.Green {
+		t.Fatalf("Run returned green for a fail verdict")
+	}
+	if len(gh.created) != 1 {
+		t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+	}
+	body := gh.created[0]
+	if !strings.HasPrefix(body, "Minion audit — dead-code") {
+		t.Errorf("comment does not start with audit prefix: %q", body)
+	}
+	for _, want := range []string{
+		"internal/hooks/precommit.go:42",
+		"first branch short-circuits on a parameter every remaining call site hardcodes",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("comment missing %q:\n%s", want, body)
+		}
+	}
+	if len(gh.updated) != 0 {
+		t.Errorf("updated %d comments, want 0", len(gh.updated))
+	}
+}

--- a/internal/auditgate/verdict.go
+++ b/internal/auditgate/verdict.go
@@ -1,0 +1,48 @@
+package auditgate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Finding is one audit finding: where the problem is and why the
+// auditor believes it is real.
+type Finding struct {
+	Location  string `json:"location"`
+	Reasoning string `json:"reasoning"`
+}
+
+// Verdict is the contract between an audit program and the gate:
+// the program writes it as its final act, the gate maps it to a
+// check outcome.
+type Verdict struct {
+	Status   string    `json:"status"`
+	Findings []Finding `json:"findings"`
+}
+
+// loadVerdict reads and validates the verdict file. Any error —
+// missing file, bad JSON, unknown status — is returned so the gate
+// can fail closed.
+func loadVerdict(path string) (Verdict, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Verdict{}, fmt.Errorf("read verdict: %w", err)
+	}
+	var v Verdict
+	if err := json.Unmarshal(data, &v); err != nil {
+		return Verdict{}, fmt.Errorf("parse verdict: %w", err)
+	}
+	if v.Status != "pass" && v.Status != "fail" {
+		return Verdict{}, fmt.Errorf("verdict status %q is neither pass nor fail", v.Status)
+	}
+	if v.Status == "fail" && len(v.Findings) == 0 {
+		return Verdict{}, fmt.Errorf("fail verdict carries no findings")
+	}
+	for i, f := range v.Findings {
+		if f.Location == "" || f.Reasoning == "" {
+			return Verdict{}, fmt.Errorf("finding %d is missing location or reasoning", i+1)
+		}
+	}
+	return v, nil
+}

--- a/internal/checkpoint/prune.go
+++ b/internal/checkpoint/prune.go
@@ -131,8 +131,13 @@ func (s *Store) rebuildTreeWithout(currentTree string, keepIDs map[string]bool, 
 		}
 	}
 
-	// Read current root tree to get existing entries (in case there are non-shard entries)
-	rootListing, _ := s.git("ls-tree", currentTree)
+	// Read current root tree to get existing entries (in case there are non-shard entries).
+	// A failed listing must abort: rebuilding from an empty listing would write
+	// a root tree that silently drops every entry it failed to read.
+	rootListing, err := s.git("ls-tree", currentTree)
+	if err != nil {
+		return "", fmt.Errorf("listing checkpoint root tree: %w", err)
+	}
 
 	var rootEntries []treeEntry
 

--- a/internal/checkpoint/read.go
+++ b/internal/checkpoint/read.go
@@ -3,6 +3,7 @@ package checkpoint
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/partio-io/cli/internal/git"
 )
@@ -38,10 +39,10 @@ func Read(id string) (*CheckpointData, error) {
 	}
 
 	// Read optional files — missing files are not errors
-	prompt, _ := git.ExecGit("show", prefix+"/0/prompt.txt")
-	plan, _ := git.ExecGit("show", prefix+"/0/plan.md")
-	diff, _ := git.ExecGit("show", prefix+"/0/diff.patch")
-	context, _ := git.ExecGit("show", prefix+"/0/context.md")
+	prompt := showOptional(prefix + "/0/prompt.txt")
+	plan := showOptional(prefix + "/0/plan.md")
+	diff := showOptional(prefix + "/0/diff.patch")
+	context := showOptional(prefix + "/0/context.md")
 
 	return &CheckpointData{
 		Metadata: meta,
@@ -50,4 +51,14 @@ func Read(id string) (*CheckpointData, error) {
 		Diff:     diff,
 		Context:  context,
 	}, nil
+}
+
+// showOptional reads one optional checkpoint file. Absence is expected, so
+// the failure is logged at debug and the file treated as empty.
+func showOptional(path string) string {
+	out, err := git.ExecGit("show", path)
+	if err != nil {
+		slog.Debug("optional checkpoint file not read", "path", path, "error", err)
+	}
+	return out
 }

--- a/internal/checkpoint/store.go
+++ b/internal/checkpoint/store.go
@@ -91,8 +91,12 @@ func (s *Store) addToTree(currentTree, shard, rest, cpTree string) (string, erro
 	// Build shard tree with new entry
 	var shardEntries []treeEntry
 	if shardTree != "" {
-		// Read existing shard entries
-		existing, _ := s.git("ls-tree", shardTree)
+		// Read existing shard entries. A failed listing must abort: rebuilding
+		// the shard from an empty listing would drop its existing checkpoints.
+		existing, lsErr := s.git("ls-tree", shardTree)
+		if lsErr != nil {
+			return "", fmt.Errorf("listing shard tree %s: %w", shard, lsErr)
+		}
 		for _, line := range strings.Split(existing, "\n") {
 			if line == "" {
 				continue

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -45,25 +46,24 @@ func mergeFromFile(dst *Config, path string) {
 		return
 	}
 
-	if v, ok := raw["enabled"]; ok {
-		_ = json.Unmarshal(v, &dst.Enabled)
+	mergeKey(raw, "enabled", path, &dst.Enabled)
+	mergeKey(raw, "strategy", path, &dst.Strategy)
+	mergeKey(raw, "agent", path, &dst.Agent)
+	mergeKey(raw, "log_level", path, &dst.LogLevel)
+	mergeKey(raw, "commit_linking", path, &dst.CommitLinking)
+	mergeKey(raw, "strategy_options", path, &dst.StrategyOptions)
+	mergeKey(raw, "stale_session_threshold", path, &dst.StaleSessionThreshold)
+}
+
+// mergeKey unmarshals raw[key] into dst if present. A malformed value keeps
+// the previous config value; it is logged rather than silently dropped so a
+// settings typo is visible instead of reverting to defaults without a trace.
+func mergeKey(raw map[string]json.RawMessage, key, path string, dst any) {
+	v, ok := raw[key]
+	if !ok {
+		return
 	}
-	if v, ok := raw["strategy"]; ok {
-		_ = json.Unmarshal(v, &dst.Strategy)
-	}
-	if v, ok := raw["agent"]; ok {
-		_ = json.Unmarshal(v, &dst.Agent)
-	}
-	if v, ok := raw["log_level"]; ok {
-		_ = json.Unmarshal(v, &dst.LogLevel)
-	}
-	if v, ok := raw["commit_linking"]; ok {
-		_ = json.Unmarshal(v, &dst.CommitLinking)
-	}
-	if v, ok := raw["strategy_options"]; ok {
-		_ = json.Unmarshal(v, &dst.StrategyOptions)
-	}
-	if v, ok := raw["stale_session_threshold"]; ok {
-		_ = json.Unmarshal(v, &dst.StaleSessionThreshold)
+	if err := json.Unmarshal(v, dst); err != nil {
+		slog.Warn("ignoring malformed config key", "path", path, "key", key, "error", err)
 	}
 }

--- a/internal/config/save.go
+++ b/internal/config/save.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -15,7 +16,12 @@ func SaveRepoSetting(repoRoot, key string, value any) error {
 
 	existing, err := os.ReadFile(settingsPath)
 	if err == nil {
-		_ = json.Unmarshal(existing, &raw)
+		// Refuse to proceed on a malformed file: continuing with an empty map
+		// would rewrite settings.json with only the new key, dropping every
+		// setting the user already had.
+		if err := json.Unmarshal(existing, &raw); err != nil {
+			return fmt.Errorf("existing %s is not valid JSON, not overwriting: %w", settingsPath, err)
+		}
 	}
 
 	encoded, err := json.Marshal(value)

--- a/internal/config/save_test.go
+++ b/internal/config/save_test.go
@@ -33,6 +33,32 @@ func TestSaveRepoSetting_NewFile(t *testing.T) {
 	}
 }
 
+func TestSaveRepoSetting_MalformedExisting(t *testing.T) {
+	dir := t.TempDir()
+	partioDir := filepath.Join(dir, PartioDir)
+	if err := os.MkdirAll(partioDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	malformed := `{"enabled": true,` // truncated JSON
+	settingsPath := filepath.Join(partioDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(malformed), 0o644); err != nil {
+		t.Fatalf("writing malformed settings: %v", err)
+	}
+
+	if err := SaveRepoSetting(dir, "commit_linking", CommitLinkingAlways); err == nil {
+		t.Fatal("expected error for malformed settings.json, got nil")
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("reading settings.json: %v", err)
+	}
+	if string(data) != malformed {
+		t.Errorf("malformed settings.json was rewritten: %q", string(data))
+	}
+}
+
 func TestSaveRepoSetting_PreservesExisting(t *testing.T) {
 	dir := t.TempDir()
 	partioDir := filepath.Join(dir, PartioDir)

--- a/internal/git/hooks/uninstall.go
+++ b/internal/git/hooks/uninstall.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -21,13 +22,17 @@ func Uninstall(repoRoot string) error {
 		// Only remove if it's our hook
 		if data, err := os.ReadFile(hookPath); err == nil {
 			if isPartioHook(string(data)) {
-				_ = os.Remove(hookPath)
+				if rmErr := os.Remove(hookPath); rmErr != nil {
+					slog.Warn("could not remove partio hook", "path", hookPath, "error", rmErr)
+				}
 			}
 		}
 
 		// Restore backup if present
 		if _, err := os.Stat(backupPath); err == nil {
-			_ = os.Rename(backupPath, hookPath)
+			if renameErr := os.Rename(backupPath, hookPath); renameErr != nil {
+				slog.Warn("could not restore hook backup", "backup", backupPath, "path", hookPath, "error", renameErr)
+			}
 		}
 	}
 

--- a/internal/hooks/commit_linking.go
+++ b/internal/hooks/commit_linking.go
@@ -38,12 +38,21 @@ func promptCommitLinking(repoRoot string) bool {
 		slog.Debug("commit linking: no TTY available, auto-linking")
 		return true
 	}
-	defer func() { _ = tty.Close() }()
+	defer func() {
+		if closeErr := tty.Close(); closeErr != nil {
+			slog.Debug("commit linking: could not close tty", "error", closeErr)
+		}
+	}()
 
-	_, _ = fmt.Fprint(tty, "partio: Link this commit to the active AI session? [Y/n/a] ")
+	if _, printErr := fmt.Fprint(tty, "partio: Link this commit to the active AI session? [Y/n/a] "); printErr != nil {
+		slog.Debug("commit linking: could not write prompt to tty", "error", printErr)
+	}
 
 	reader := bufio.NewReader(tty)
-	line, _ := reader.ReadString('\n')
+	line, readErr := reader.ReadString('\n')
+	if readErr != nil {
+		slog.Debug("commit linking: could not read tty answer, using default", "error", readErr)
+	}
 	answer := strings.TrimSpace(strings.ToLower(line))
 
 	switch answer {

--- a/internal/hooks/postcommit.go
+++ b/internal/hooks/postcommit.go
@@ -35,7 +35,9 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 		return nil
 	}
 	// Remove immediately to prevent re-entry (amend triggers post-commit again)
-	_ = os.Remove(stateFile)
+	if rmErr := os.Remove(stateFile); rmErr != nil {
+		slog.Warn("could not remove pre-commit state file; amend may re-trigger checkpoint", "state_file", stateFile, "error", rmErr)
+	}
 
 	var state preCommitState
 	if err := json.Unmarshal(data, &state); err != nil {
@@ -90,7 +92,10 @@ func runPostCommit(repoRoot string, cfg config.Config) error {
 
 	// Log staged file paths and session content paths for diagnosing path mismatches.
 	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
-		commitFiles, _ := git.DiffNameOnly(commitHash)
+		commitFiles, diffErr := git.DiffNameOnly(commitHash)
+		if diffErr != nil {
+			slog.Debug("post-commit: could not list commit files", "commit", commitHash, "error", diffErr)
+		}
 		slog.Debug("post-commit: file overlap check",
 			"commit", commitHash,
 			"staged_files", commitFiles,

--- a/internal/hooks/precommit.go
+++ b/internal/hooks/precommit.go
@@ -39,10 +39,16 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 		d, err := agent.NewDetector(cfg.Agent)
 		if err != nil {
 			slog.Warn("unknown configured agent", "agent", cfg.Agent, "error", err)
-		} else if r, _ := d.IsRunning(); r {
-			detector = d
-			running = true
-			slog.Debug("using configured agent", "agent", detector.Name())
+		} else {
+			r, runErr := d.IsRunning()
+			if runErr != nil {
+				slog.Warn("configured agent liveness check failed", "agent", cfg.Agent, "error", runErr)
+			}
+			if r {
+				detector = d
+				running = true
+				slog.Debug("using configured agent", "agent", detector.Name())
+			}
 		}
 	}
 
@@ -87,8 +93,14 @@ func runPreCommit(repoRoot string, cfg config.Config) error {
 		}
 	}
 
-	branch, _ := git.CurrentBranch()
-	commitHash, _ := git.CurrentCommit()
+	branch, branchErr := git.CurrentBranch()
+	if branchErr != nil {
+		slog.Debug("could not resolve current branch", "error", branchErr)
+	}
+	commitHash, commitErr := git.CurrentCommit()
+	if commitErr != nil {
+		slog.Debug("could not resolve current commit", "error", commitErr)
+	}
 
 	// If the agent supports session parsing, require a session path.
 	// Otherwise (no SessionParser), running is sufficient.


### PR DESCRIPTION
## Summary

Implements `docs/2026-08-03-minion-pr-audits/` (PRD + all 5 slices):

- **Lint gate** — golangci-lint now fails on blank-discarded errors, closing the swallowed-error pattern at the source instead of re-finding it in every audit.
- **Deadcode audit** (`deadcode-audit.yml` + program) — runs on PR opened/labeled/synchronize; audits the PR read-only and writes `.minion-audit/verdict.json` consumed by a gate check. Findings become `minion-proposal` issues and never turn the check red — only a crashed session (missing/malformed verdict) fails the gate.
- **Deadcode fix round** — bounded in-place fix commits (`audit:` prefix) on top of the read-only audit, with export preservation as a hard rule and an isolated golangci-lint cache. Concurrency sits on the audit job, not the workflow, so a fix push's guard-skipped run can't cancel the in-flight audit.
- **E2e-need audit** (`e2e-audit.yml` + program) — second audit action reusing the same trigger gating and verdict contract; each distinct coverage gap becomes a filed proposal.
- **Session-liveness proposal** — program file + issue #617: replace the machine-global `pgrep -f claude` liveness check with the agent PID recorded in session state, so manual commits made after a session ends stop getting agent attribution. Falls back to global detection when no PID was recorded.

Shared conventions across the audits: skip label `no-audit`, comment prefix `Minion audit —`, fix-commit prefix `audit:`, verdict file `.minion-audit/verdict.json` (never committed).

Mid-feature fix worth noting: proposal program files are now pushed to `HEAD:main` explicitly — the audit session's worktree sits on a session branch, so a bare push never reached main and left filed proposals pointing at program files that didn't exist there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)