### PR TITLE
fix(minions): let the dead-code fixer repair exported identifiers

### DIFF
--- a/.minions/programs/deadcode-audit-fix.md
+++ b/.minions/programs/deadcode-audit-fix.md
@@ -59,17 +59,18 @@ Work through the repair in this order:
    names. Rules:
 
    - Do not guess. If a repair requires a decision the finding does
-     not settle — choosing between two plausible behaviors, changing
-     a public contract, resurrecting the dead path instead of
-     removing it — leave that finding unfixed. A surviving finding
-     is the correct outcome for a fix that needs a human.
-   - Hard rule, no judgment: never change or remove an exported
-     identifier — function, method, type, field, or any signature —
-     even when the finding proves part of it inert, and even if
-     that means fixing nothing. An exported contract is a design
-     decision by definition; a comment marking the choice as open
-     (a TODO, a "decide later") makes this absolute. Export-level
-     repairs always go to a human.
+     not settle — choosing between two plausible behaviors,
+     resurrecting the dead path instead of removing it — leave that
+     finding unfixed. A surviving finding is the correct outcome
+     for a fix that needs a human.
+   - An exported identifier is fair game. Every Go file in this
+     module lives under `internal/` or `cmd/`, and Go forbids
+     importing an `internal/` package from outside the module that
+     declares it — so no package here is importable and a capital
+     letter is not a public contract. Repair a proven-inert
+     exported function, method, type, field, or signature exactly
+     as you would an unexported one. What bounds you is the proof
+     in the finding's reasoning, not the case of the first letter.
    - No opportunistic edits. Style, naming, or refactors beyond the
      findings are out of scope, however tempting.
    - Keep each repair coherent: removing a branch that orphans a

--- a/docs/2026-08-06-minion-ci-self-repair/issues.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues.md
@@ -1,0 +1,23 @@
+# Issues — 2026-08-06-minion-ci-self-repair
+
+Source: [prd.md](./prd.md)
+
+| Done | # | Title | Blocked by |
+|------|---|-------|------------|
+| [ ]  | 1 | [Unblock the dead-code fixer](./issues/01-unblock-deadcode-fixer.md) | None |
+| [ ]  | 2 | [Count repair rounds instead of forbidding them](./issues/02-count-repair-rounds.md) | [#1](./issues/01-unblock-deadcode-fixer.md) |
+| [ ]  | 3 | [Say when it gave up](./issues/03-rounds-exhausted-comment.md) | [#2](./issues/02-count-repair-rounds.md) |
+| [ ]  | 4 | [One shared apply-prove-push](./issues/04-shared-patch-apply.md) | [#2](./issues/02-count-repair-rounds.md) |
+| [ ]  | 5 | [Lint and test as a PR check](./issues/05-lint-test-pr-check.md) | None |
+| [ ]  | 6 | [Repair failing lint and tests](./issues/06-repair-failing-checks.md) | [#4](./issues/04-shared-patch-apply.md), [#5](./issues/05-lint-test-pr-check.md) |
+| [ ]  | 7 | [Stop the gates colliding](./issues/07-gate-concurrency-and-retry.md) | [#6](./issues/06-repair-failing-checks.md) |
+
+## Notes
+
+Every slice lands on `main` through a pull request that jcleira merges;
+no slice merges itself. Where a slice's proof requires the change to be
+live on `main` — slice 1's re-run of PR #622 is the clearest case —
+that step is called out in the slice's own acceptance criteria as a
+post-merge verification.
+
+Slices 1 and 5 have no blockers and can start immediately.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/01-unblock-deadcode-fixer.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/01-unblock-deadcode-fixer.md
@@ -1,0 +1,102 @@
+# 01 — Unblock the dead-code fixer
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+The dead-code audit's repair session currently refuses to fix any
+finding that involves a capitalized (exported) identifier, even when
+the audit has fully proven the code inert. It writes no patch, the
+first verdict stands, and the pull request goes red for a human to
+resolve. Remove that refusal.
+
+The rule exists to protect an external contract. This module has none:
+every Go file lives under `internal/` or `cmd/`, and Go forbids
+importing an `internal/` package from outside the module that declares
+it. There is no consumer any repair here can break.
+
+Concretely, the fix program that runs after a failed dead-code audit
+loses its exported-identifier prohibition and the reasoning paragraph
+that justified it. Its other restraints are unchanged and must survive
+the edit: repair only what a finding's reasoning proves, decline
+findings that need a judgment the reasoning does not settle, make no
+opportunistic edits beyond the findings, keep each repair coherent so
+the tree still builds, and export nothing at all when the repo's checks
+cannot be made green.
+
+Record the new rationale in the program itself — that this module
+exposes no importable API, so an exported identifier here is not a
+public contract — so a future reader knows the rule was scoped
+deliberately rather than dropped by accident.
+
+## User stories covered
+
+PRD user stories 1, 2, 3, 30.
+
+## Acceptance criteria
+
+- [x] The dead-code fix program no longer contains a prohibition on
+      changing or removing exported identifiers.
+- [x] The program states why the prohibition does not apply here: no
+      package in this module is importable from outside it.
+- [x] The program's remaining restraints are still present and
+      unweakened — proof-bounded repairs, declining under-determined
+      findings, no opportunistic edits, coherent repairs, and exporting
+      nothing when the checks cannot pass.
+- [x] The program still forbids the session from running any git write
+      command and still requires the skip marker as its final act.
+- [x] A dry run of the dead-code audit fix program generates a prompt
+      that contains no exported-identifier prohibition.
+- [ ] Post-merge verification: re-running the dead-code audit on PR
+      #622 completes with no surviving findings, and the inert `Model`
+      field on the session type is removed by the pipeline with no
+      human edit.
+
+## Modules touched
+
+The dead-code fix program from the PRD's Implementation Decisions
+("Dead-code fix program (modified)"). No Go packages change in this
+slice.
+
+## Test prior art
+
+None applicable — this slice changes a prompt program, which is
+model-driven and not unit-testable. The PRD names this gap explicitly
+in Testing Decisions. The program's contract is enforced downstream
+instead: a session that produces a bad patch fails the apply step's
+`make lint && make test` and pushes nothing.
+
+Verification for this slice is the dry-run prompt inspection and the
+post-merge audit re-run named in the acceptance criteria. Dry-run
+character counts are a useful tell that a section survived the edit —
+sections outside the program's agent prose are silently dropped by the
+runtime.
+
+The `dry_run` input on the Deadcode Audit workflow does not exercise
+this program. That path runs `deadcode-audit.md` only, and the `Fix
+round` step waits for a verdict status that a dry run never writes.
+Prove the fix program directly, with the version CI pins:
+
+```
+GOBIN=/tmp/mbin go install github.com/partio-io/minions/cmd/minions@v0.0.13
+MINION_AUDIT_DIR=/tmp/.minion-audit GH_TOKEN="$(gh auth token)" \
+  /tmp/mbin/minions run .minions/programs/deadcode-audit-fix.md \
+  --pr partio-io/cli#622 --dry-run
+```
+
+The run prints a per-component character count. Read
+`agent_instructions:deadcode-audit-fix`: it must stay near 3044 chars
+and the component count must stay 5. A sharp drop means the rules
+section was dropped, not edited.
+
+## Out of scope
+
+- Round counting. The repair still gets exactly one attempt; slice
+  [02](./02-count-repair-rounds.md) changes that.
+- Any change to what the dead-code audit itself reports. Only the
+  fixer's permissions change.
+- The e2e-need audit and its fix behavior — it has no fix round and is
+  not gaining one.
+- Re-scoping the rule to a future importable package. Noted in the
+  PRD's Further Notes as the thing to do if one ever appears.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/02-count-repair-rounds.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/02-count-repair-rounds.md
@@ -1,0 +1,87 @@
+# 02 — Count repair rounds instead of forbidding them
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [01 — Unblock the dead-code fixer](./01-unblock-deadcode-fixer.md)
+
+## What to build
+
+Today a repaired pull request can never be repaired again. The audit
+workflow's loop guard reads the head commit's subject line and skips
+the entire run when it looks like a repair commit. That stops runaway
+loops, but it also means a repair that lands one edit short of green is
+indistinguishable from a repair that was never attempted.
+
+Replace the guard with accounting. Before an audit runs, ask how many
+repair rounds for *this* check already sit on the pull request's
+branch. Under the cap, the run proceeds and knows which round it is;
+at the cap, the run stops without auditing again.
+
+The cap is three rounds per check, counted independently. A dead-code
+repair must never consume the budget a failing test would need, so
+repair commits have to carry a marker naming which check produced
+them, and the count for one check must ignore commits belonging to
+another. Commits authored by a human, and commits whose subject merely
+resembles a repair marker without being one, must not be counted.
+
+This slice introduces the accounting as a tested package and wires the
+dead-code audit workflow to it. Once landed, a dead-code finding that
+survives its first repair gets a second and a third attempt, and the
+fourth run declines.
+
+## User stories covered
+
+PRD user stories 4, 5, 6, 19, 25.
+
+## Acceptance criteria
+
+- [ ] A new package owns the decision "may another repair round start
+      for this check, and which round is it?", taking the branch's
+      commit subjects, the check name, and the cap as input.
+- [ ] Repair commits are marked so that the check that produced them is
+      recoverable from the commit subject alone.
+- [ ] Counting for one check ignores repair commits belonging to another
+      check.
+- [ ] The cap is three rounds per check, and the package reports the
+      round number so a caller can distinguish the first attempt from
+      the last.
+- [ ] Human-authored commits and near-miss subjects are not counted as
+      repair rounds.
+- [ ] The dead-code audit workflow consults the package instead of its
+      inline shell skip guard, and stops auditing once the budget for
+      that check is spent.
+- [ ] A pull request whose first repair leaves findings receives a
+      second repair attempt rather than going red immediately.
+- [ ] The package is covered by table-driven tests over commit-subject
+      lists: no prior rounds, one, at the cap, over the cap, another
+      check's rounds interleaved, human commits interleaved, an empty
+      branch, and a subject that resembles a marker without being one.
+
+## Modules touched
+
+`internal/repairround` (new), and the dead-code audit workflow from the
+PRD's Implementation Decisions ("Workflows").
+
+## Test prior art
+
+`internal/*/[a-z]*_test.go` throughout the repo: table-driven, standard
+library `testing` only, no external assertion frameworks. `t.TempDir()`
+for filesystem isolation and `t.Setenv()` for environment variables.
+`internal/auditgate/*_test.go` is the closest sibling in both subject
+matter and shape.
+
+The repository convention of one primary concern per file applies to
+the new package.
+
+## Out of scope
+
+- What happens after the budget is spent. The pull request simply stops
+  being audited; slice [03](./03-rounds-exhausted-comment.md) adds the
+  comment that says so.
+- Moving the apply-prove-push shell into Go. Slice
+  [04](./04-shared-patch-apply.md) does that.
+- The lint/test gate, which does not exist yet. Slice
+  [05](./05-lint-test-pr-check.md) adds it, and slice
+  [06](./06-repair-failing-checks.md) gives it repair rounds using this
+  package.
+- Concurrency between gates. Slice
+  [07](./07-gate-concurrency-and-retry.md) covers it.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/03-rounds-exhausted-comment.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/03-rounds-exhausted-comment.md
@@ -1,0 +1,66 @@
+# 03 — Say when it gave up
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [02 — Count repair rounds instead of forbidding them](./02-count-repair-rounds.md)
+
+## What to build
+
+With round counting in place, a pull request can exhaust its repair
+budget and stop. From the outside that is indistinguishable from a
+check that never attempted a repair at all — both look like a red
+check with a findings comment. Make the difference visible.
+
+When the budget is spent and findings still survive, the check's
+comment says so: it names the findings that remain and states how many
+repair rounds ran. The operator should be able to act on it without
+opening a workflow log.
+
+The comment surface already exists and already upserts — a pull request
+accumulates one comment per check rather than one per run. That
+behavior must hold: three rounds must not leave three comments, and the
+final comment replaces whatever the earlier rounds left.
+
+## User stories covered
+
+PRD user stories 15, 16, 17, 18.
+
+## Acceptance criteria
+
+- [ ] When repair rounds are exhausted and findings survive, the
+      check's pull request comment names the surviving findings.
+- [ ] That comment states how many repair rounds ran.
+- [ ] The comment is distinguishable from a first-round failure comment,
+      so "gave up after spending the budget" reads differently from
+      "failed on the first pass".
+- [ ] Repeated rounds upsert a single comment per check rather than
+      appending a new one each round.
+- [ ] The pull request is left red and open. Nothing closes it, rebuilds
+      it, or re-runs the build.
+- [ ] Tests cover the rounds-exhausted comment body and the upsert path
+      that replaces a prior comment rather than appending.
+
+## Modules touched
+
+`internal/auditgate` (modified), per the PRD's Implementation Decisions.
+Consumes the round number produced by `internal/repairround` from slice
+[02](./02-count-repair-rounds.md).
+
+## Test prior art
+
+`internal/auditgate/run_test.go` is the direct precedent and the file
+this slice extends: table-driven, standard library `testing` only, a
+local `httptest` server standing in for the GitHub API so no test
+touches the network, and `t.TempDir()` for verdict-file fixtures.
+
+Assert on the comment body's observable content and on which HTTP verb
+the upsert chose — not on unexported helper names or call ordering.
+
+## Out of scope
+
+- Rebuilding or closing an exhausted pull request. The PRD rules that
+  out explicitly; the pipeline stops and reports.
+- Changing what the audits themselves find or how findings are worded.
+- Notifying anywhere other than the pull request comment — no email, no
+  Slack, no issue.
+- The lint/test gate's comments, which arrive with slice
+  [05](./05-lint-test-pr-check.md) and reuse this same surface.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/04-shared-patch-apply.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/04-shared-patch-apply.md
@@ -1,0 +1,87 @@
+# 04 — One shared apply-prove-push
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [02 — Count repair rounds instead of forbidding them](./02-count-repair-rounds.md)
+
+## What to build
+
+A repair session never commits or pushes. It produces a patch, and the
+workflow owns everything after that: fetch the pull request's real
+head, detach a worktree onto it, apply the patch, prove the result with
+the repository's own lint and test targets, commit it with a marked
+subject, and push it. That sequence currently lives as inline shell in
+the audit workflow, and a second gate would mean copying it.
+
+Move it into a tested package and switch the dead-code gate over. After
+this slice there is one implementation of apply-prove-push, so a defect
+found in it is fixed once for every gate rather than once per workflow.
+
+Behavior that must be preserved exactly, because each piece was learned
+the hard way:
+
+- A patch that does not apply pushes nothing and reports that, rather
+  than failing the job.
+- A patch that applies but leaves the checks red pushes nothing.
+- The push uses the personal access token explicitly. A push made with
+  the default Actions token does not trigger the follow-up run that
+  round accounting depends on, so the fix would appear to work and
+  then silently stop the loop.
+- A pull request whose head branch lives in a fork is detected and
+  refused before any fetch is attempted, since the workflow cannot push
+  there.
+- The commit subject carries the marker slice
+  [02](./02-count-repair-rounds.md) counts on, naming which check
+  produced the repair.
+
+## User stories covered
+
+PRD user stories 13, 14, 26, 28.
+
+## Acceptance criteria
+
+- [ ] A new package owns fetch, detach, apply, prove, commit, and push
+      for a repair patch, given the patch, the pull request reference,
+      and the check name.
+- [ ] The dead-code audit workflow uses the package instead of its
+      inline shell, and its end-to-end repair behavior is unchanged.
+- [ ] A patch that fails to apply results in nothing pushed, reported as
+      a failed round rather than a job error.
+- [ ] A patch that applies but fails `make lint` or `make test` results
+      in nothing pushed.
+- [ ] The push is made with the personal access token, not the default
+      Actions token.
+- [ ] A fork head is refused before any fetch, with a clear reason.
+- [ ] The commit subject carries the per-check repair marker that slice
+      [02](./02-count-repair-rounds.md) counts.
+- [ ] Tests drive the package against temporary git repositories created
+      by the test, pushing to a local bare repository so no test touches
+      the network, and cover: a patch that applies and passes, one that
+      does not apply, one that applies but fails the checks, and a fork
+      head.
+
+## Modules touched
+
+`internal/patchapply` (new), and the dead-code audit workflow from the
+PRD's Implementation Decisions ("Workflows"). Produces commit subjects
+that `internal/repairround` reads.
+
+## Test prior art
+
+`internal/git/*_test.go` for tests that build real repositories in
+`t.TempDir()` and drive git operations against them. `internal/checkpoint`
+tests are the precedent for exercising git plumbing without a remote.
+
+Assert on observable outcomes — was anything pushed, what does the
+target repository contain, what does the commit subject say — not on
+which git commands ran in what order.
+
+## Out of scope
+
+- The lint/test gate's repair path, which becomes the package's second
+  consumer in slice [06](./06-repair-failing-checks.md).
+- Changing how a repair session produces its patch. The session contract
+  is unchanged: emit a patch, never commit, never push, write the skip
+  marker.
+- Concurrency between gates pushing to the same branch. Slice
+  [07](./07-gate-concurrency-and-retry.md) covers it.
+- The e2e-need audit, which produces no patches and never pushes.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/05-lint-test-pr-check.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/05-lint-test-pr-check.md
@@ -1,0 +1,81 @@
+# 05 — Lint and test as a PR check
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+There is no `make test` or `make lint` check on pull requests. Both run
+inside the minion session and inside the audit's apply step, but
+neither produces a check, so a broken build never turns anything red.
+It is found by reading the diff, or after merging.
+
+Add the gate. It runs on every pull request — hand-written ones
+included — and reports red or green like the audits do. This slice
+delivers signal only; repair arrives in slice
+[06](./06-repair-failing-checks.md).
+
+The design point that makes the rest of the work cheap: the gate emits
+the *same verdict artifact the audits already emit* — a status plus a
+list of findings, each with a location and the reasoning behind it.
+Because the shape matches, the existing verdict gate command, the pull
+request comment surface, the round accounting from slice
+[02](./02-count-repair-rounds.md), and the patch applier from slice
+[04](./04-shared-patch-apply.md) all work on lint and test failures
+without knowing what produced them.
+
+Failures must carry enough reasoning for a later repair session to act
+without re-running anything itself: which package or linter failed,
+where, and what the failure said.
+
+## User stories covered
+
+PRD user stories 7, 8, 9, 23, 29.
+
+## Acceptance criteria
+
+- [ ] `make lint` and `make test` run as a check on every pull request,
+      including pull requests with no minion label.
+- [ ] Failures are converted into the same verdict shape the audits
+      emit, one finding per failing package or linter finding.
+- [ ] Each finding carries a location and reasoning sufficient to act on
+      without re-running the command.
+- [ ] A clean run yields a pass verdict and a green check.
+- [ ] The check reports through the existing pull request comment
+      surface, upserting one comment rather than appending per run.
+- [ ] A missing or malformed verdict fails the check closed, matching
+      how the audits behave — a gate must never pass by producing
+      nothing.
+- [ ] No repair is attempted and no commit is pushed by this slice, on
+      any pull request.
+- [ ] The verdict conversion is covered by tests over captured command
+      output fixtures: a clean run, a failing test, a lint finding, and
+      unparseable output — asserting the resulting status and findings.
+- [ ] The work requires no minions release and no version-pin bump.
+
+## Modules touched
+
+`internal/checksverdict` (new) and the new checks workflow from the
+PRD's Implementation Decisions ("Workflows"). Reuses the existing
+verdict gate command and `internal/auditgate`'s comment surface
+unchanged.
+
+## Test prior art
+
+`internal/auditgate/*_test.go` for verdict loading and gate outcomes,
+including the fail-closed paths for a missing or malformed verdict —
+this slice must not regress that behavior for its own verdicts.
+
+Command-output fixtures belong in `testdata/` per Go convention.
+Table-driven, standard library `testing` only, `t.TempDir()` for
+filesystem isolation.
+
+## Out of scope
+
+- Repairing anything. The gate reports; slice
+  [06](./06-repair-failing-checks.md) makes it fix.
+- Pushing commits to any branch, including minion branches.
+- Any quality signal beyond lint and test. Others may earn a gate later
+  and would inherit the repair contract rather than extend this scope.
+- Concurrency with the audit gates, added in slice
+  [07](./07-gate-concurrency-and-retry.md).

--- a/docs/2026-08-06-minion-ci-self-repair/issues/06-repair-failing-checks.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/06-repair-failing-checks.md
@@ -1,0 +1,95 @@
+# 06 — Repair failing lint and tests
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [04 — One shared apply-prove-push](./04-shared-patch-apply.md), [05 — Lint and test as a PR check](./05-lint-test-pr-check.md)
+
+## What to build
+
+The lint/test gate reports failures but does nothing about them. Give
+it the repair round the dead-code audit has, using the machinery the
+previous slices built: round accounting decides whether another attempt
+is allowed, a repair session produces a patch, and the shared applier
+proves and pushes it.
+
+Repair is attempted only on pull requests that carry the minion label
+and whose head branch lives in this repository. Hand-written branches
+get the red/green signal and nothing else — no bot commits are pushed
+to work the operator wrote.
+
+The repair session's boundary is what makes this safe. It may modify
+implementation code freely. It may modify a test **only when that test
+was added by the pull request under repair** — a minion's own new test
+being wrong is the common case and should not become the operator's
+queue. A test that predates the pull request is out of bounds, and a
+failure in one is a surviving finding that goes red. This is the one
+rule that prevents the classic failure where a bot reaches green by
+deleting an assertion.
+
+The session follows the same contract as the dead-code fixer: produce a
+patch, never commit, never push, never comment, and write the skip
+marker as its final act on every path.
+
+## User stories covered
+
+PRD user stories 10, 11, 12, 27.
+
+## Acceptance criteria
+
+- [ ] A failing lint/test verdict on a minion-labeled pull request
+      triggers a repair round.
+- [ ] Repair is skipped for pull requests without the minion label, and
+      no commit is pushed to them.
+- [ ] Repair is skipped for pull requests whose head branch lives in a
+      fork, with a clear reason and no push attempt.
+- [ ] The repair session may modify implementation code and may modify
+      tests the same pull request added.
+- [ ] The repair session does not modify tests that predate the pull
+      request; a failure in one survives as a finding and the check goes
+      red.
+- [ ] The session produces a patch only, and runs no git write command
+      on any path.
+- [ ] Rounds are capped at three for this check, counted independently
+      of the dead-code check's rounds.
+- [ ] Repairs are applied, proven, and pushed through the shared applier
+      from slice [04](./04-shared-patch-apply.md), not through new
+      inline shell.
+- [ ] A pull request whose failing test the minion itself wrote goes
+      green without human edits.
+- [ ] Rounds exhausted with findings surviving produces the give-up
+      comment from slice [03](./03-rounds-exhausted-comment.md), naming
+      the survivors and the round count.
+
+## Modules touched
+
+The checks fix program (new) from the PRD's Implementation Decisions,
+plus the checks workflow (modified). Consumes `internal/repairround`,
+`internal/patchapply`, `internal/checksverdict`, and `internal/auditgate`
+— no new Go package is introduced by this slice.
+
+## Test prior art
+
+The repair program itself is model-driven and not unit-testable; the
+PRD names this in Testing Decisions. Its contract is enforced
+downstream — a session that produces a bad patch fails the applier's
+`make lint && make test` and pushes nothing.
+
+The Go-side behavior this slice wires together is already covered by
+the tests from slices [02](./02-count-repair-rounds.md),
+[04](./04-shared-patch-apply.md), and
+[05](./05-lint-test-pr-check.md). Any new decision logic added here —
+label and fork gating in particular — gets its own table-driven tests
+in the style of `internal/auditgate/*_test.go`.
+
+Distinguishing PR-added tests from pre-existing ones is decidable from
+the pull request diff; that determination is Go-side logic and must be
+tested, not left to the session's judgment alone.
+
+## Out of scope
+
+- Widening the gate beyond lint and test.
+- Repairing hand-written or fork pull requests.
+- Rebuilding a pull request that exhausts its rounds — it stops and
+  reports.
+- Concurrency between this gate and the audit gates, which slice
+  [07](./07-gate-concurrency-and-retry.md) resolves. Until that lands,
+  two gates repairing the same branch at once remains possible.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/07-gate-concurrency-and-retry.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/07-gate-concurrency-and-retry.md
@@ -1,0 +1,77 @@
+# 07 — Stop the gates colliding
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [06 — Repair failing lint and tests](./06-repair-failing-checks.md)
+
+## What to build
+
+Two hardening changes that only matter once a third gate exists and two
+of them can repair.
+
+**A per-pull-request lock across the gates.** The dead-code gate and
+the lint/test gate can both fail on the same pull request, and both can
+push a repair to the same branch. Nothing today stops them doing it at
+the same time, which loses one repair or produces a confusing branch
+state. All three gates share a concurrency group keyed on the pull
+request number, so at most one repair pushes to a branch at a time.
+
+The existing arrangement has a subtlety that must survive: concurrency
+lives on the auditing job, not on the workflow. A repair's own push
+triggers a follow-up run, and a workflow-level group would let that run
+cancel the in-flight job doing the repairing. A job that skips without
+auditing never enters the group, so only runs that will actually do
+work supersede each other.
+
+**A single retry for a crashed e2e session.** The e2e-need audit never
+fails a pull request on findings — they become proposal issues. Its
+only red state is infrastructure: a session that crashes, or one that
+finishes without writing a verdict. That is not a code defect and
+should not read as one. Retry the audit session once; if the second
+attempt also produces nothing readable, the check goes red rather than
+being treated as a pass.
+
+## User stories covered
+
+PRD user stories 20, 21, 22, 24.
+
+## Acceptance criteria
+
+- [ ] All three gates share a concurrency group keyed on the pull
+      request number.
+- [ ] The group is scoped to the job that audits, not to the workflow,
+      so a repair's follow-up run cannot cancel the job performing the
+      repair.
+- [ ] A job that skips without auditing does not enter the group.
+- [ ] Two gates failing on the same pull request cannot push repairs
+      concurrently.
+- [ ] A crashed e2e audit session, or one that writes no verdict, is
+      retried once.
+- [ ] A second failed attempt leaves the check red; an infrastructure
+      failure is never reported as a pass.
+- [ ] The e2e audit's judgment is otherwise unchanged: findings still
+      become proposal issues and still never fail a pull request.
+
+## Modules touched
+
+All three gate workflows from the PRD's Implementation Decisions
+("Workflows"). No Go package changes.
+
+## Test prior art
+
+None applicable — this slice changes workflow configuration, which the
+PRD names in Testing Decisions as deliberately not unit-tested. Its
+correctness is established by live runs: a pull request failing two
+gates at once should show serialized repairs, and the e2e retry is
+observable in the run log.
+
+## Out of scope
+
+- Any change to what the e2e audit judges or how it words findings.
+- Giving the e2e audit a repair round. It does not block pull requests,
+  so it needs none.
+- Cross-pull-request serialization. Gates on different pull requests may
+  still run concurrently; the runner's own capacity is the only limit
+  there.
+- Retrying the dead-code or lint/test sessions on a crash. Those already
+  fail closed into the verdict gate, and their repair budget covers
+  retry.

--- a/docs/2026-08-06-minion-ci-self-repair/prd.md
+++ b/docs/2026-08-06-minion-ci-self-repair/prd.md
@@ -1,0 +1,310 @@
+# Minion CI Self-Repair
+
+## Problem Statement
+
+The minion pipeline builds pull requests unattended, but the moment one
+of its checks goes red the work stops and lands on the operator. That
+is the exact toil the pipeline exists to remove, and today it happens
+for three separate reasons.
+
+**The repair round declines on its own guardrail.** The dead-code audit
+already has a fix round, and it fires correctly. But the fix program
+carries a hard rule — never change or remove an exported identifier,
+even when proven inert, because an exported contract is a design
+decision for a human. On PR #622 the audit proved that a newly-added
+`Model` field on the session type is written by nothing and read by
+nothing. The fix session read the finding, matched the rule, exported
+no patch, and the gate failed the PR. The rule guards a public API this
+module does not have: every Go file lives under `internal/` or `cmd/`,
+so nothing outside the module can import any of it. The rule therefore
+fires on nearly every finding the audit can produce, and the escalation
+it triggers is always to a human who has no contract to protect.
+
+**One attempt, ever.** The workflow takes exactly one repair round and
+the loop guard actively prevents a second: any run whose head commit
+begins with the repair prefix is skipped outright. A fix that lands
+one edit short is indistinguishable from a fix that was never tried.
+
+**The largest failure class has no check at all.** There is no
+`make test` or `make lint` gate on pull requests. Both run inside the
+minion session and inside the audit's apply step, but neither produces
+a PR check, so a broken build never turns anything red and never
+reaches the repair machinery. The operator finds it by reading the
+diff or by merging it.
+
+The net effect is a pipeline that is unattended right up until it isn't,
+with no way to tell "the machine gave up" from "the machine never
+tried".
+
+## Solution
+
+Give every blocking check the same repair contract, and let it try more
+than once.
+
+- **One verdict shape for every gate.** The lint/test gate emits the
+  same verdict artifact the audits already emit — a status plus a list
+  of findings, each with a location and the reasoning behind it. The
+  existing verdict gate, the PR comment surface, the round counter, and
+  the patch applier then work on all three checks without knowing which
+  one produced the verdict.
+- **Repair rounds are counted, not forbidden.** The loop guard stops
+  being a hard skip and becomes an accounting question: how many repair
+  commits for this check already sit on the PR branch, and is another
+  round allowed? The cap is three per check, counted independently, so
+  a dead-code repair never consumes a test repair's budget.
+- **Repair is deterministic where it must be.** A repair session only
+  ever produces a patch. Applying it to the true PR head, proving it
+  with the repo's own checks, committing it and pushing it stays
+  machine-owned, in one shared implementation rather than shell copied
+  into each workflow. A patch that does not apply, or applies but fails
+  the checks, pushes nothing and costs one round.
+- **The fixer's reach matches the repo.** The exported-identifier rule
+  comes out. Nothing in this module is importable from outside it, so
+  there is no contract for the rule to protect and no reason for the
+  fixer to stop at a capital letter.
+- **Failure terminates visibly.** After the third round the PR stays
+  red and gets one comment naming the findings that survived and how
+  many rounds ran. The pipeline never rebuilds the PR on its own and
+  never cycles.
+- **Signal for everyone, commits for minions only.** The lint/test gate
+  runs on every pull request, so hand-written branches get the same
+  red/green signal. Automatic repair commits are pushed only to
+  minion-labeled PRs whose head branch lives in this repository.
+
+The e2e-need audit is unchanged. Its findings become `minion-proposal`
+issues and never fail a PR, so it needs no repair round; its only red
+state is an infrastructure failure, which retries once and then reports.
+
+## User Stories
+
+1. As the operator, I want a minion PR that fails an audit to repair
+   itself, so that I am not hand-editing code a machine wrote.
+2. As the operator, I want the dead-code fixer to remove an inert
+   exported field, so that a finding it has fully proven does not
+   escalate to me for a decision there is nothing to decide.
+3. As the operator, I want the fixer's reach justified by the repo's
+   actual import surface, so that the guardrail reflects real risk
+   rather than a naming convention.
+4. As the operator, I want a repair that lands one edit short to get
+   another attempt, so that a near-miss is not treated as a refusal.
+5. As the operator, I want repair attempts capped, so that a confused
+   fixer cannot occupy my single self-hosted runner indefinitely.
+6. As the operator, I want each check to have its own repair budget, so
+   that a stubborn dead-code finding does not exhaust the attempts a
+   failing test needed.
+7. As the operator, I want `make test` to run on every pull request, so
+   that a broken build is visible before review rather than after merge.
+8. As the operator, I want `make lint` to run on every pull request, so
+   that lint failures surface on the same terms as test failures.
+9. As the operator, I want the lint/test gate on my own branches too,
+   so that I get the same signal the minions get.
+10. As the operator, I want no bot commits pushed to branches I wrote,
+    so that my own work stays mine even while minion PRs self-repair.
+11. As the operator, I want a failing test the minion itself just wrote
+    to be repairable, so that its own mistakes do not become my queue.
+12. As the operator, I want my established test suite frozen against the
+    fixer, so that a real assertion cannot quietly disappear on the way
+    to green.
+13. As the operator, I want every repair proven with the repo's own
+    checks before it is pushed, so that a repair cannot make the branch
+    worse than it found it.
+14. As the operator, I want a repair patch that fails to apply to push
+    nothing, so that a stale patch never corrupts the branch.
+15. As the operator, I want a PR still red after the last round to say
+    so plainly, so that I can tell "gave up" from "never ran".
+16. As the operator, I want the give-up comment to name the surviving
+    findings, so that I can act without opening workflow logs.
+17. As the operator, I want the give-up comment to state how many rounds
+    ran, so that I know the budget was actually spent.
+18. As the operator, I want the pipeline never to rebuild a PR on its
+    own, so that a bad issue cannot cycle build-and-fail unattended.
+19. As the operator, I want repair commits clearly marked in history, so
+    that I can see at a glance which changes a machine made after the
+    build.
+20. As the operator, I want two failing gates never to push to the same
+    branch at once, so that concurrent repairs cannot clobber each other.
+21. As the operator, I want a crashed audit session to retry once, so
+    that infrastructure noise does not read as a code defect.
+22. As the operator, I want a crashed session that fails twice to go
+    red, so that a broken runner is never silently treated as a pass.
+23. As the operator, I want an unreadable or missing verdict to fail the
+    check closed, so that a gate cannot pass by producing nothing.
+24. As the operator, I want the e2e-need audit left alone, so that
+    coverage gaps keep flowing back as issues instead of blocking PRs.
+25. As the operator, I want repair round accounting to be tested code
+    rather than inline shell, so that its edge cases are provable.
+26. As the operator, I want the apply-prove-push step written once, so
+    that a fix to it fixes every gate at the same time.
+27. As the operator, I want the lint/test gate to reuse the existing
+    verdict and comment machinery, so that a fourth check later inherits
+    repair for free.
+28. As the operator, I want repair confined to PRs whose head branch is
+    in this repository, so that a fork PR fails cleanly instead of
+    erroring on a push it cannot make.
+29. As the operator, I want the whole change to ship from this
+    repository, so that I do not have to cut a minions release and bump
+    a version pin to get it live.
+30. As the operator, I want PR #622 to go green without me touching it,
+    so that the first proof of this system is the case that motivated it.
+
+## Implementation Decisions
+
+**Verdict as the shared contract.** The lint/test gate produces the
+same verdict artifact the audits produce: a status field and a findings
+list, each finding carrying a location and the reasoning that justifies
+it. This is the seam that lets one repair mechanism serve three checks.
+The existing verdict gate command is unchanged in its contract — it
+still exits non-zero for anything that is not a valid pass, including a
+missing or malformed verdict.
+
+**`internal/repairround` (new).** Owns the question "may another repair
+round start for this check, and which round is it?" Its input is the
+list of commit subjects on the PR branch plus the check name and the
+cap; its output is a decision and a round number. This replaces the
+inline shell loop guard, which today answers a cruder question with a
+prefix match and no counting. Repair commits are distinguishable per
+check so the counts do not interfere. Rounds are capped at three per
+check.
+
+**`internal/patchapply` (new).** Owns the deterministic half of a
+repair round: fetch the PR head, detach a worktree onto it, apply the
+exported patch, run the repo's lint and test targets in that worktree,
+and on success commit with a check-specific marked subject and push
+with the PAT. Any failure along that path is reported as "nothing
+pushed" rather than an error that fails the job. The push must use the
+PAT explicitly — a push made with the default Actions token does not
+trigger the follow-up run the round accounting depends on. Fork heads
+are detected and refused before any fetch.
+
+**`internal/checksverdict` (new).** Runs the repo's lint and test
+targets and converts failures into the shared verdict shape, one
+finding per failing package or linter finding, with enough reasoning
+for a repair session to act without re-running anything itself. A clean
+run yields a pass verdict.
+
+**`internal/auditgate` (modified).** Gains the rounds-exhausted comment:
+when the budget is spent and findings survive, the comment names the
+survivors and the number of rounds that ran. It keeps its existing
+upsert behavior so a PR accumulates one comment per check rather than
+one per round.
+
+**Dead-code fix program (modified).** The exported-identifier hard rule
+is removed, along with the reasoning that justified it. The remaining
+restraints stay: repair only what a finding's reasoning proves, make no
+opportunistic edits, keep each repair coherent, and export nothing when
+the checks cannot be made green. The rationale recorded in the program
+is that this module exposes no importable API — every package is
+internal to it — so no repair the fixer can make breaks an external
+contract.
+
+**Checks fix program (new).** Repairs a failing lint/test verdict. It
+may modify implementation code freely, and may modify a test only when
+that test was added by the pull request under repair; tests that
+predate the PR are out of bounds and a failure in one is a surviving
+finding. It follows the same session contract as the dead-code fixer:
+produce a patch, never commit, never push, always write the skip
+marker.
+
+**Workflows.** A new checks workflow runs the lint/test gate on every
+pull request. Its repair path is guarded on the minion label and on the
+head branch living in this repository, so unlabeled and fork PRs get
+the signal without the commits. The two audit workflows adopt the round
+counter in place of their skip guard. All three gates share a
+concurrency group keyed on the PR number, so at most one repair pushes
+to a branch at a time. The e2e workflow gains a single retry around its
+audit session, covering a crashed session or an unwritten verdict.
+
+**No minions release.** Every change lands in this repository. The
+session capabilities the repair programs rely on — the skip marker and
+the audit directory for patch export — already exist in the pinned
+minions version, so no tag and no version-pin bump are required.
+
+**Language.** Go, matching the repository. The new work deliberately
+moves logic out of inline workflow shell and into packages, continuing
+the direction the existing audit-gate command already established with
+its thin `main` over a tested internal package.
+
+## Testing Decisions
+
+A good test here asserts external behavior only: what a module returns
+for a given input, not how it got there. These modules are unusually
+well suited to that, because each one is a pure decision over inputs
+that a test can construct — a list of commit subjects, a verdict file,
+a directory of command output. Tests must not assert on log lines,
+internal helper names, or the order of unexported calls.
+
+Every module named above is tested. Specifically:
+
+- `internal/repairround` — table-driven over commit-subject lists:
+  no prior rounds, one, at the cap, over the cap, rounds for a
+  different check interleaved, human commits interleaved, an empty
+  branch, and subjects that merely resemble a repair marker.
+- `internal/patchapply` — driven against temporary git repositories
+  created in the test, covering a patch that applies and passes, one
+  that does not apply, one that applies but fails the repo's checks,
+  and a head that belongs to a fork. The push target is a local bare
+  repository, so no network is involved.
+- `internal/checksverdict` — over captured command output fixtures:
+  clean runs, a failing test, a lint finding, and unparseable output,
+  asserting the resulting verdict shape and status.
+- `internal/auditgate` — extends the existing tests with the
+  rounds-exhausted comment body and the upsert path that replaces a
+  prior comment rather than appending.
+
+Prior art is `internal/auditgate/run_test.go`: table-driven, standard
+library `testing` only, no external assertion frameworks, `t.TempDir()`
+for filesystem isolation and a local `httptest` server standing in for
+the GitHub API. The new tests follow that shape exactly, and the
+repository's existing convention of one primary concern per file
+applies to the new packages.
+
+Two areas are deliberately left without unit tests, named here so the
+gap is visible rather than silent. The workflow YAML itself is not
+unit-testable — its correctness is established by a live run, with PR
+#622 as the first case and a known-correct outcome. The repair prompt
+programs are not unit-testable either, being model-driven by nature;
+their contract is enforced downstream, since a session that produces a
+bad patch fails the apply step's checks and pushes nothing.
+
+## Out of Scope
+
+- **Rebuilding a failed PR.** After the last round the pipeline stops
+  and reports. Closing the PR and re-running the build stays a manual
+  decision.
+- **Merging.** No part of this system merges, approves, or marks a PR
+  ready. A green PR is still reviewed by a human.
+- **The e2e-need audit's judgment.** Its findings continue to become
+  proposal issues and continue never to block a PR. Only its
+  infrastructure retry changes.
+- **Repair on fork pull requests.** Fork heads cannot be pushed to from
+  this workflow; they receive the gate signal and nothing more.
+- **The research and planning stages.** Nothing here changes how issues
+  are researched, sliced, or approved.
+- **Any change to the minions runtime.** Should a repair need a
+  capability the pinned version lacks, that is a separate piece of work
+  with its own release and version-pin bump.
+- **Widening the checks gate beyond lint and test.** Other quality
+  signals may earn a gate later; they would inherit the repair contract
+  rather than extend this scope.
+
+## Further Notes
+
+The motivating case is PR #622, "Track and display AI model name in
+session and checkpoint info". Its dead-code audit produced exactly one
+finding: a `Model` field added to the session type with no writer and
+no reader, while four sibling `Model` fields on other types all had
+proven write paths. The fix round ran and declined on the exported
+identifier rule. That PR is intentionally left red until this work
+ships, at which point re-running its audit is the acceptance test — the
+field should disappear without anyone touching it.
+
+The decision to cap rounds at three rather than repairing until green
+is a runner constraint, not a philosophical one. The minion runner is a
+single self-hosted machine, and an unbounded repair loop starves every
+other job queued behind it.
+
+The exported-identifier rule was not wrong when it was written; it was
+written for a general case and this repository is not the general case.
+If a package here is ever promoted out of `internal/` and becomes
+importable, the rule should come back scoped to that package rather
+than to capitalization everywhere.


### PR DESCRIPTION
## What changed

The dead-code fix program loses its ban on a change to an exported
identifier. The program records why the ban does not apply here.

Slice 01 of `docs/2026-08-06-minion-ci-self-repair`. This pull request
also adds the PRD and the seven issue files.

## Why

The ban protects an external contract. This module has none. Each Go
file is under `internal/` or `cmd/`, and Go forbids an import of an
`internal/` package from outside the module that declares it. No
consumer can break.

Before this change, the fixer declined each finding on a capitalized
identifier. It wrote no patch, and the pull request stayed red.

## What stays

- Repair only what a finding's reasoning proves.
- Decline a finding that needs a judgment the reasoning does not settle.
- Make no opportunistic edit.
- Keep each repair coherent.
- Export no patch when `make lint` and `make test` cannot pass.
- Run no git write command.
- Write the skip marker as the final act.

## Verification

A dry run of the fix program, at the version CI pins:

```
GOBIN=/tmp/mbin go install github.com/partio-io/minions/cmd/minions@v0.0.13
MINION_AUDIT_DIR=/tmp/.minion-audit GH_TOKEN="$(gh auth token)" \
  /tmp/mbin/minions run .minions/programs/deadcode-audit-fix.md \
  --pr partio-io/cli#622 --dry-run
```

Result: `agent_instructions:deadcode-audit-fix` is 3044 chars, and the
component count is 5. Both values match the expected ones, so the rules
section survived the edit. The generated prompt holds no ban text, and
it holds each limit in the list above.

No Go package changed in this pull request.

## After the merge

One acceptance criterion is open. It needs this change on `main`:

- Re-run the dead-code audit on PR #622.
- Expect no finding to survive.
- Expect the pipeline to remove the inert `Model` field on the session
  type, with no human edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
