### PR TITLE
Let the minion gates repair a pull request instead of reporting it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,274 @@
+name: Checks
+
+# Every pull request, not only the minion ones. The audits guard on the
+# "minion" label because they cost a model session; lint and test cost
+# a build, and a hand-written pull request breaks them just as easily.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# The check reads the code and comments on the pull request. The repair
+# job pushes, and it pushes with the personal access token rather than
+# with this permission — a push made with the Actions token starts no
+# follow-up run, and the next repair round is a follow-up run.
+permissions:
+  contents: read
+
+# Concurrency is deliberately absent here, and lives on the repair job
+# instead. Lint and test run on every pull request and push nothing, so
+# they must never queue behind a model session; only the job that
+# pushes joins the gate group. See the note on that job.
+
+jobs:
+  # Everything the repair path needs to know, decided before either of
+  # the jobs below starts, and decided in Go: whether this pull request
+  # may receive a repair commit at all, and how many rounds it has
+  # already had.
+  #
+  # The label is read from the API rather than from the event payload.
+  # The payload is a snapshot taken when the run was queued, and a
+  # minion pull request is labelled moments after it opens — an "opened"
+  # run would see no label and refuse to repair its own branch.
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      repairable: ${{ steps.budget.outputs.repairable }}
+      reason: ${{ steps.budget.outputs.reason }}
+      skip: ${{ steps.budget.outputs.skip }}
+      prior: ${{ steps.budget.outputs.prior }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Failing softly on purpose, unlike the audits' guard. There the
+      # count decides whether to audit at all; here it decides only
+      # whether to repair, and the check itself must still report on
+      # every pull request. An unanswered question leaves the outputs
+      # empty, which reads as "do not repair" below.
+      - name: Repair budget
+        id: budget
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          go run ./cmd/minion-repair-round \
+            --pr ${{ github.event.pull_request.number }} \
+            --check checks \
+            --repairable
+
+  checks:
+    needs: guard
+    # The guard informs this job; it does not gate it. A guard that
+    # dies must not take the only build signal on the pull request down
+    # with it.
+    if: always()
+    # A hosted runner, unlike the audits: lint and test need no model
+    # session and no credentials, and this runs on every pull request,
+    # so it must not queue behind the audits on the single self-hosted
+    # box.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # This job reports and stops. With no persisted credentials
+          # no step here can push, whatever it is later asked to do.
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      # Writes the verdict; it never decides the outcome. A crash here
+      # leaves no verdict, which the gate below turns into a red check
+      # and a comment saying so — the same fail-closed path a crashed
+      # audit session takes.
+      - name: Run checks
+        continue-on-error: true
+        env:
+          # A cache of its own, so a lint cache shared with another
+          # checkout cannot replay issues from paths that no longer
+          # exist. The runner is ephemeral today; this keeps the
+          # guarantee if it ever stops being.
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-cache-checks
+        run: |
+          rm -rf .minion-checks
+          go run ./cmd/minion-checks-verdict \
+            --out "${{ github.workspace }}/.minion-checks/verdict.json"
+
+      # Always runs, because a check that reports nothing when the step
+      # before it dies is a check that passes by producing nothing.
+      #
+      # The round reported is the number of repair rounds already on
+      # the branch, not the one this run may start: unlike the audits,
+      # this gate runs before its run's repair rather than after it. So
+      # the run that finds three repair commits is the run whose
+      # findings no further round will address, and it is the one that
+      # says the pipeline gave up. An absent count falls back to 0,
+      # which means no accounting and the plain failure comment.
+      - name: Verdict gate
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          PRIOR="${{ needs.guard.outputs.prior }}"
+          go run ./cmd/minion-audit-gate \
+            --pr ${{ github.event.pull_request.number }} \
+            --audit checks \
+            --round "${PRIOR:-0}" \
+            --verdict "${{ github.workspace }}/.minion-checks/verdict.json"
+
+  # The repair round. It runs only for a pull request the pipeline
+  # opened, whose branch lives here, and which has rounds left — the
+  # guard decided all three. A hand-written or forked pull request gets
+  # the check above and nothing else.
+  repair:
+    needs: [guard, checks]
+    if: >
+      needs.guard.outputs.repairable == 'true' &&
+      needs.guard.outputs.skip != 'true' &&
+      needs.checks.result == 'failure'
+    # The same group the two audits hold, keyed on the pull request
+    # number: this gate and the dead-code gate can both fail on one
+    # pull request, and two repairs pushing to one branch at the same
+    # time lose one of them. A run that does not repair never reaches
+    # this job, so it never enters the group.
+    #
+    # It does not cancel what is running. A repair's own push starts a
+    # follow-up run, and cancelling would kill the job part-way through
+    # the push that started it. The follow-up run waits its turn.
+    concurrency:
+      group: minion-gate-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    # The self-hosted box, because a fix session is a model session.
+    runs-on: github-runner-partio-minion-ai-01
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Two commits, so the merge commit's first parent is present
+          # and the pull request's own diff can be taken from it below.
+          fetch-depth: 2
+          # The apply step pushes with the personal access token
+          # explicitly; a checkout-persisted token would push a commit
+          # that starts no follow-up run.
+          persist-credentials: false
+
+      - name: Install minions
+        run: |
+          go install github.com/partio-io/minions/cmd/minions@v0.0.13
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      # The fix session proves its repair with the repo's own checks;
+      # make lint needs the binary on the runner's PATH.
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      # Derived here rather than carried over from the job above. The
+      # findings are what the session repairs, and a verdict taken on
+      # this runner describes the tree the session is about to edit.
+      - name: Run checks
+        continue-on-error: true
+        env:
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-cache-repair
+        run: |
+          rm -rf .minion-checks
+          go run ./cmd/minion-checks-verdict \
+            --out "${{ github.workspace }}/.minion-checks/verdict.json"
+
+      # Branch point for the fix round. Parsed with plain shell — the
+      # runner is minimal Debian and jq is not a given. An absent or
+      # malformed verdict yields an empty status and no fix round; the
+      # gate in the job above has already failed the check closed.
+      - name: Read verdict
+        id: verdict
+        run: |
+          STATUS=""
+          if [ -f .minion-checks/verdict.json ]; then
+            STATUS=$(tr -d ' \n\t' < .minion-checks/verdict.json | grep -o '"status":"[a-z]*"' | head -n1 | cut -d'"' -f4 || true)
+          fi
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+          echo "Verdict status: '${STATUS}'"
+
+      # The session's one hard boundary, decided in Go and handed over.
+      # A session that works out for itself which tests are fair game is
+      # a session that can talk itself into deleting an assertion a
+      # person wrote.
+      #
+      # HEAD is the merge commit GitHub builds for the pull request, so
+      # its first parent is the base branch and the diff between them is
+      # exactly what the pull request changes. A HEAD that is not a
+      # merge commit leaves the list empty, which bounds the session to
+      # implementation code.
+      - name: List the tests this pull request added
+        if: steps.verdict.outputs.status == 'fail'
+        run: |
+          FILES="${RUNNER_TEMP}/pr-files.txt"
+          if git rev-parse --verify --quiet "HEAD^2" >/dev/null; then
+            git diff --name-status "HEAD^1" HEAD > "${FILES}"
+          else
+            echo "HEAD is not a merge commit; no test file is in bounds"
+            : > "${FILES}"
+          fi
+          go run ./cmd/minion-checks-verdict \
+            --pr-files "${FILES}" \
+            --tests-out "${{ github.workspace }}/.minion-checks/added-tests.txt"
+
+      # One attempt per run, up to the budget: this step has no retry,
+      # and the round it belongs to is the run the guard admitted. The
+      # session only emits a checked patch to .minion-checks/ — it never
+      # commits or pushes; the apply step below owns that.
+      - name: Fix round
+        if: steps.verdict.outputs.status == 'fail'
+        # A crashed fix session is a failed fix round, not a broken
+        # job — the next run's gate still owns the outcome.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          # The session runs in an isolated minions worktree, so it
+          # reads the verdict and the boundary through an absolute path
+          # into this workspace.
+          MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-checks
+          # Fresh lint cache per step: the shared cache replays issues
+          # recorded under other (since-deleted) worktrees, whose
+          # unreadable paths defeat the test-file exclusion rules.
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-cache-fix
+        run: |
+          minions run .minions/programs/checks-fix.md \
+            --pr ${{ github.repository }}#${{ github.event.pull_request.number }}
+
+      # Deterministic half of the fix round, and the same package the
+      # dead-code gate uses: apply the session's patch to the true PR
+      # head, prove it with the repo's own checks, and push one commit
+      # with the personal access token. A patch that does not apply, or
+      # one that leaves the checks red, pushes nothing and leaves the
+      # verdict standing. The commit subject carries this check's
+      # marker, which is what the guard counts on the next run.
+      - name: Apply fix
+        id: fixpush
+        if: steps.verdict.outputs.status == 'fail'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-cache-apply
+        run: |
+          go run ./cmd/minion-apply-fix \
+            --pr ${{ github.event.pull_request.number }} \
+            --check checks \
+            --patch "${{ github.workspace }}/.minion-checks/fix.patch" \
+            --summary "${{ github.workspace }}/.minion-checks/fix-summary.txt" \
+            --worktree "${RUNNER_TEMP}/checks-fixwt"

--- a/.github/workflows/deadcode-audit.yml
+++ b/.github/workflows/deadcode-audit.yml
@@ -15,11 +15,20 @@ on:
         default: false
         type: boolean
 
-# Concurrency lives on the audit job, not the workflow: the fix
-# round's own push triggers a guard-skipped run, and a workflow-level
-# group would let that run cancel the in-flight job doing the fixing.
-# A skipped audit job never enters the group, so only runs that will
-# actually audit supersede each other.
+# Concurrency lives on the audit job, not the workflow: a run whose
+# repair budget is spent skips the audit job and never enters the
+# group, so only runs that will actually audit queue against each
+# other.
+#
+# The group is shared with the e2e audit and the checks gate, and keyed
+# on the pull request number, so at most one gate pushes a repair to a
+# branch at a time. Two gates can fail on the same pull request, and
+# two repairs pushing at once lose one of them.
+#
+# It does not cancel what is running. Since accounting replaced the
+# loop guard, a fix round's own push starts a run that does audit, and
+# cancelling would kill the in-flight job part-way through the push
+# that started it. The follow-up run waits its turn instead.
 
 jobs:
   guard:
@@ -33,7 +42,8 @@ jobs:
       pr_ref: ${{ steps.src.outputs.pr_ref }}
       pr_num: ${{ steps.src.outputs.pr_num }}
       dry_run: ${{ steps.src.outputs.dry_run }}
-      skip: ${{ steps.guard.outputs.skip }}
+      skip: ${{ steps.budget.outputs.skip }}
+      round: ${{ steps.budget.outputs.round }}
     steps:
       - name: Resolve PR reference
         id: src
@@ -49,29 +59,29 @@ jobs:
             echo "dry_run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Loop guard
-        id: guard
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Accounting, not prohibition. The command counts the dead-code
+      # repair commits already on the branch and reports whether
+      # another round may start. Counting is per check, so a dead-code
+      # repair never spends the budget a failing test needs, and it
+      # reads commit subjects, so human commits count for nothing.
+      #
+      # A failure here fails the job on purpose: auditing on a count we
+      # do not have is how a repair loop starts.
+      - name: Repair-round budget
+        id: budget
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.src.outputs.pr_num }}" --jq .head.sha)
-          SUBJECT=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}" --jq .commit.message | head -n1)
-          case "$SUBJECT" in
-            "audit:"*)
-              echo "Head commit is an audit fix ('${SUBJECT}'); skipping to avoid an audit loop."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
+        run: go run ./cmd/minion-repair-round --pr ${{ steps.src.outputs.pr_num }} --check dead-code
 
   audit:
     needs: guard
     if: needs.guard.outputs.skip != 'true'
     concurrency:
-      group: deadcode-audit-${{ github.event.pull_request.number || github.run_id }}
-      cancel-in-progress: true
+      group: minion-gate-${{ github.event.pull_request.number || needs.guard.outputs.pr_num }}
+      cancel-in-progress: false
     runs-on: github-runner-partio-minion-ai-01
     timeout-minutes: 60
     steps:
@@ -79,8 +89,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           # The apply step pushes with the PAT explicitly: a push with
-          # the checkout-persisted GITHUB_TOKEN would not trigger the
-          # guard-skipped follow-up run the loop guard exists for.
+          # the checkout-persisted GITHUB_TOKEN would trigger no
+          # follow-up run at all, and the next repair round is a
+          # follow-up run.
           persist-credentials: false
 
       - name: Install minions
@@ -128,10 +139,10 @@ jobs:
           echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
           echo "Verdict status: '${STATUS}'"
 
-      # Exactly one fix attempt, ever: this step has no retry and the
-      # loop guard keeps the pushed commit from starting a new round.
-      # The session only emits a checked patch to .minion-audit/ — it
-      # never commits or pushes; the apply step below owns that.
+      # One attempt per run, up to the budget: this step has no retry,
+      # and the round it belongs to is the run the guard admitted. The
+      # session only emits a checked patch to .minion-audit/ — it never
+      # commits or pushes; the apply step below owns that.
       - name: Fix round
         if: steps.verdict.outputs.status == 'fail'
         # A crashed fix session is a failed fix round, not a broken
@@ -148,9 +159,13 @@ jobs:
 
       # Deterministic half of the fix round: apply the session's
       # patch to the true PR head, prove it with the repo's own
-      # checks, and push one audit-prefixed commit with the PAT (a
-      # GITHUB_TOKEN push would suppress the follow-up run). Any
-      # failure leaves pushed=false and the first verdict stands.
+      # checks, and push one commit with the PAT (a GITHUB_TOKEN push
+      # would suppress the follow-up run, and the next repair round is
+      # a follow-up run). internal/patchapply owns the whole sequence,
+      # so the second gate reuses it instead of copying it, and the
+      # commit subject is built by the same package that later counts
+      # it. Any failure leaves pushed=false and the first verdict
+      # stands.
       - name: Apply fix
         id: fixpush
         if: steps.verdict.outputs.status == 'fail'
@@ -159,39 +174,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-cache-apply
         run: |
-          PUSHED=false
-          PATCH="${{ github.workspace }}/.minion-audit/fix.patch"
-          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          if [ -s "$PATCH" ]; then
-            HEAD_REF=$(gh api "repos/${{ github.repository }}/pulls/${{ needs.guard.outputs.pr_num }}" --jq .head.ref)
-            HEAD_REPO=$(gh api "repos/${{ github.repository }}/pulls/${{ needs.guard.outputs.pr_num }}" --jq .head.repo.full_name)
-            if [ "$HEAD_REPO" = "${{ github.repository }}" ]; then
-              git fetch --no-tags "$REMOTE" "$HEAD_REF"
-              WT="${RUNNER_TEMP}/audit-fixwt"
-              git worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
-              git worktree add --detach "$WT" FETCH_HEAD
-              BODY=""
-              if [ -f .minion-audit/fix-summary.txt ]; then
-                BODY=$(head -c 300 .minion-audit/fix-summary.txt)
-              fi
-              if git -C "$WT" apply --index "$PATCH" \
-                && (cd "$WT" && make lint && make test); then
-                git -C "$WT" -c user.name="minion audit" -c user.email="minions@partio.io" \
-                  commit -m "audit: fix dead-code findings (#${{ needs.guard.outputs.pr_num }})" -m "$BODY"
-                if git -C "$WT" push "$REMOTE" HEAD:"$HEAD_REF"; then
-                  PUSHED=true
-                fi
-              else
-                echo "Patch did not apply or failed checks; pushing nothing."
-              fi
-              git worktree remove --force "$WT" || true
-            else
-              echo "PR head lives in a fork; the fix round cannot push there."
-            fi
-          else
-            echo "Fix session exported no patch; the first verdict stands."
-          fi
-          echo "pushed=${PUSHED}" >> "$GITHUB_OUTPUT"
+          go run ./cmd/minion-apply-fix \
+            --pr ${{ needs.guard.outputs.pr_num }} \
+            --check dead-code \
+            --patch "${{ github.workspace }}/.minion-audit/fix.patch" \
+            --summary "${{ github.workspace }}/.minion-audit/fix-summary.txt" \
+            --worktree "${RUNNER_TEMP}/audit-fixwt"
 
       # Fresh session, final verdict. Only runs when the fix round
       # actually moved the branch — an unchanged head would re-derive
@@ -206,8 +194,21 @@ jobs:
           rm -rf .minion-audit
           minions run .minions/programs/deadcode-audit.md --pr ${{ needs.guard.outputs.pr_ref }}
 
+      # The round travels from the guard so the gate can tell a spent
+      # budget from a first-pass failure. On the last round a surviving
+      # finding gets the "gave up" comment: the run that would have
+      # been round four never reaches this step, because the guard
+      # skips the whole audit job, so this is the pipeline's last word
+      # on the pull request. An absent round falls back to 0, which
+      # means no accounting: the gate then reports as it did before,
+      # rather than failing on a flag it cannot parse.
       - name: Verdict gate
         if: needs.guard.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: go run ./cmd/minion-audit-gate --pr ${{ needs.guard.outputs.pr_num }} --audit dead-code
+        run: |
+          ROUND="${{ needs.guard.outputs.round }}"
+          go run ./cmd/minion-audit-gate \
+            --pr ${{ needs.guard.outputs.pr_num }} \
+            --audit dead-code \
+            --round "${ROUND:-0}"

--- a/.github/workflows/e2e-audit.yml
+++ b/.github/workflows/e2e-audit.yml
@@ -17,8 +17,17 @@ on:
 
 # Concurrency lives on the audit job, not the workflow: the deadcode
 # audit's fix push triggers a guard-skipped run here too, and a
-# workflow-level group would let that run cancel an in-flight audit.
+# workflow-level group would let that run supersede an in-flight audit.
 # A skipped audit job never enters the group.
+#
+# The group is shared with the dead-code audit and the checks gate, and
+# keyed on the pull request number, so at most one gate pushes a repair
+# to a branch at a time. This audit pushes no repair itself, but it
+# holds the same lock: its session reads a branch the other two write.
+#
+# It does not cancel what is running. A repair's own push starts a
+# follow-up run, and cancelling would kill the job part-way through the
+# push that started it. The follow-up run waits its turn instead.
 
 jobs:
   guard:
@@ -69,8 +78,8 @@ jobs:
     needs: guard
     if: needs.guard.outputs.skip != 'true'
     concurrency:
-      group: e2e-audit-${{ github.event.pull_request.number || github.run_id }}
-      cancel-in-progress: true
+      group: minion-gate-${{ github.event.pull_request.number || needs.guard.outputs.pr_num }}
+      cancel-in-progress: false
     runs-on: github-runner-partio-minion-ai-01
     timeout-minutes: 60
     steps:
@@ -90,6 +99,17 @@ jobs:
         # On real runs the verdict gate owns the outcome, so a crashed
         # audit session must not end the job before the gate fails it
         # closed. Dry runs have no gate and fail here normally.
+        #
+        # The session gets two attempts. This audit never fails a pull
+        # request on findings — they become proposal issues — so its
+        # only red state is infrastructure: the session crashed, or it
+        # finished without writing the verdict it owes. Neither is a
+        # defect in the pull request, and one flaky session should not
+        # read as one.
+        #
+        # A second attempt that also produces nothing leaves no verdict
+        # behind, and the gate below fails closed on a missing verdict.
+        # An infrastructure failure goes red; it is never a pass.
         continue-on-error: ${{ needs.guard.outputs.dry_run != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -98,12 +118,27 @@ jobs:
           # workspace for the gate step to find it.
           MINION_AUDIT_DIR: ${{ github.workspace }}/.minion-audit
         run: |
-          rm -rf .minion-audit
-          ARGS="run .minions/programs/e2e-audit.md --pr ${{ needs.guard.outputs.pr_ref }}"
+          # A dry run writes no verdict and has no gate, so it runs once
+          # and reports its own exit status.
           if [ "${{ needs.guard.outputs.dry_run }}" = "true" ]; then
-            ARGS="${ARGS} --dry-run"
+            minions run .minions/programs/e2e-audit.md \
+              --pr ${{ needs.guard.outputs.pr_ref }} --dry-run
+            exit
           fi
-          minions $ARGS
+
+          for attempt in 1 2; do
+            rm -rf "${MINION_AUDIT_DIR}"
+            if minions run .minions/programs/e2e-audit.md \
+                 --pr ${{ needs.guard.outputs.pr_ref }} \
+               && [ -s "${MINION_AUDIT_DIR}/verdict.json" ]; then
+              exit 0
+            fi
+            echo "Attempt ${attempt} of 2 produced no readable verdict."
+          done
+
+          echo "The audit session produced no verdict twice."
+          echo "The gate below fails this check closed."
+          exit 1
 
       - name: Verdict gate
         if: needs.guard.outputs.dry_run != 'true'

--- a/.minions/programs/checks-fix.md
+++ b/.minions/programs/checks-fix.md
@@ -1,0 +1,116 @@
+---
+id: checks-fix
+target_repos:
+  - cli
+acceptance_criteria:
+  - "Every change in the exported patch addresses a specific finding in $MINION_AUDIT_DIR/verdict.json; no unrelated changes"
+  - "No test file is modified unless its path is listed in $MINION_AUDIT_DIR/added-tests.txt"
+  - "make lint and make test pass in the patched tree before the patch is exported"
+  - "The session runs no git write commands: no commit, no push, no branches, no PRs, no comments"
+  - "A patch is exported only when at least one finding was safely fixable and checks pass; otherwise nothing is exported"
+  - "The skip marker file is written as the session's final act on every path"
+---
+
+# Repair the lint and test failures a check found
+
+The lint and test check just failed on a pull request of the cli repo.
+You get exactly one attempt to repair what it found: fix the findings
+in your worktree, prove the tree passes the repo's own checks, and
+export the result as a patch. You do not commit or push — the workflow
+applies your patch, re-runs the checks, and pushes the fix commit
+deterministically. The next run judges the result, not you. There is no
+second attempt inside this session, so a fix you cannot verify is worse
+than no fix at all.
+
+The PR — its reference (`org/repo#number`), title, body, and full diff
+— is provided in the **## Pull Request** section of this prompt. The
+findings are in `$MINION_AUDIT_DIR/verdict.json`: a `findings` list
+where each entry has a `location` (path:line, or the package that
+failed) and `reasoning` carrying what the command reported. The
+reasoning is complete — you do not need to re-run lint or the tests to
+learn what failed, only to prove your repair.
+
+## Agents
+
+### checks-fix
+
+```capabilities
+max_turns: 50
+skip_marker: .minion-fix-done
+```
+
+Work through the repair in this order:
+
+1. **Read the findings.** Parse `$MINION_AUDIT_DIR/verdict.json`. If it
+   is missing, malformed, or its `findings` list is empty, write the
+   skip marker (step 7) and end without touching the repo.
+
+2. **Read your boundary.** `$MINION_AUDIT_DIR/added-tests.txt` lists,
+   one path per line, the test files this pull request added. Those are
+   the only test files you may modify. If the file is missing, no test
+   file is in bounds — treat the list as empty and repair
+   implementation code only. An empty list is a real answer, not an
+   error.
+
+3. **Move to the PR head — your worktree is based on origin's default
+   branch, not the PR.** Resolve the head and detach onto it before
+   editing anything:
+
+   ```
+   gh pr view <pr-ref> --json headRefName,headRefOid
+   git fetch origin <head-ref-name>
+   git checkout --detach <head-ref-oid>
+   ```
+
+4. **Repair what the findings name.** For each finding, apply the
+   smallest change that makes the reported failure go away. Rules:
+
+   - Implementation code is yours to change, bounded by the findings.
+   - A test file is yours to change only if step 2 listed it. A test
+     that predates this pull request is out of bounds, whatever it
+     asserts and however wrong it looks. Leave that finding unfixed: it
+     survives, the check stays red, and a person decides. This is the
+     one rule that separates a repair from a bot that reaches green by
+     deleting an assertion.
+   - Repair the implementation first. Change a listed test only when
+     the failure shows the test itself is wrong — it asserts a
+     behaviour nobody agreed to, or it was written against an interface
+     that changed in the same pull request. Never weaken a test to make
+     it pass: do not delete an assertion, do not skip a case, and do
+     not relax a comparison, in a listed test or any other.
+   - Do not guess. If a repair needs a decision the finding does not
+     settle — which of two behaviours is correct, whether a linter rule
+     should be suppressed — leave that finding unfixed. A surviving
+     finding is the correct outcome for a fix that needs a human.
+   - No opportunistic edits. Style, naming, or refactors beyond the
+     findings are out of scope, however tempting.
+   - Keep each repair coherent: a signature you change is a signature
+     every caller must follow — the checks below must pass.
+
+5. **Prove the tree with the repo's own checks.** Run `make lint` and
+   `make test` from the worktree root. Both must pass. If they fail
+   because of your edits, repair your edits and rerun. If you cannot
+   get both green, restore the tree (`git checkout -- .` and delete
+   files you added) and skip step 6 — exporting nothing is the correct
+   failed-round outcome.
+
+6. **Export the patch — only when checks pass and something was
+   fixed.**
+
+   ```
+   git add -A
+   git diff --cached --binary > "$MINION_AUDIT_DIR/fix.patch"
+   ```
+
+   Also write one plain-text line describing the repair to
+   `$MINION_AUDIT_DIR/fix-summary.txt` — it becomes the fix commit's
+   body.
+
+7. **Write the skip marker — always your final act.** Create the empty
+   file `.minion-fix-done` at the worktree root. This tells the runtime
+   the session's output is the exported patch, not a branch: without
+   it, leftover edits would be auto-committed to a stray `minion/*`
+   pull request.
+
+Never run `git commit`, `git push`, `gh pr create`, or post comments,
+on any path. Write outside the worktree only under `$MINION_AUDIT_DIR`.

--- a/cmd/minion-apply-fix/main.go
+++ b/cmd/minion-apply-fix/main.go
@@ -1,0 +1,116 @@
+// Command minion-apply-fix turns a repair session's patch into one
+// pushed commit. It fetches the pull request's real head, detaches a
+// worktree onto it, applies the patch, proves the result with the
+// repository's own lint and test targets, and pushes a commit marked
+// with the check that produced it.
+//
+// It writes pushed to $GITHUB_OUTPUT. A patch that does not apply, or
+// that leaves the checks red, is a spent round and not an error: the
+// command says so and exits 0, and the first verdict stands.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/partio-io/cli/internal/patchapply"
+)
+
+// maxBodyBytes bounds the commit body taken from the session's fix
+// summary. A commit body is read by people.
+const maxBodyBytes = 300
+
+func main() {
+	var (
+		pr       = flag.Int("pr", 0, "pull request number (required)")
+		check    = flag.String("check", "", "check that produced the patch, e.g. dead-code (required)")
+		patch    = flag.String("patch", ".minion-audit/fix.patch", "patch the repair session exported")
+		summary  = flag.String("summary", ".minion-audit/fix-summary.txt", "summary used as the commit body")
+		worktree = flag.String("worktree", "", "where to detach the pull request head")
+	)
+	flag.Parse()
+	if *pr == 0 || *check == "" {
+		fmt.Fprintln(os.Stderr,
+			"usage: minion-apply-fix --pr <number> --check <name> [--patch <path>] [--summary <path>] [--worktree <dir>]")
+		os.Exit(2)
+	}
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	token := os.Getenv("GH_TOKEN")
+	if repo == "" || token == "" {
+		fmt.Fprintln(os.Stderr, "minion-apply-fix: GITHUB_REPOSITORY and GH_TOKEN must be set")
+		os.Exit(2)
+	}
+	api := os.Getenv("GITHUB_API_URL")
+	if api == "" {
+		api = "https://api.github.com"
+	}
+
+	res, runErr := patchapply.Run(patchapply.Config{
+		PatchPath:   *patch,
+		WorktreeDir: *worktree,
+		Body:        body(*summary),
+		Repo:        repo,
+		PRNumber:    *pr,
+		Check:       *check,
+		Token:       token,
+		APIBaseURL:  api,
+	})
+	if runErr != nil {
+		fmt.Fprintf(os.Stderr, "minion-apply-fix: %v\n", runErr)
+	}
+	if res.Pushed {
+		fmt.Printf("minion-apply-fix: %s\n", res.Reason)
+	} else if res.Reason != "" {
+		fmt.Printf("minion-apply-fix: pushed nothing. %s\n", res.Reason)
+	}
+
+	// The output goes out before the exit code, because the job reads
+	// pushed on every path, including the failed one.
+	if err := writeOutputs(res); err != nil {
+		fmt.Fprintf(os.Stderr, "minion-apply-fix: %v\n", err)
+		os.Exit(1)
+	}
+	if runErr != nil {
+		os.Exit(1)
+	}
+}
+
+// body returns the commit body, taken from the session's fix summary.
+// A missing summary is normal, and gives an empty body.
+func body(path string) string {
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	text := strings.TrimSpace(string(data))
+	if len(text) > maxBodyBytes {
+		text = strings.ToValidUTF8(text[:maxBodyBytes], "")
+	}
+	return text
+}
+
+// writeOutputs appends the outcome to the step's $GITHUB_OUTPUT file.
+func writeOutputs(res patchapply.Result) error {
+	path := os.Getenv("GITHUB_OUTPUT")
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_OUTPUT: %w", err)
+	}
+	_, writeErr := fmt.Fprintf(f, "pushed=%t\n", res.Pushed)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return fmt.Errorf("write GITHUB_OUTPUT: %w", writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close GITHUB_OUTPUT: %w", closeErr)
+	}
+	return nil
+}

--- a/cmd/minion-audit-gate/main.go
+++ b/cmd/minion-audit-gate/main.go
@@ -2,6 +2,11 @@
 // outcome. It exits 0 only for a valid pass verdict; anything else —
 // fail verdict, missing or malformed file — exits 1 (fail-closed)
 // after upserting the single audit comment on the PR.
+//
+// Given the repair round it belongs to, the gate also reports a spent
+// repair budget: on the last round, surviving findings produce a
+// comment that says the pipeline gave up rather than one that reads
+// like a first-pass failure.
 package main
 
 import (
@@ -10,6 +15,7 @@ import (
 	"os"
 
 	"github.com/partio-io/cli/internal/auditgate"
+	"github.com/partio-io/cli/internal/repairround"
 )
 
 func main() {
@@ -17,10 +23,16 @@ func main() {
 		pr      = flag.Int("pr", 0, "pull request number (required)")
 		audit   = flag.String("audit", "", "audit name for the comment, e.g. dead-code (required)")
 		verdict = flag.String("verdict", ".minion-audit/verdict.json", "path to the verdict file")
+		round   = flag.Int("round", 0, "repair round this run belongs to; 0 means no round accounting")
+		// The default is the same constant minion-repair-round counts
+		// against, so the two sides of one round cannot disagree about
+		// the cap unless a caller overrides both.
+		maxRounds = flag.Int("max", repairround.DefaultMaxRounds, "repair rounds allowed for this check")
 	)
 	flag.Parse()
 	if *pr == 0 || *audit == "" {
-		fmt.Fprintln(os.Stderr, "usage: minion-audit-gate --pr <number> --audit <name> [--verdict <path>]")
+		fmt.Fprintln(os.Stderr,
+			"usage: minion-audit-gate --pr <number> --audit <name> [--verdict <path>] [--round <n>] [--max <n>]")
 		os.Exit(2)
 	}
 	repo := os.Getenv("GITHUB_REPOSITORY")
@@ -41,6 +53,8 @@ func main() {
 		AuditName:   *audit,
 		APIBaseURL:  api,
 		Token:       token,
+		Round:       *round,
+		MaxRounds:   *maxRounds,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "minion-audit-gate: %v\n", err)

--- a/cmd/minion-checks-verdict/main.go
+++ b/cmd/minion-checks-verdict/main.go
@@ -1,0 +1,73 @@
+// Command minion-checks-verdict runs the repository's own lint and
+// test targets and writes their result as a verdict file, in the shape
+// the minion audits emit.
+//
+// It does not decide the check's outcome. minion-audit-gate reads the
+// verdict and owns red or green, exactly as it does for an audit, so
+// this command exits 0 whenever it managed to write a verdict — even
+// one that says the checks failed. A failure to write is the only
+// error, and the gate then fails the check closed on its own.
+//
+// With --pr-files it does a different, smaller job: it reads a
+// name-status diff and writes the list of test files the pull request
+// added. That list is the repair session's boundary — the only tests it
+// may edit — so it is decided here and handed over, not left to the
+// session to work out.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/partio-io/cli/internal/checksverdict"
+)
+
+func main() {
+	var (
+		dir     = flag.String("dir", ".", "directory to run the checks in")
+		out     = flag.String("out", ".minion-checks/verdict.json", "path to write the verdict to")
+		prFiles = flag.String("pr-files", "",
+			"name-status diff of the pull request; writes the added-test list instead of running the checks")
+		testsOut = flag.String("tests-out", ".minion-checks/added-tests.txt",
+			"path to write the added-test list to, with --pr-files")
+	)
+	flag.Parse()
+
+	if *prFiles != "" {
+		if err := writeAddedTests(*prFiles, *testsOut); err != nil {
+			fmt.Fprintf(os.Stderr, "minion-checks-verdict: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	verdict := checksverdict.Convert(checksverdict.Run(*dir, checksverdict.DefaultCommands()))
+	if err := checksverdict.Write(*out, verdict); err != nil {
+		fmt.Fprintf(os.Stderr, "minion-checks-verdict: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("minion-checks-verdict: %s with %d finding(s) → %s\n",
+		verdict.Status, len(verdict.Findings), *out)
+}
+
+// writeAddedTests reads a name-status diff and saves the test files the
+// pull request added.
+//
+// An unreadable diff is an error, not an empty list. The list bounds
+// what the repair session may edit, and a silent empty one would read
+// as "this pull request added no tests" when the truth is "nobody
+// looked".
+func writeAddedTests(prFiles, testsOut string) error {
+	diff, err := os.ReadFile(filepath.Clean(prFiles))
+	if err != nil {
+		return fmt.Errorf("read the pull request file list: %w", err)
+	}
+	added := checksverdict.AddedTestFiles(string(diff))
+	if err := checksverdict.WriteAddedTests(testsOut, added); err != nil {
+		return err
+	}
+	fmt.Printf("minion-checks-verdict: the pull request added %d test file(s) → %s\n", len(added), testsOut)
+	return nil
+}

--- a/cmd/minion-repair-round/main.go
+++ b/cmd/minion-repair-round/main.go
@@ -1,0 +1,140 @@
+// Command minion-repair-round reports whether a pull request may
+// receive another automated repair round for one check, and which
+// round it would be. It replaces the loop guard that skipped any run
+// whose head commit looked like a repair: a repair that lands one edit
+// short of green now gets another attempt, up to the cap.
+//
+// It writes skip, round, prior and subject to $GITHUB_OUTPUT. With
+// --repairable it also answers the question that comes before the
+// count — may this pull request receive a repair commit at all — and
+// writes repairable and reason. A gate that runs on every pull request
+// needs that answer; a gate that already guards on the label does not.
+//
+// Exit 1 means the count could not be established — the caller must
+// not audit on a number it does not have.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/partio-io/cli/internal/repairround"
+)
+
+func main() {
+	var (
+		pr         = flag.Int("pr", 0, "pull request number (required)")
+		check      = flag.String("check", "", "check whose budget is counted, e.g. dead-code (required)")
+		maxRounds  = flag.Int("max", repairround.DefaultMaxRounds, "repair rounds allowed for this check")
+		repairable = flag.Bool("repairable", false,
+			"also decide whether this pull request may be repaired at all, and report it")
+	)
+	flag.Parse()
+	if *pr == 0 || *check == "" {
+		fmt.Fprintln(os.Stderr,
+			"usage: minion-repair-round --pr <number> --check <name> [--max <n>] [--repairable]")
+		os.Exit(2)
+	}
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	token := os.Getenv("GH_TOKEN")
+	if repo == "" || token == "" {
+		fmt.Fprintln(os.Stderr, "minion-repair-round: GITHUB_REPOSITORY and GH_TOKEN must be set")
+		os.Exit(2)
+	}
+	api := os.Getenv("GITHUB_API_URL")
+	if api == "" {
+		api = "https://api.github.com"
+	}
+
+	cfg := repairround.Config{
+		Repo:       repo,
+		PRNumber:   *pr,
+		Check:      *check,
+		MaxRounds:  *maxRounds,
+		APIBaseURL: api,
+		Token:      token,
+	}
+
+	// Asked for and reported before the count, because the two answers
+	// are different: an ineligible pull request was never the
+	// pipeline's to touch, while a spent budget is one it tried.
+	var eligibility repairround.Eligibility
+	if *repairable {
+		e, err := repairround.RunEligibility(cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "minion-repair-round: %v\n", err)
+			os.Exit(1)
+		}
+		eligibility = e
+		if eligibility.Allowed {
+			fmt.Printf("minion-repair-round: %s may repair this pull request — %s\n", *check, eligibility.Reason)
+		} else {
+			fmt.Printf("minion-repair-round: %s will not repair this pull request — %s\n", *check, eligibility.Reason)
+		}
+	}
+
+	// Counted even for a pull request no repair may touch, so the round
+	// number the gate reports stays true if a label is removed part-way
+	// through a repair loop.
+	d, err := repairround.Run(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "minion-repair-round: %v\n", err)
+		os.Exit(1)
+	}
+
+	if d.Allowed {
+		fmt.Printf("minion-repair-round: %s round %d of %d may start (%d already on the branch)\n",
+			*check, d.Round, *maxRounds, d.Prior)
+	} else {
+		fmt.Printf("minion-repair-round: %s spent its repair budget (%d of %d rounds); not auditing again\n",
+			*check, d.Prior, *maxRounds)
+	}
+
+	if err := writeOutputs(d, eligibility, *repairable, *check, *pr); err != nil {
+		fmt.Fprintf(os.Stderr, "minion-repair-round: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// writeOutputs appends the decision to the step's $GITHUB_OUTPUT file.
+// The subject travels with it so the commit a repair pushes is built
+// by the same package that later counts it.
+//
+// repairable and reason are written only when they were asked for. A
+// caller that did not ask gets no such outputs, so a workflow cannot
+// read a "false" that was never decided.
+func writeOutputs(d repairround.Decision, e repairround.Eligibility, asked bool, check string, pr int) error {
+	path := os.Getenv("GITHUB_OUTPUT")
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_OUTPUT: %w", err)
+	}
+	out := fmt.Sprintf("skip=%t\nround=%d\nprior=%d\nsubject=%s\n",
+		!d.Allowed, d.Round, d.Prior, repairround.Subject(check, pr))
+	if asked {
+		// The reason is one line by construction; a multi-line value
+		// would need a heredoc delimiter and there is nothing to gain
+		// from allowing one.
+		out += fmt.Sprintf("repairable=%t\nreason=%s\n", e.Allowed, singleLine(e.Reason))
+	}
+	_, writeErr := fmt.Fprint(f, out)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return fmt.Errorf("write GITHUB_OUTPUT: %w", writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close GITHUB_OUTPUT: %w", closeErr)
+	}
+	return nil
+}
+
+// singleLine folds a reason onto one line so it cannot break the
+// key=value form $GITHUB_OUTPUT expects.
+func singleLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/docs/2026-08-06-minion-ci-self-repair/issues.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues.md
@@ -4,13 +4,13 @@ Source: [prd.md](./prd.md)
 
 | Done | # | Title | Blocked by |
 |------|---|-------|------------|
-| [ ]  | 1 | [Unblock the dead-code fixer](./issues/01-unblock-deadcode-fixer.md) | None |
-| [ ]  | 2 | [Count repair rounds instead of forbidding them](./issues/02-count-repair-rounds.md) | [#1](./issues/01-unblock-deadcode-fixer.md) |
-| [ ]  | 3 | [Say when it gave up](./issues/03-rounds-exhausted-comment.md) | [#2](./issues/02-count-repair-rounds.md) |
-| [ ]  | 4 | [One shared apply-prove-push](./issues/04-shared-patch-apply.md) | [#2](./issues/02-count-repair-rounds.md) |
-| [ ]  | 5 | [Lint and test as a PR check](./issues/05-lint-test-pr-check.md) | None |
+| [x]  | 1 | [Unblock the dead-code fixer](./issues/01-unblock-deadcode-fixer.md) | None |
+| [x]  | 2 | [Count repair rounds instead of forbidding them](./issues/02-count-repair-rounds.md) | [#1](./issues/01-unblock-deadcode-fixer.md) |
+| [x]  | 3 | [Say when it gave up](./issues/03-rounds-exhausted-comment.md) | [#2](./issues/02-count-repair-rounds.md) |
+| [x]  | 4 | [One shared apply-prove-push](./issues/04-shared-patch-apply.md) | [#2](./issues/02-count-repair-rounds.md) |
+| [x]  | 5 | [Lint and test as a PR check](./issues/05-lint-test-pr-check.md) | None |
 | [ ]  | 6 | [Repair failing lint and tests](./issues/06-repair-failing-checks.md) | [#4](./issues/04-shared-patch-apply.md), [#5](./issues/05-lint-test-pr-check.md) |
-| [ ]  | 7 | [Stop the gates colliding](./issues/07-gate-concurrency-and-retry.md) | [#6](./issues/06-repair-failing-checks.md) |
+| [x]  | 7 | [Stop the gates colliding](./issues/07-gate-concurrency-and-retry.md) | [#6](./issues/06-repair-failing-checks.md) |
 
 ## Notes
 
@@ -19,5 +19,10 @@ no slice merges itself. Where a slice's proof requires the change to be
 live on `main` — slice 1's re-run of PR #622 is the clearest case —
 that step is called out in the slice's own acceptance criteria as a
 post-merge verification.
+
+Slice 6 is built and its row stays `[ ]` for one reason: its last
+criterion is a post-merge verification that no working tree can show.
+Do not implement it again. Merge it, watch the first minion pull request
+that breaks its own test, then check the row.
 
 Slices 1 and 5 have no blockers and can start immediately.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/01-unblock-deadcode-fixer.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/01-unblock-deadcode-fixer.md
@@ -48,7 +48,7 @@ PRD user stories 1, 2, 3, 30.
       command and still requires the skip marker as its final act.
 - [x] A dry run of the dead-code audit fix program generates a prompt
       that contains no exported-identifier prohibition.
-- [ ] Post-merge verification: re-running the dead-code audit on PR
+- [x] Post-merge verification: re-running the dead-code audit on PR
       #622 completes with no surviving findings, and the inert `Model`
       field on the session type is removed by the pipeline with no
       human edit.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/02-count-repair-rounds.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/02-count-repair-rounds.md
@@ -34,24 +34,24 @@ PRD user stories 4, 5, 6, 19, 25.
 
 ## Acceptance criteria
 
-- [ ] A new package owns the decision "may another repair round start
+- [x] A new package owns the decision "may another repair round start
       for this check, and which round is it?", taking the branch's
       commit subjects, the check name, and the cap as input.
-- [ ] Repair commits are marked so that the check that produced them is
+- [x] Repair commits are marked so that the check that produced them is
       recoverable from the commit subject alone.
-- [ ] Counting for one check ignores repair commits belonging to another
+- [x] Counting for one check ignores repair commits belonging to another
       check.
-- [ ] The cap is three rounds per check, and the package reports the
+- [x] The cap is three rounds per check, and the package reports the
       round number so a caller can distinguish the first attempt from
       the last.
-- [ ] Human-authored commits and near-miss subjects are not counted as
+- [x] Human-authored commits and near-miss subjects are not counted as
       repair rounds.
-- [ ] The dead-code audit workflow consults the package instead of its
+- [x] The dead-code audit workflow consults the package instead of its
       inline shell skip guard, and stops auditing once the budget for
       that check is spent.
-- [ ] A pull request whose first repair leaves findings receives a
+- [x] A pull request whose first repair leaves findings receives a
       second repair attempt rather than going red immediately.
-- [ ] The package is covered by table-driven tests over commit-subject
+- [x] The package is covered by table-driven tests over commit-subject
       lists: no prior rounds, one, at the cap, over the cap, another
       check's rounds interleaved, human commits interleaved, an empty
       branch, and a subject that resembles a marker without being one.

--- a/docs/2026-08-06-minion-ci-self-repair/issues/03-rounds-exhausted-comment.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/03-rounds-exhausted-comment.md
@@ -26,17 +26,17 @@ PRD user stories 15, 16, 17, 18.
 
 ## Acceptance criteria
 
-- [ ] When repair rounds are exhausted and findings survive, the
+- [x] When repair rounds are exhausted and findings survive, the
       check's pull request comment names the surviving findings.
-- [ ] That comment states how many repair rounds ran.
-- [ ] The comment is distinguishable from a first-round failure comment,
+- [x] That comment states how many repair rounds ran.
+- [x] The comment is distinguishable from a first-round failure comment,
       so "gave up after spending the budget" reads differently from
       "failed on the first pass".
-- [ ] Repeated rounds upsert a single comment per check rather than
+- [x] Repeated rounds upsert a single comment per check rather than
       appending a new one each round.
-- [ ] The pull request is left red and open. Nothing closes it, rebuilds
+- [x] The pull request is left red and open. Nothing closes it, rebuilds
       it, or re-runs the build.
-- [ ] Tests cover the rounds-exhausted comment body and the upsert path
+- [x] Tests cover the rounds-exhausted comment body and the upsert path
       that replaces a prior comment rather than appending.
 
 ## Modules touched

--- a/docs/2026-08-06-minion-ci-self-repair/issues/04-shared-patch-apply.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/04-shared-patch-apply.md
@@ -39,21 +39,21 @@ PRD user stories 13, 14, 26, 28.
 
 ## Acceptance criteria
 
-- [ ] A new package owns fetch, detach, apply, prove, commit, and push
+- [x] A new package owns fetch, detach, apply, prove, commit, and push
       for a repair patch, given the patch, the pull request reference,
       and the check name.
-- [ ] The dead-code audit workflow uses the package instead of its
+- [x] The dead-code audit workflow uses the package instead of its
       inline shell, and its end-to-end repair behavior is unchanged.
-- [ ] A patch that fails to apply results in nothing pushed, reported as
+- [x] A patch that fails to apply results in nothing pushed, reported as
       a failed round rather than a job error.
-- [ ] A patch that applies but fails `make lint` or `make test` results
+- [x] A patch that applies but fails `make lint` or `make test` results
       in nothing pushed.
-- [ ] The push is made with the personal access token, not the default
+- [x] The push is made with the personal access token, not the default
       Actions token.
-- [ ] A fork head is refused before any fetch, with a clear reason.
-- [ ] The commit subject carries the per-check repair marker that slice
+- [x] A fork head is refused before any fetch, with a clear reason.
+- [x] The commit subject carries the per-check repair marker that slice
       [02](./02-count-repair-rounds.md) counts.
-- [ ] Tests drive the package against temporary git repositories created
+- [x] Tests drive the package against temporary git repositories created
       by the test, pushing to a local bare repository so no test touches
       the network, and cover: a patch that applies and passes, one that
       does not apply, one that applies but fails the checks, and a fork

--- a/docs/2026-08-06-minion-ci-self-repair/issues/05-lint-test-pr-check.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/05-lint-test-pr-check.md
@@ -34,24 +34,24 @@ PRD user stories 7, 8, 9, 23, 29.
 
 ## Acceptance criteria
 
-- [ ] `make lint` and `make test` run as a check on every pull request,
+- [x] `make lint` and `make test` run as a check on every pull request,
       including pull requests with no minion label.
-- [ ] Failures are converted into the same verdict shape the audits
+- [x] Failures are converted into the same verdict shape the audits
       emit, one finding per failing package or linter finding.
-- [ ] Each finding carries a location and reasoning sufficient to act on
+- [x] Each finding carries a location and reasoning sufficient to act on
       without re-running the command.
-- [ ] A clean run yields a pass verdict and a green check.
-- [ ] The check reports through the existing pull request comment
+- [x] A clean run yields a pass verdict and a green check.
+- [x] The check reports through the existing pull request comment
       surface, upserting one comment rather than appending per run.
-- [ ] A missing or malformed verdict fails the check closed, matching
+- [x] A missing or malformed verdict fails the check closed, matching
       how the audits behave — a gate must never pass by producing
       nothing.
-- [ ] No repair is attempted and no commit is pushed by this slice, on
+- [x] No repair is attempted and no commit is pushed by this slice, on
       any pull request.
-- [ ] The verdict conversion is covered by tests over captured command
+- [x] The verdict conversion is covered by tests over captured command
       output fixtures: a clean run, a failing test, a lint finding, and
       unparseable output — asserting the resulting status and findings.
-- [ ] The work requires no minions release and no version-pin bump.
+- [x] The work requires no minions release and no version-pin bump.
 
 ## Modules touched
 

--- a/docs/2026-08-06-minion-ci-self-repair/issues/06-repair-failing-checks.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/06-repair-failing-checks.md
@@ -35,27 +35,29 @@ PRD user stories 10, 11, 12, 27.
 
 ## Acceptance criteria
 
-- [ ] A failing lint/test verdict on a minion-labeled pull request
+- [x] A failing lint/test verdict on a minion-labeled pull request
       triggers a repair round.
-- [ ] Repair is skipped for pull requests without the minion label, and
+- [x] Repair is skipped for pull requests without the minion label, and
       no commit is pushed to them.
-- [ ] Repair is skipped for pull requests whose head branch lives in a
+- [x] Repair is skipped for pull requests whose head branch lives in a
       fork, with a clear reason and no push attempt.
-- [ ] The repair session may modify implementation code and may modify
+- [x] The repair session may modify implementation code and may modify
       tests the same pull request added.
-- [ ] The repair session does not modify tests that predate the pull
+- [x] The repair session does not modify tests that predate the pull
       request; a failure in one survives as a finding and the check goes
       red.
-- [ ] The session produces a patch only, and runs no git write command
+- [x] The session produces a patch only, and runs no git write command
       on any path.
-- [ ] Rounds are capped at three for this check, counted independently
+- [x] Rounds are capped at three for this check, counted independently
       of the dead-code check's rounds.
-- [ ] Repairs are applied, proven, and pushed through the shared applier
+- [x] Repairs are applied, proven, and pushed through the shared applier
       from slice [04](./04-shared-patch-apply.md), not through new
       inline shell.
-- [ ] A pull request whose failing test the minion itself wrote goes
-      green without human edits.
-- [ ] Rounds exhausted with findings surviving produces the give-up
+- [ ] Post-merge verification: a pull request whose failing test the
+      minion itself wrote goes green without human edits. This one needs
+      the workflow live on `main` and a minion pull request that breaks
+      its own test; it cannot be shown from the working tree.
+- [x] Rounds exhausted with findings surviving produces the give-up
       comment from slice [03](./03-rounds-exhausted-comment.md), naming
       the survivors and the round count.
 

--- a/docs/2026-08-06-minion-ci-self-repair/issues/07-gate-concurrency-and-retry.md
+++ b/docs/2026-08-06-minion-ci-self-repair/issues/07-gate-concurrency-and-retry.md
@@ -36,19 +36,19 @@ PRD user stories 20, 21, 22, 24.
 
 ## Acceptance criteria
 
-- [ ] All three gates share a concurrency group keyed on the pull
+- [x] All three gates share a concurrency group keyed on the pull
       request number.
-- [ ] The group is scoped to the job that audits, not to the workflow,
+- [x] The group is scoped to the job that audits, not to the workflow,
       so a repair's follow-up run cannot cancel the job performing the
       repair.
-- [ ] A job that skips without auditing does not enter the group.
-- [ ] Two gates failing on the same pull request cannot push repairs
+- [x] A job that skips without auditing does not enter the group.
+- [x] Two gates failing on the same pull request cannot push repairs
       concurrently.
-- [ ] A crashed e2e audit session, or one that writes no verdict, is
+- [x] A crashed e2e audit session, or one that writes no verdict, is
       retried once.
-- [ ] A second failed attempt leaves the check red; an infrastructure
+- [x] A second failed attempt leaves the check red; an infrastructure
       failure is never reported as a pass.
-- [ ] The e2e audit's judgment is otherwise unchanged: findings still
+- [x] The e2e audit's judgment is otherwise unchanged: findings still
       become proposal issues and still never fail a pull request.
 
 ## Modules touched

--- a/internal/auditgate/comment.go
+++ b/internal/auditgate/comment.go
@@ -18,9 +18,45 @@ const commentPrefix = "Minion audit — "
 func failBody(auditName string, v Verdict) string {
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "%s%s audit failed.\n", commentPrefix, auditName)
+	writeFindings(&b, v)
+	return b.String()
+}
+
+// writeFindings renders the numbered findings list both red-run
+// comments share.
+func writeFindings(b *bytes.Buffer, v Verdict) {
 	for i, f := range v.Findings {
-		fmt.Fprintf(&b, "\n%d. `%s` — %s\n", i+1, f.Location, f.Reasoning)
+		fmt.Fprintf(b, "\n%d. `%s` — %s\n", i+1, f.Location, f.Reasoning)
 	}
+}
+
+// plural picks the form matching n. The comment is read by a person
+// deciding whether to take the pull request over, so it reads as
+// prose rather than as log output.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// exhaustedBody renders the comment for a fail verdict that no further
+// repair round will address, because rounds is the whole budget. It
+// opens differently from failBody on purpose: an operator reading the
+// pull request must be able to tell "gave up after spending the
+// budget" from "failed on the first pass" without opening a run log.
+func exhaustedBody(auditName string, v Verdict, rounds int) string {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%s%s audit gave up after %d repair %s; the repair budget is spent.\n",
+		commentPrefix, auditName, rounds, plural(rounds, "round", "rounds"))
+	if len(v.Findings) == 1 {
+		fmt.Fprint(&b, "\nThis finding survived every round:\n")
+	} else {
+		fmt.Fprintf(&b, "\nThese %d findings survived every round:\n", len(v.Findings))
+	}
+	writeFindings(&b, v)
+	fmt.Fprint(&b, "\nNo further repair round starts for this check on this branch. "+
+		"The pull request stays red and open for a human to take over.\n")
 	return b.String()
 }
 

--- a/internal/auditgate/run.go
+++ b/internal/auditgate/run.go
@@ -18,6 +18,20 @@ type Config struct {
 	APIBaseURL  string       // GitHub API root, e.g. https://api.github.com
 	Token       string       // token for the comment upsert
 	HTTPClient  *http.Client // nil means http.DefaultClient
+
+	// Round is the repair round this run belongs to, as counted by
+	// internal/repairround; 1 is the first attempt. MaxRounds is the
+	// cap for this check. Both zero means the caller keeps no round
+	// accounting, and every failure reads as a first-pass failure.
+	Round     int
+	MaxRounds int
+}
+
+// budgetSpent reports whether this run is the last repair round the
+// check gets. The gate runs after the round's repair attempt, so a
+// surviving finding at the cap is one no further round will address.
+func (c Config) budgetSpent() bool {
+	return c.MaxRounds > 0 && c.Round >= c.MaxRounds
 }
 
 // Result is the gate's outcome. Green maps to exit 0, red to exit 1.
@@ -38,6 +52,14 @@ func Run(cfg Config) (Result, error) {
 	}
 	if v.Status == "pass" {
 		return Result{Green: true, Reason: "verdict: pass"}, nil
+	}
+	if cfg.budgetSpent() {
+		if err := upsertComment(cfg, exhaustedBody(cfg.AuditName, v, cfg.Round)); err != nil {
+			return Result{}, err
+		}
+		return Result{Green: false, Reason: fmt.Sprintf(
+			"verdict: fail with %d finding(s) after %d repair round(s); budget spent",
+			len(v.Findings), cfg.Round)}, nil
 	}
 	if err := upsertComment(cfg, failBody(cfg.AuditName, v)); err != nil {
 		return Result{}, err

--- a/internal/auditgate/run_test.go
+++ b/internal/auditgate/run_test.go
@@ -2,6 +2,7 @@ package auditgate
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,14 +20,24 @@ type fakeGitHub struct {
 	comments []map[string]any
 	created  []string
 	updated  map[int64]string
+	srv      *httptest.Server
+	// other records every request that is not a comment read or
+	// write, as "METHOD /path". Closing a pull request, reopening it,
+	// or dispatching a rebuild would land here.
+	other []string
 }
 
 func newFakeGitHub(seed ...map[string]any) *fakeGitHub {
 	return &fakeGitHub{comments: seed, updated: map[int64]string{}}
 }
 
+// server starts the double once and reuses it, so several gate runs
+// can share one pull request and see each other's comments.
 func (f *fakeGitHub) server(t *testing.T) *httptest.Server {
 	t.Helper()
+	if f.srv != nil {
+		return f.srv
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repos/partio-io/cli/issues/41/comments", func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(f.comments); err != nil {
@@ -46,8 +57,10 @@ func (f *fakeGitHub) server(t *testing.T) *httptest.Server {
 			t.Errorf("decode created comment: %v", err)
 		}
 		f.created = append(f.created, payload.Body)
+		id := int64(100 + len(f.created))
+		f.comments = append(f.comments, map[string]any{"id": id, "body": payload.Body})
 		w.WriteHeader(http.StatusCreated)
-		if _, err := w.Write([]byte(`{"id":1}`)); err != nil {
+		if _, err := fmt.Fprintf(w, `{"id":%d}`, id); err != nil {
 			t.Errorf("write response: %v", err)
 		}
 	})
@@ -68,12 +81,22 @@ func (f *fakeGitHub) server(t *testing.T) *httptest.Server {
 			t.Errorf("parse comment id: %v", err)
 		}
 		f.updated[id] = payload.Body
+		for _, c := range f.comments {
+			if c["id"] == id {
+				c["body"] = payload.Body
+			}
+		}
 		if _, err := w.Write([]byte(`{}`)); err != nil {
 			t.Errorf("write response: %v", err)
 		}
 	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		f.other = append(f.other, r.Method+" "+r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
+	f.srv = srv
 	return srv
 }
 
@@ -88,6 +111,14 @@ func writeVerdict(t *testing.T, content string) string {
 
 func runGate(t *testing.T, gh *fakeGitHub, verdictPath string) Result {
 	t.Helper()
+	return runGateRound(t, gh, verdictPath, 0, 0)
+}
+
+// runGateRound runs the gate as a numbered repair round. Round and
+// maxRounds of zero mean the caller has no round accounting, which is
+// how the audits that predate the round counter still call it.
+func runGateRound(t *testing.T, gh *fakeGitHub, verdictPath string, round, maxRounds int) Result {
+	t.Helper()
 	srv := gh.server(t)
 	res, err := Run(Config{
 		VerdictPath: verdictPath,
@@ -97,6 +128,8 @@ func runGate(t *testing.T, gh *fakeGitHub, verdictPath string) Result {
 		APIBaseURL:  srv.URL,
 		Token:       "test-token",
 		HTTPClient:  srv.Client(),
+		Round:       round,
+		MaxRounds:   maxRounds,
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -243,5 +276,217 @@ func TestRunFailVerdictGoesRedAndPostsOneComment(t *testing.T) {
 	}
 	if len(gh.updated) != 0 {
 		t.Errorf("updated %d comments, want 0", len(gh.updated))
+	}
+}
+
+// Tracer bullet for the spent budget: the last round's verdict still
+// fails, so the gate's one comment has to carry both halves of the
+// story — which findings survived, and that three rounds were spent
+// reaching them.
+func TestRunLastRoundReportsExhaustedBudget(t *testing.T) {
+	verdict := writeVerdict(t, `{
+		"status": "fail",
+		"findings": [
+			{
+				"location": "internal/session/state.go:88",
+				"reasoning": "reachable only from a test helper the PR deleted"
+			}
+		]
+	}`)
+	gh := newFakeGitHub()
+
+	res := runGateRound(t, gh, verdict, 3, 3)
+
+	if res.Green {
+		t.Fatalf("Run returned green for a fail verdict on the last round")
+	}
+	if len(gh.created) != 1 {
+		t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+	}
+	body := gh.created[0]
+	if !strings.HasPrefix(body, "Minion audit — dead-code") {
+		t.Errorf("comment does not start with audit prefix, so the next upsert cannot find it: %q", body)
+	}
+	for _, want := range []string{
+		"internal/session/state.go:88",
+		"reachable only from a test helper the PR deleted",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("exhausted comment missing %q:\n%s", want, body)
+		}
+	}
+	if !strings.Contains(body, "3 repair round") {
+		t.Errorf("exhausted comment does not say how many rounds ran:\n%s", body)
+	}
+}
+
+// Every survivor is named, not just the first: the comment is the
+// whole handover to whoever picks the pull request up.
+func TestRunExhaustedCommentNamesEverySurvivingFinding(t *testing.T) {
+	verdict := writeVerdict(t, `{
+		"status": "fail",
+		"findings": [
+			{"location": "internal/git/branch.go:31", "reasoning": "only caller was deleted by this PR"},
+			{"location": "internal/git/diff.go:77", "reasoning": "unreachable after the helper merge"},
+			{"location": "internal/config/env.go:9", "reasoning": "superseded by the layered loader"}
+		]
+	}`)
+	gh := newFakeGitHub()
+
+	runGateRound(t, gh, verdict, 3, 3)
+
+	if len(gh.created) != 1 {
+		t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+	}
+	body := gh.created[0]
+	for _, want := range []string{
+		"internal/git/branch.go:31", "only caller was deleted by this PR",
+		"internal/git/diff.go:77", "unreachable after the helper merge",
+		"internal/config/env.go:9", "superseded by the layered loader",
+		"3 findings survived",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("exhausted comment missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// The round count is the operator's cue for how much was already
+// tried, so the comment must carry the round this run actually is,
+// not the cap and not a constant.
+func TestRunExhaustedCommentStatesRoundsRun(t *testing.T) {
+	cases := []struct {
+		name      string
+		round     int
+		maxRounds int
+		want      string
+	}{
+		{"cap of three", 3, 3, "3 repair round"},
+		{"cap of one", 1, 1, "1 repair round"},
+		{"round past the cap", 4, 3, "4 repair round"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := writeVerdict(t, `{
+				"status": "fail",
+				"findings": [{"location": "internal/git/diff.go:12", "reasoning": "no caller remains"}]
+			}`)
+			gh := newFakeGitHub()
+
+			res := runGateRound(t, gh, verdict, tc.round, tc.maxRounds)
+
+			if res.Green {
+				t.Fatalf("Run returned green for a fail verdict")
+			}
+			if len(gh.created) != 1 {
+				t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+			}
+			if !strings.Contains(gh.created[0], tc.want) {
+				t.Errorf("comment does not state %q:\n%s", tc.want, gh.created[0])
+			}
+		})
+	}
+}
+
+// "Gave up after spending the budget" and "failed on the first pass"
+// are the two red states an operator has to tell apart. A run with no
+// round accounting reads as the latter, which is how the audits that
+// predate the counter keep their existing comment.
+func TestRunFailBodyDistinguishesFirstPassFromExhausted(t *testing.T) {
+	const verdictJSON = `{
+		"status": "fail",
+		"findings": [{"location": "internal/config/load.go:30", "reasoning": "unreferenced since the PR"}]
+	}`
+	cases := []struct {
+		name       string
+		round      int
+		maxRounds  int
+		wantRounds bool
+	}{
+		{"first round of three", 1, 3, false},
+		{"middle round of three", 2, 3, false},
+		{"no round accounting", 0, 0, false},
+		{"last round of three", 3, 3, true},
+	}
+	bodies := map[string]string{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gh := newFakeGitHub()
+
+			runGateRound(t, gh, writeVerdict(t, verdictJSON), tc.round, tc.maxRounds)
+
+			if len(gh.created) != 1 {
+				t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+			}
+			body := gh.created[0]
+			bodies[tc.name] = body
+			if got := strings.Contains(body, "repair budget is spent"); got != tc.wantRounds {
+				t.Errorf("body reports a spent budget = %v, want %v:\n%s", got, tc.wantRounds, body)
+			}
+		})
+	}
+	if bodies["first round of three"] == bodies["last round of three"] {
+		t.Errorf("first-pass and exhausted comments are identical:\n%s", bodies["first round of three"])
+	}
+	if bodies["no round accounting"] != bodies["first round of three"] {
+		t.Errorf("a run with no round accounting changed the existing fail comment:\n%s\nvs\n%s",
+			bodies["no round accounting"], bodies["first round of three"])
+	}
+}
+
+// Three rounds on one pull request leave one comment, not three. The
+// exhausted body opens differently from the fail body, so this also
+// proves the prefix match still finds the earlier round's comment and
+// replaces it rather than appending beside it.
+func TestRunRepeatedRoundsUpsertOneComment(t *testing.T) {
+	verdict := writeVerdict(t, `{
+		"status": "fail",
+		"findings": [{"location": "internal/attribution/lines.go:64", "reasoning": "dead since the rewrite"}]
+	}`)
+	gh := newFakeGitHub(map[string]any{"id": int64(8), "body": "Minion audit — e2e-need audit failed.\n\nanother check"})
+
+	for round := 1; round <= 3; round++ {
+		if res := runGateRound(t, gh, verdict, round, 3); res.Green {
+			t.Fatalf("round %d returned green for a fail verdict", round)
+		}
+	}
+
+	if len(gh.created) != 1 {
+		t.Fatalf("three rounds created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+	}
+	if len(gh.updated) != 1 {
+		t.Fatalf("three rounds updated %d distinct comments, want exactly 1: %v", len(gh.updated), gh.updated)
+	}
+	final, ok := gh.updated[101]
+	if !ok {
+		t.Fatalf("later rounds did not update the comment the first round created: %v", gh.updated)
+	}
+	if !strings.Contains(final, "repair budget is spent") {
+		t.Errorf("the surviving comment is not the last round's:\n%s", final)
+	}
+	for _, c := range gh.comments {
+		if c["id"] == int64(8) && c["body"] != "Minion audit — e2e-need audit failed.\n\nanother check" {
+			t.Errorf("the repair rounds overwrote another check's comment: %v", c["body"])
+		}
+	}
+}
+
+// A spent budget stops the pipeline and reports. It must not close the
+// pull request, reopen it, or dispatch a rebuild: the gate's only
+// side effect is the comment, and its only verdict is red.
+func TestRunExhaustedLeavesPullRequestRedAndOpen(t *testing.T) {
+	verdict := writeVerdict(t, `{
+		"status": "fail",
+		"findings": [{"location": "internal/log/setup.go:20", "reasoning": "no remaining caller"}]
+	}`)
+	gh := newFakeGitHub()
+
+	res := runGateRound(t, gh, verdict, 3, 3)
+
+	if res.Green {
+		t.Fatalf("Run returned green for an exhausted budget: %+v", res)
+	}
+	if len(gh.other) != 0 {
+		t.Errorf("the gate made requests beyond the comment surface: %q", gh.other)
 	}
 }

--- a/internal/checksverdict/added_tests.go
+++ b/internal/checksverdict/added_tests.go
@@ -1,0 +1,72 @@
+package checksverdict
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// testSuffix names a Go test file. It is the whole definition of "a
+// test" here: the repair boundary has to be decidable from a path, and
+// this is the only naming rule the toolchain itself enforces.
+const testSuffix = "_test.go"
+
+// AddedTestFiles returns the test files a pull request added, read from
+// the name-status form of its diff — the output of
+// `git diff --name-status` or `gh pr diff --name-status`, one record per
+// line, status first.
+//
+// This decides the repair session's one hard boundary. A test the pull
+// request added is the minion's own work, and a wrong assertion in it
+// is the common failure this pipeline exists to fix. Every other test
+// predates the pull request, and a session that may edit those can
+// reach green by deleting what someone else proved.
+//
+// Only the "A" status counts. A modified test is a pre-existing test
+// the pull request touched, and a renamed or copied one is old content
+// at a new path — in both cases the assertions predate the pull
+// request, so neither is an addition.
+//
+// The result is sorted and free of duplicates: a file added on one
+// commit and re-added on another is still one file.
+func AddedTestFiles(nameStatus string) []string {
+	var added []string
+	for line := range strings.SplitSeq(nameStatus, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "A" {
+			continue
+		}
+		if path := fields[1]; strings.HasSuffix(path, testSuffix) {
+			added = append(added, path)
+		}
+	}
+	slices.Sort(added)
+	return slices.Compact(added)
+}
+
+// WriteAddedTests saves the list where the repair session reads it, one
+// path per line.
+//
+// An empty list is written as an empty file rather than skipped. The
+// session's rule is "edit only the tests named here", so a missing file
+// and an empty one must not look the same: the first is a crash
+// upstream, and treating it as "no restriction" would hand the session
+// every test in the repository.
+func WriteAddedTests(path string, files []string) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("create the added-tests directory: %w", err)
+		}
+	}
+	var b strings.Builder
+	for _, f := range files {
+		b.WriteString(f)
+		b.WriteString("\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		return fmt.Errorf("write the added-tests list: %w", err)
+	}
+	return nil
+}

--- a/internal/checksverdict/added_tests_test.go
+++ b/internal/checksverdict/added_tests_test.go
@@ -1,0 +1,147 @@
+package checksverdict
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// The boundary a repair session is held to: a test the pull request
+// added is the minion's own work and may be corrected; every other
+// test predates the pull request and is out of bounds. Deciding it
+// here, from the diff, is what stops the session from reaching green
+// by deleting an assertion someone else wrote.
+func TestAddedTestFiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		nameStatus string
+		want       []string
+	}{
+		{
+			name:       "no diff at all",
+			nameStatus: "",
+			want:       nil,
+		},
+		{
+			name:       "a test the pull request added",
+			nameStatus: "A\tinternal/foo/bar_test.go\n",
+			want:       []string{"internal/foo/bar_test.go"},
+		},
+		{
+			name: "implementation and its new test",
+			nameStatus: "M\tinternal/foo/bar.go\n" +
+				"A\tinternal/foo/bar_test.go\n",
+			want: []string{"internal/foo/bar_test.go"},
+		},
+		// The common case the rule protects. A test that existed
+		// before the pull request stays out of bounds even when the
+		// pull request edited it — the assertions in it are not the
+		// minion's to remove.
+		{
+			name:       "a test the pull request only modified",
+			nameStatus: "M\tinternal/foo/existing_test.go\n",
+			want:       nil,
+		},
+		{
+			name:       "a test the pull request deleted",
+			nameStatus: "D\tinternal/foo/gone_test.go\n",
+			want:       nil,
+		},
+		// A renamed file is old content at a new path. Its assertions
+		// predate the pull request, so it is not an addition.
+		{
+			name:       "a test the pull request renamed",
+			nameStatus: "R100\tinternal/old/bar_test.go\tinternal/new/bar_test.go\n",
+			want:       nil,
+		},
+		{
+			name:       "a test the pull request copied",
+			nameStatus: "C085\tinternal/old/bar_test.go\tinternal/new/bar_test.go\n",
+			want:       nil,
+		},
+		{
+			name:       "an added file that is not a test",
+			nameStatus: "A\tinternal/foo/baz.go\n",
+			want:       nil,
+		},
+		// "_test.go" is the whole rule: a file merely named after
+		// testing is implementation and needs no exemption.
+		{
+			name: "files that only look like tests",
+			nameStatus: "A\tinternal/foo/test.go\n" +
+				"A\tinternal/foo/testing.go\n" +
+				"A\tinternal/foo/my_test_helper.go\n",
+			want: nil,
+		},
+		{
+			name: "several additions, sorted",
+			nameStatus: "A\tinternal/z/z_test.go\n" +
+				"A\tinternal/a/a_test.go\n" +
+				"A\tinternal/m/m_test.go\n",
+			want: []string{"internal/a/a_test.go", "internal/m/m_test.go", "internal/z/z_test.go"},
+		},
+		{
+			name: "the same file added twice across commits",
+			nameStatus: "A\tinternal/foo/bar_test.go\n" +
+				"A\tinternal/foo/bar_test.go\n",
+			want: []string{"internal/foo/bar_test.go"},
+		},
+		{
+			name: "blank and malformed lines are ignored",
+			nameStatus: "\n" +
+				"A\n" +
+				"   \n" +
+				"A\tinternal/foo/bar_test.go\n",
+			want: []string{"internal/foo/bar_test.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AddedTestFiles(tt.nameStatus)
+
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("AddedTestFiles = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The session reads this file to learn which tests it may touch, so
+// one path per line and nothing else.
+func TestWriteAddedTests(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "added-tests.txt")
+
+	if err := WriteAddedTests(path, []string{"internal/a/a_test.go", "internal/b/b_test.go"}); err != nil {
+		t.Fatalf("WriteAddedTests: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read the list back: %v", err)
+	}
+	if got, want := string(data), "internal/a/a_test.go\ninternal/b/b_test.go\n"; got != want {
+		t.Errorf("wrote %q, want %q", got, want)
+	}
+}
+
+// A pull request that added no tests still gets a file. "No test is
+// yours to edit" and "the list was never written" have to look
+// different to the session, or a crash upstream would read as a licence
+// to edit every test in the repository.
+func TestWriteAddedTestsWritesAnEmptyList(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "added-tests.txt")
+
+	if err := WriteAddedTests(path, nil); err != nil {
+		t.Fatalf("WriteAddedTests: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("the empty list was not written: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("wrote %q for an empty list, want nothing", data)
+	}
+}

--- a/internal/checksverdict/convert.go
+++ b/internal/checksverdict/convert.go
@@ -1,0 +1,97 @@
+// Package checksverdict turns the repository's own lint and test
+// commands into the verdict shape the minion audits already emit. The
+// gate, the pull request comment, the round accounting, and the patch
+// applier then work on a failing test exactly as they work on a
+// dead-code finding, without knowing which produced it.
+package checksverdict
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/partio-io/cli/internal/auditgate"
+)
+
+// maxRawOutput caps the raw output carried by a fallback finding. The
+// tail is the useful end of a command's output, and a pull request
+// comment has to stay readable.
+const maxRawOutput = 2000
+
+// Outcome is one check command's captured result. Name both labels the
+// check in its findings and selects the parser: "lint" and "test" are
+// understood, and anything else falls back to the raw output.
+type Outcome struct {
+	Name    string
+	Command string // what ran, e.g. "make test", quoted in fallback findings
+	Output  string // combined stdout and stderr
+	Failed  bool   // the command exited non-zero
+}
+
+// Convert maps captured outcomes to a verdict. The command's exit
+// status decides the status — never the parse, which can only add
+// detail to a failure the command already reported. A failed command
+// whose output yields nothing still produces a finding, because a fail
+// verdict with no findings is one the gate rejects as malformed.
+func Convert(outcomes []Outcome) auditgate.Verdict {
+	v := auditgate.Verdict{Status: "pass", Findings: []auditgate.Finding{}}
+	for _, o := range outcomes {
+		if !o.Failed {
+			continue
+		}
+		v.Status = "fail"
+		found := o.findings()
+		if len(found) == 0 {
+			found = []auditgate.Finding{o.unreadable()}
+		}
+		v.Findings = append(v.Findings, found...)
+	}
+	return v
+}
+
+// findings parses one failed command's output.
+func (o Outcome) findings() []auditgate.Finding {
+	switch o.Name {
+	case "test":
+		return parseTestOutput(o.Output, o.label())
+	case "lint":
+		return parseLintOutput(o.Output, o.label())
+	default:
+		return nil
+	}
+}
+
+// unreadable is the finding for a command that failed in a way its
+// parser does not recognise — a missing make target, a runner that
+// died, a format change. It hands over the raw tail so the failure is
+// still actionable, and it names the command so it can be re-run.
+func (o Outcome) unreadable() auditgate.Finding {
+	return auditgate.Finding{
+		Location: o.label(),
+		Reasoning: fmt.Sprintf(
+			"%s failed, and its output does not parse into findings. Raw output:\n%s",
+			o.label(), tail(o.Output)),
+	}
+}
+
+// label names the command in a finding, preferring what actually ran.
+func (o Outcome) label() string {
+	if o.Command != "" {
+		return o.Command
+	}
+	if o.Name != "" {
+		return o.Name
+	}
+	return "check"
+}
+
+// tail returns the last maxRawOutput characters, marking the cut.
+func tail(out string) string {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "(no output)"
+	}
+	if len(out) <= maxRawOutput {
+		return out
+	}
+	return "…\n" + out[len(out)-maxRawOutput:]
+}

--- a/internal/checksverdict/convert_test.go
+++ b/internal/checksverdict/convert_test.go
@@ -1,0 +1,259 @@
+package checksverdict
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/partio-io/cli/internal/auditgate"
+)
+
+// Both commands succeeded, so the verdict is a pass with no findings
+// and the gate takes it green without touching the pull request. A
+// green check that still posts a comment would train everyone to
+// ignore the comment.
+func TestCleanRunPassesAndLeavesThePullRequestAlone(t *testing.T) {
+	path := writeTo(t,
+		Outcome{Name: "lint", Command: "make lint", Output: fixture(t, "lint-clean.txt")},
+		Outcome{Name: "test", Command: "make test", Output: fixture(t, "test-clean.txt")},
+	)
+	gh := newFakeGitHub()
+
+	res := runGate(t, gh, path)
+
+	if !res.Green {
+		t.Fatalf("gate returned red for a clean run: %+v", res)
+	}
+	if len(gh.created) != 0 || len(gh.updated) != 0 {
+		t.Errorf("a clean run touched comments: created=%q updated=%v", gh.created, gh.updated)
+	}
+}
+
+// The status comes from the exit code, so passing output that happens
+// to contain failure-shaped text cannot turn the check red, and a
+// command that failed silently cannot turn it green.
+func TestStatusFollowsTheExitCodeNotTheOutput(t *testing.T) {
+	cases := []struct {
+		name      string
+		outcome   Outcome
+		want      string
+		wantEmpty bool
+	}{
+		{
+			name:      "failing output but the command succeeded",
+			outcome:   Outcome{Name: "test", Command: "make test", Output: fixture(t, "test-fail.txt")},
+			want:      "pass",
+			wantEmpty: true,
+		},
+		{
+			name:    "clean output but the command failed",
+			outcome: Outcome{Name: "test", Command: "make test", Output: fixture(t, "test-clean.txt"), Failed: true},
+			want:    "fail",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := Convert([]Outcome{tc.outcome})
+
+			if v.Status != tc.want {
+				t.Errorf("status = %q, want %q", v.Status, tc.want)
+			}
+			if tc.wantEmpty && len(v.Findings) != 0 {
+				t.Errorf("a passing command produced %d findings: %+v", len(v.Findings), v.Findings)
+			}
+			if !tc.wantEmpty && len(v.Findings) == 0 {
+				t.Error("a failing command produced no findings; the gate rejects that as malformed")
+			}
+		})
+	}
+}
+
+// Every golangci-lint issue becomes its own finding, located at the
+// exact file, line, and column the linter reported, and carrying both
+// the message and the linter that raised it. The trailing summary
+// block is bookkeeping, not an issue, and must not become a finding.
+func TestLintIssuesBecomeOneFindingEach(t *testing.T) {
+	v := Convert([]Outcome{
+		{Name: "lint", Command: "make lint", Output: fixture(t, "lint-fail.txt"), Failed: true},
+	})
+
+	if v.Status != "fail" {
+		t.Fatalf("status = %q, want fail", v.Status)
+	}
+	if len(v.Findings) != 4 {
+		t.Fatalf("got %d findings, want 4 (one per lint issue): %+v", len(v.Findings), v.Findings)
+	}
+	for _, want := range []struct{ location, reasoning string }{
+		{"internal/config/load.go:11:5", "Error return value of `os.Create` is not checked"},
+		{"internal/config/load.go:12:15", "Error return value of `f.WriteString` is not checked"},
+		{"internal/config/load.go:13:9", "Error return value of `f.Close` is not checked"},
+		{"internal/config/load.go:8:6", "func unusedHelper is unused"},
+	} {
+		if !hasFinding(v.Findings, want.location, want.reasoning) {
+			t.Errorf("no finding at %s saying %q:\n%+v", want.location, want.reasoning, v.Findings)
+		}
+	}
+	// The linter's name is what tells a repair session which rule it
+	// broke, so it has to survive into the reasoning.
+	if !hasFinding(v.Findings, "load.go:8:6", "unused") {
+		t.Error("findings do not name the linter that raised them")
+	}
+	for _, f := range v.Findings {
+		if strings.Contains(f.Location, "issues:") || strings.HasPrefix(f.Location, "*") {
+			t.Errorf("the summary block leaked into a finding: %+v", f)
+		}
+	}
+}
+
+// A package that never compiled prints compiler errors instead of test
+// results, so there is no failing test name to hang them on. The
+// finding still has to carry the file, the line, and the compiler's
+// own words.
+func TestBuildFailureCarriesTheCompilerErrors(t *testing.T) {
+	v := Convert([]Outcome{
+		{Name: "test", Command: "make test", Output: fixture(t, "test-build-fail.txt"), Failed: true},
+	})
+
+	if len(v.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1 (the package that failed to build): %+v", len(v.Findings), v.Findings)
+	}
+	f := v.Findings[0]
+	if f.Location != "github.com/partio-io/cli/internal/attribution" {
+		t.Errorf("location = %q, want the package that failed to build", f.Location)
+	}
+	for _, want := range []string{
+		"internal/attribution/lines.go:3:37",
+		"undefined: undefinedThing",
+	} {
+		if !strings.Contains(f.Reasoning, want) {
+			t.Errorf("reasoning missing %q:\n%s", want, f.Reasoning)
+		}
+	}
+	// The package that built and passed is not a finding.
+	if strings.Contains(f.Location, "internal/config") {
+		t.Errorf("a passing package produced a finding: %+v", f)
+	}
+}
+
+// Subtests report twice: once inline as they run, and again as an
+// indented roll-up under the parent. The roll-up is not detail, and a
+// passing subtest's roll-up line must never be filed under a failing
+// test — a reader who sees "--- PASS" under a failure stops trusting
+// the report.
+func TestPassingSubtestsDoNotPolluteAFailure(t *testing.T) {
+	v := Convert([]Outcome{
+		{Name: "test", Command: "make test", Output: fixture(t, "test-fail-subtests.txt"), Failed: true},
+	})
+
+	if len(v.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(v.Findings), v.Findings)
+	}
+	f := v.Findings[0]
+	if !strings.Contains(f.Reasoning, `metadata session id = "", want "s-42"`) {
+		t.Errorf("reasoning lost the assertion that failed:\n%s", f.Reasoning)
+	}
+	if strings.Contains(f.Reasoning, "PASS") {
+		t.Errorf("a passing subtest was reported under the failure:\n%s", f.Reasoning)
+	}
+	if strings.Contains(f.Reasoning, "TestFindByBranch") {
+		t.Errorf("a test that passed was named in the failure:\n%s", f.Reasoning)
+	}
+}
+
+// When the subtests are what failed, the finding has to name them and
+// carry their assertions. Naming only the parent sends a repair
+// session to a table with no clue which row broke.
+func TestFailingSubtestsAreNamedWithTheirAssertions(t *testing.T) {
+	v := Convert([]Outcome{
+		{Name: "test", Command: "make test", Output: fixture(t, "test-fail-subtest.txt"), Failed: true},
+	})
+
+	if len(v.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1 (one failing package): %+v", len(v.Findings), v.Findings)
+	}
+	f := v.Findings[0]
+	for _, want := range []string{
+		"TestLoadMergesLayers/local_over_repo",
+		"TestLoadMergesLayers/env_over_local",
+		`load_test.go:17: merged value = "global", want "local"`,
+	} {
+		if !strings.Contains(f.Reasoning, want) {
+			t.Errorf("reasoning missing %q:\n%s", want, f.Reasoning)
+		}
+	}
+	if strings.Contains(f.Reasoning, "repo_over_global") {
+		t.Errorf("the subtest that passed was reported as failing:\n%s", f.Reasoning)
+	}
+	if strings.Contains(f.Reasoning, "this one is fine") {
+		t.Errorf("a passing test's log output leaked into the failure:\n%s", f.Reasoning)
+	}
+}
+
+// Output the parser does not recognise is the case that decides
+// whether the gate can be trusted. It must never yield a pass, and
+// never a fail with no findings — the gate rejects that as malformed,
+// which would turn an unreadable failure into a fail-closed with the
+// evidence thrown away. The raw output travels instead.
+func TestUnparseableOutputStillFailsWithAnActionableFinding(t *testing.T) {
+	v := Convert([]Outcome{
+		{Name: "test", Command: "make test", Output: fixture(t, "unparseable.txt"), Failed: true},
+	})
+
+	if v.Status != "fail" {
+		t.Fatalf("status = %q, want fail", v.Status)
+	}
+	if len(v.Findings) != 1 {
+		t.Fatalf("got %d findings, want exactly 1 fallback: %+v", len(v.Findings), v.Findings)
+	}
+	f := v.Findings[0]
+	if f.Location != "make test" {
+		t.Errorf("location = %q, want the command that failed", f.Location)
+	}
+	if !strings.Contains(f.Reasoning, "No rule to make target") {
+		t.Errorf("reasoning does not carry the raw output:\n%s", f.Reasoning)
+	}
+}
+
+// Whatever a command prints, a failure must arrive as findings the
+// gate accepts. Anything else fails the check closed and discards the
+// reason it failed.
+func TestAFailedCommandAlwaysProducesUsableFindings(t *testing.T) {
+	outputs := []string{
+		fixture(t, "test-fail.txt"),
+		fixture(t, "test-build-fail.txt"),
+		fixture(t, "lint-fail.txt"),
+		fixture(t, "unparseable.txt"),
+		"",
+		"FAIL\n",
+		"panic: runtime error: index out of range [3] with length 2",
+	}
+	for _, name := range []string{"lint", "test", "something-else"} {
+		for i, out := range outputs {
+			t.Run(fmt.Sprintf("%s/%d", name, i), func(t *testing.T) {
+				v := Convert([]Outcome{{Name: name, Command: "make " + name, Output: out, Failed: true}})
+
+				if v.Status != "fail" {
+					t.Fatalf("status = %q, want fail", v.Status)
+				}
+				if len(v.Findings) == 0 {
+					t.Fatal("a failed command produced no findings; the gate would fail closed and lose the reason")
+				}
+				for _, f := range v.Findings {
+					if strings.TrimSpace(f.Location) == "" || strings.TrimSpace(f.Reasoning) == "" {
+						t.Errorf("finding is missing location or reasoning: %+v", f)
+					}
+				}
+			})
+		}
+	}
+}
+
+// hasFinding reports whether some finding matches both substrings.
+func hasFinding(findings []auditgate.Finding, location, reasoning string) bool {
+	for _, f := range findings {
+		if strings.Contains(f.Location, location) && strings.Contains(f.Reasoning, reasoning) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/checksverdict/gate_test.go
+++ b/internal/checksverdict/gate_test.go
@@ -1,0 +1,289 @@
+package checksverdict
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/partio-io/cli/internal/auditgate"
+)
+
+// fakeGitHub is the smallest issues-comments double this package
+// needs. auditgate has a fuller one for its own tests; here the point
+// is only that a checks verdict travels the real gate, so this records
+// what the gate posts and nothing else.
+type fakeGitHub struct {
+	comments []map[string]any
+	created  []string
+	updated  map[int64]string
+	srv      *httptest.Server
+	// other records any request outside the comment surface, as
+	// "METHOD /path". A push, a merge, or a dispatch would land here.
+	other []string
+}
+
+func newFakeGitHub() *fakeGitHub {
+	return &fakeGitHub{updated: map[int64]string{}}
+}
+
+func (f *fakeGitHub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	if f.srv != nil {
+		return f.srv
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/partio-io/cli/issues/41/comments", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(f.comments); err != nil {
+			t.Errorf("encode comments: %v", err)
+		}
+	})
+	mux.HandleFunc("POST /repos/partio-io/cli/issues/41/comments", func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+		f.created = append(f.created, body)
+		id := int64(100 + len(f.created))
+		f.comments = append(f.comments, map[string]any{"id": id, "body": body})
+		w.WriteHeader(http.StatusCreated)
+		if _, err := fmt.Fprintf(w, `{"id":%d}`, id); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+	mux.HandleFunc("PATCH /repos/partio-io/cli/issues/comments/{id}", func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+		var id int64
+		if _, err := fmt.Sscanf(r.PathValue("id"), "%d", &id); err != nil {
+			t.Errorf("parse comment id: %v", err)
+		}
+		f.updated[id] = body
+		for _, c := range f.comments {
+			if c["id"] == id {
+				c["body"] = body
+			}
+		}
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		f.other = append(f.other, r.Method+" "+r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.srv = srv
+	return srv
+}
+
+func readBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("read request body: %v", err)
+		return ""
+	}
+	var payload struct {
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Errorf("decode comment payload: %v", err)
+	}
+	return payload.Body
+}
+
+// fixture returns a captured command output. The files under testdata
+// are real `go test` and `golangci-lint` output, not hand-written
+// approximations of it.
+func fixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return string(data)
+}
+
+// runGate sends a verdict through the real gate against the double.
+func runGate(t *testing.T, gh *fakeGitHub, verdictPath string) auditgate.Result {
+	t.Helper()
+	srv := gh.server(t)
+	res, err := auditgate.Run(auditgate.Config{
+		VerdictPath: verdictPath,
+		Repo:        "partio-io/cli",
+		PRNumber:    41,
+		AuditName:   "checks",
+		APIBaseURL:  srv.URL,
+		Token:       "test-token",
+		HTTPClient:  srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("auditgate.Run: %v", err)
+	}
+	return res
+}
+
+// writeTo converts outcomes and writes the verdict, returning its path.
+func writeTo(t *testing.T, outcomes ...Outcome) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "verdict.json")
+	if err := Write(path, Convert(outcomes)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return path
+}
+
+// Re-running the check on a new push replaces its comment instead of
+// adding one, and leaves the audits' comments alone. A check that runs
+// on every push would otherwise bury the pull request.
+func TestRepeatedRunsUpsertOneComment(t *testing.T) {
+	path := writeTo(t,
+		Outcome{Name: "test", Command: "make test", Output: fixture(t, "test-fail.txt"), Failed: true},
+	)
+	gh := newFakeGitHub()
+	gh.comments = append(gh.comments, map[string]any{
+		"id":   int64(8),
+		"body": "Minion audit — dead-code audit failed.\n\nanother check's comment",
+	})
+
+	for run := 1; run <= 3; run++ {
+		if res := runGate(t, gh, path); res.Green {
+			t.Fatalf("run %d returned green for a failing test run", run)
+		}
+	}
+
+	if len(gh.created) != 1 {
+		t.Fatalf("three runs created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+	}
+	if len(gh.updated) != 1 {
+		t.Fatalf("three runs updated %d distinct comments, want exactly 1: %v", len(gh.updated), gh.updated)
+	}
+	if _, ok := gh.updated[101]; !ok {
+		t.Errorf("later runs did not update the comment the first run created: %v", gh.updated)
+	}
+	for _, c := range gh.comments {
+		if c["id"] == int64(8) && !strings.Contains(c["body"].(string), "another check's comment") {
+			t.Errorf("the checks gate overwrote the dead-code audit's comment: %v", c["body"])
+		}
+	}
+}
+
+// The check has to fail closed exactly as the audits do. A crashed
+// converter writes no verdict, and a truncated one writes half of it;
+// neither may pass. This is the case that decides whether a green
+// check means anything.
+func TestMissingOrMalformedVerdictFailsClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string // empty means: never write the file at all
+	}{
+		{"never written", ""},
+		{"truncated json", `{"status": "fail", "findings": [`},
+		{"unknown status", `{"status": "unknown", "findings": []}`},
+		{"fail with no findings", `{"status": "fail", "findings": []}`},
+		{"finding with no reasoning", `{"status": "fail", "findings": [{"location": "internal/x.go:1", "reasoning": ""}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "verdict.json")
+			if tc.content != "" {
+				if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+					t.Fatalf("write verdict: %v", err)
+				}
+			}
+			gh := newFakeGitHub()
+
+			res := runGate(t, gh, path)
+
+			if res.Green {
+				t.Fatalf("gate returned green with no usable verdict: %+v", res)
+			}
+			if len(gh.created) != 1 {
+				t.Fatalf("created %d comments, want exactly 1 saying why: %q", len(gh.created), gh.created)
+			}
+			if !strings.Contains(gh.created[0], "no usable verdict") {
+				t.Errorf("comment is not the fail-closed body: %q", gh.created[0])
+			}
+		})
+	}
+}
+
+// Everything Convert produces has to survive the round trip to disk
+// and back through the gate's own loader. A shape the gate rejects is
+// a check that reports nothing while looking like it ran.
+func TestWrittenVerdictsAreAlwaysLoadableByTheGate(t *testing.T) {
+	cases := []struct {
+		name     string
+		outcomes []Outcome
+		green    bool
+	}{
+		{"clean", []Outcome{
+			{Name: "lint", Command: "make lint", Output: fixture(t, "lint-clean.txt")},
+			{Name: "test", Command: "make test", Output: fixture(t, "test-clean.txt")},
+		}, true},
+		{"lint failed", []Outcome{
+			{Name: "lint", Command: "make lint", Output: fixture(t, "lint-fail.txt"), Failed: true},
+			{Name: "test", Command: "make test", Output: fixture(t, "test-clean.txt")},
+		}, false},
+		{"both failed", []Outcome{
+			{Name: "lint", Command: "make lint", Output: fixture(t, "lint-fail.txt"), Failed: true},
+			{Name: "test", Command: "make test", Output: fixture(t, "test-fail.txt"), Failed: true},
+		}, false},
+		{"failed with output nobody can parse", []Outcome{
+			{Name: "test", Command: "make test", Output: fixture(t, "unparseable.txt"), Failed: true},
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gh := newFakeGitHub()
+
+			res := runGate(t, gh, writeTo(t, tc.outcomes...))
+
+			if res.Green != tc.green {
+				t.Fatalf("green = %v, want %v (%s)", res.Green, tc.green, res.Reason)
+			}
+			if strings.Contains(res.Reason, "fail-closed") {
+				t.Errorf("the gate could not read a verdict this package wrote: %s", res.Reason)
+			}
+		})
+	}
+}
+
+// Tracer bullet: output from a failing test package travels the whole
+// path — parse, verdict file, the audits' own gate — and arrives as a
+// red check whose single comment names the package and says what
+// failed. Nothing along the way knows the failure came from `make
+// test` rather than from an audit session; that is the point of
+// reusing the verdict shape.
+func TestFailingTestReachesTheGateAsARedCheck(t *testing.T) {
+	path := writeTo(t,
+		Outcome{Name: "lint", Command: "make lint", Output: fixture(t, "lint-clean.txt")},
+		Outcome{Name: "test", Command: "make test", Output: fixture(t, "test-fail.txt"), Failed: true},
+	)
+	gh := newFakeGitHub()
+
+	res := runGate(t, gh, path)
+
+	if res.Green {
+		t.Fatalf("gate returned green for a failing test run: %+v", res)
+	}
+	if len(gh.created) != 1 {
+		t.Fatalf("created %d comments, want exactly 1: %q", len(gh.created), gh.created)
+	}
+	body := gh.created[0]
+	for _, want := range []string{
+		"github.com/partio-io/cli/internal/attribution",
+		"TestCalculateSplitsAgentAndHumanLines",
+		"Calculate(diff) agent lines = 4, want 5",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("comment missing %q:\n%s", want, body)
+		}
+	}
+	if len(gh.other) != 0 {
+		t.Errorf("the check made requests beyond the comment surface: %q", gh.other)
+	}
+}

--- a/internal/checksverdict/parse_lint_output.go
+++ b/internal/checksverdict/parse_lint_output.go
@@ -1,0 +1,64 @@
+package checksverdict
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/partio-io/cli/internal/auditgate"
+)
+
+// lintIssue matches the head of one golangci-lint issue:
+// "path/file.go:12:34: message (linter)". The column is optional. The
+// path must carry a file extension, which is what keeps the trailing
+// summary block and any log lines from parsing as issues.
+var lintIssue = regexp.MustCompile(`^(\S+\.\w+:\d+(?::\d+)?): (.+)$`)
+
+// lintSummary matches the count line that closes the report, after
+// which nothing belongs to an issue any more.
+var lintSummary = regexp.MustCompile(`^\d+ issues?:$`)
+
+// maxLintContext caps the source lines kept under one issue. The
+// reporter prints the offending line and a caret; more than a few
+// lines means the format changed, and a pull request comment is not
+// the place to find that out.
+const maxLintContext = 4
+
+// parseLintOutput turns golangci-lint output into one finding per
+// issue. The source excerpt the reporter prints under each issue is
+// kept, so a repair session can see the offending line without opening
+// the file.
+func parseLintOutput(out, label string) []auditgate.Finding {
+	var (
+		findings []auditgate.Finding
+		context  []string
+	)
+	flush := func() {
+		if len(findings) == 0 || len(context) == 0 {
+			context = nil
+			return
+		}
+		last := &findings[len(findings)-1]
+		last.Reasoning += "\n" + strings.Join(context, "\n")
+		context = nil
+	}
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case lintSummary.MatchString(strings.TrimSpace(line)):
+			flush()
+			return findings
+		case lintIssue.MatchString(line):
+			flush()
+			m := lintIssue.FindStringSubmatch(line)
+			findings = append(findings, auditgate.Finding{
+				Location:  m[1],
+				Reasoning: fmt.Sprintf("`%s` reported: %s", label, m[2]),
+			})
+		case strings.TrimSpace(line) == "":
+		case len(context) < maxLintContext:
+			context = append(context, strings.TrimRight(line, " \t"))
+		}
+	}
+	flush()
+	return findings
+}

--- a/internal/checksverdict/parse_test_output.go
+++ b/internal/checksverdict/parse_test_output.go
@@ -1,0 +1,180 @@
+package checksverdict
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/partio-io/cli/internal/auditgate"
+)
+
+// The verbose test format, matched structurally rather than by raw
+// prefix: an assertion message can itself start with "---" (a unified
+// diff does), and that message is the most valuable line in the
+// report.
+var (
+	testRun    = regexp.MustCompile(`^=== RUN\s+(\S+)$`)
+	testStatus = regexp.MustCompile(`^--- (PASS|FAIL|SKIP|BENCH): (\S+)`)
+	testOther  = regexp.MustCompile(`^=== (PAUSE|CONT|NAME)\s`)
+)
+
+const (
+	// A failing package's report ends up in a pull request comment, so
+	// each part of it is bounded: the lines kept under one test, the
+	// compiler errors or panic dump kept under a package, and the
+	// number of failing tests named before the rest are counted.
+	maxDetailLines = 20
+	maxLooseLines  = 40
+	maxFailedTests = 10
+)
+
+// parseTestOutput turns `go test ./... -v` output into one finding per
+// failing package.
+//
+// The package a line belongs to is only known at the line that closes
+// it — "ok" or "FAIL" — so lines accumulate until one of those arrives
+// and are then either dropped or attributed.
+func parseTestOutput(out, label string) []auditgate.Finding {
+	var (
+		findings []auditgate.Finding
+		buf      []string
+	)
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case closesPassingPackage(line):
+			buf = nil
+		case strings.HasPrefix(line, "FAIL\t"):
+			if pkg := packageOf(line); pkg != "" {
+				findings = append(findings, auditgate.Finding{
+					Location:  pkg,
+					Reasoning: failureReport(pkg, label, buf),
+				})
+			}
+			buf = nil
+		case line == "PASS" || line == "FAIL":
+			// Per-package separators; they carry nothing.
+		default:
+			buf = append(buf, line)
+		}
+	}
+	return findings
+}
+
+// closesPassingPackage reports whether the line ends a package that
+// needs no finding: one that passed, or one with no test files.
+func closesPassingPackage(line string) bool {
+	return strings.HasPrefix(line, "ok  \t") || strings.HasPrefix(line, "?   \t")
+}
+
+// packageOf pulls the import path out of a "FAIL" line. It covers both
+// "FAIL\tpkg\t0.01s" and "FAIL\tpkg [build failed]".
+func packageOf(line string) string {
+	fields := strings.Fields(strings.TrimPrefix(line, "FAIL"))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// failureReport builds the reasoning for one failing package: which
+// tests failed and what they printed, or the compiler errors when the
+// package never built. It is written to be read without re-running the
+// command.
+func failureReport(pkg, label string, buf []string) string {
+	failed, loose := splitFailures(buf)
+	report := &strings.Builder{}
+	fmt.Fprintf(report, "Package %s failed under `%s`.", pkg, label)
+	shown := failed
+	if len(shown) > maxFailedTests {
+		shown = shown[:maxFailedTests]
+	}
+	for _, f := range shown {
+		fmt.Fprintf(report, "\n\n%s failed:", f.test)
+		for _, d := range f.detail {
+			fmt.Fprintf(report, "\n%s", strings.TrimRight(d, " \t"))
+		}
+	}
+	if rest := len(failed) - len(shown); rest > 0 {
+		fmt.Fprintf(report, "\n\n… and %d more failing test(s) in this package.", rest)
+	}
+	if len(loose) > 0 {
+		// A build failure prints compiler errors instead of test
+		// results, and a panic prints a stack; neither has a test name
+		// to hang it on.
+		fmt.Fprintf(report, "\n\n%s", strings.Join(loose, "\n"))
+	}
+	return report.String()
+}
+
+// testFailure is one failing test and the lines it printed.
+type testFailure struct {
+	test   string
+	detail []string
+}
+
+// splitFailures separates a failing package's buffered lines into the
+// tests that failed with their output, and everything that belonged to
+// no test — compiler errors, panics, and stray writes to stderr.
+//
+// Output is attributed by test name, not by position: subtests report
+// once inline as they run and again as an indented roll-up under the
+// parent, so the run that produced a line and the line that declares
+// it failed can be far apart.
+func splitFailures(buf []string) (failed []testFailure, loose []string) {
+	var (
+		detail  = map[string][]string{}
+		order   []string
+		current string
+	)
+	for _, line := range buf {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case testRun.MatchString(trimmed):
+			current = testRun.FindStringSubmatch(trimmed)[1]
+		case testStatus.MatchString(trimmed):
+			m := testStatus.FindStringSubmatch(trimmed)
+			if m[1] == "FAIL" {
+				order = append(order, m[2])
+			}
+			current = ""
+		case testOther.MatchString(trimmed):
+			// PAUSE, CONT and NAME are scheduling noise.
+		case trimmed == "":
+		case current != "":
+			if len(detail[current]) < maxDetailLines {
+				detail[current] = append(detail[current], line)
+			}
+		default:
+			if len(loose) < maxLooseLines {
+				loose = append(loose, line)
+			}
+		}
+	}
+	for _, name := range withoutRolledUpParents(order) {
+		failed = append(failed, testFailure{test: name, detail: detail[name]})
+	}
+	return failed, loose
+}
+
+// withoutRolledUpParents drops a parent test whose failure is only the
+// sum of its subtests' failures. The subtest names say which table row
+// broke; the parent's name says nothing the children do not.
+func withoutRolledUpParents(names []string) []string {
+	kept := make([]string, 0, len(names))
+	for _, name := range names {
+		if hasFailingChild(name, names) {
+			continue
+		}
+		kept = append(kept, name)
+	}
+	return kept
+}
+
+func hasFailingChild(name string, names []string) bool {
+	for _, other := range names {
+		if other != name && strings.HasPrefix(other, name+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/checksverdict/program_test.go
+++ b/internal/checksverdict/program_test.go
@@ -1,0 +1,83 @@
+package checksverdict
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// programPath is the repair session's program, read from the repository
+// for the same reason the workflow is: these are guarantees about what
+// CI actually runs, and a copy would drift away from that silently.
+const programPath = "../../.minions/programs/checks-fix.md"
+
+func program(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(programPath))
+	if err != nil {
+		t.Fatalf("read the checks fix program: %v", err)
+	}
+	return string(data)
+}
+
+// The rule that separates a repair from a bot that reaches green by
+// deleting an assertion. The session may correct a test the pull
+// request added — a minion's own wrong test is the common case — and
+// may not touch one that predates it. A failure in a pre-existing test
+// survives as a finding, and the check stays red for a person to read.
+func TestTheProgramBoundsWhichTestsMayChange(t *testing.T) {
+	p := program(t)
+
+	if !strings.Contains(p, "added-tests.txt") {
+		t.Error("the program never reads the added-test list, so its boundary is its own judgment")
+	}
+	for _, rule := range []string{
+		"only test files you may modify",
+		"predates this pull request is out of bounds",
+		"survives",
+		"Never weaken a test",
+	} {
+		if !strings.Contains(p, rule) {
+			t.Errorf("the program does not state %q", rule)
+		}
+	}
+}
+
+// Implementation code is what a repair usually has to change, and a
+// program that only talked about tests would leave the session unsure
+// it may touch anything else.
+func TestTheProgramAllowsImplementationRepairs(t *testing.T) {
+	p := program(t)
+
+	if !strings.Contains(p, "Implementation code is yours to change") {
+		t.Error("the program does not say implementation code may be changed")
+	}
+	if !strings.Contains(p, "Repair the implementation first") {
+		t.Error("the program does not prefer an implementation repair over a test change")
+	}
+}
+
+// The session contract, unchanged from the dead-code fixer: a patch,
+// proven, and nothing else. The workflow owns every write to the
+// repository, so a session that commits or pushes would be pushing work
+// no one proved and no one counted.
+func TestTheProgramProducesAPatchAndNothingElse(t *testing.T) {
+	p := program(t)
+
+	for _, rule := range []string{
+		"The session runs no git write commands: no commit, no push, no branches, no PRs, no comments",
+		"The skip marker file is written as the session's final act on every path",
+		"make lint and make test pass in the patched tree before the patch is exported",
+	} {
+		if !strings.Contains(p, rule) {
+			t.Errorf("the program's acceptance criteria do not carry %q", rule)
+		}
+	}
+	if !strings.Contains(p, "You do not commit or push") {
+		t.Error("the program does not tell the session it must not commit or push")
+	}
+	if !strings.Contains(p, "skip_marker: .minion-fix-done") {
+		t.Error("the program declares no skip marker, so leftover edits would become a stray pull request")
+	}
+}

--- a/internal/checksverdict/run.go
+++ b/internal/checksverdict/run.go
@@ -1,0 +1,51 @@
+package checksverdict
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// Command is one check to run: the name that labels its findings and
+// the argv that produces them.
+type Command struct {
+	Name string
+	Args []string
+}
+
+// DefaultCommands is what the check runs when a caller names nothing:
+// the repository's own targets, in the order a developer runs them.
+// Lint comes first because it is the cheaper of the two.
+func DefaultCommands() []Command {
+	return []Command{
+		{Name: "lint", Args: []string{"make", "lint"}},
+		{Name: "test", Args: []string{"make", "test"}},
+	}
+}
+
+// Run runs every command in dir and captures what each one did.
+//
+// Unlike proving a repair, this does not stop at the first failure:
+// the pull request gets one verdict per run, so a lint failure that
+// hid a failing test would send the author back for a second round
+// over a problem this run already knew about.
+func Run(dir string, commands []Command) []Outcome {
+	if len(commands) == 0 {
+		commands = DefaultCommands()
+	}
+	outcomes := make([]Outcome, 0, len(commands))
+	for _, c := range commands {
+		if len(c.Args) == 0 {
+			continue
+		}
+		cmd := exec.Command(c.Args[0], c.Args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		outcomes = append(outcomes, Outcome{
+			Name:    c.Name,
+			Command: strings.Join(c.Args, " "),
+			Output:  string(out),
+			Failed:  err != nil,
+		})
+	}
+	return outcomes
+}

--- a/internal/checksverdict/run_test.go
+++ b/internal/checksverdict/run_test.go
@@ -1,0 +1,94 @@
+package checksverdict
+
+import (
+	"strings"
+	"testing"
+)
+
+// Both commands run even when the first one fails. Stopping early
+// would hide a failing test behind a lint finding, and the author
+// would come back for a second round over a failure this run already
+// knew about.
+func TestRunKeepsGoingAfterAFailure(t *testing.T) {
+	outcomes := Run(t.TempDir(), []Command{
+		{Name: "lint", Args: []string{"sh", "-c", "echo lint spoke; exit 1"}},
+		{Name: "test", Args: []string{"sh", "-c", "echo test spoke; exit 1"}},
+	})
+
+	if len(outcomes) != 2 {
+		t.Fatalf("ran %d commands, want 2: %+v", len(outcomes), outcomes)
+	}
+	for _, o := range outcomes {
+		if !o.Failed {
+			t.Errorf("%s reported success for a command that exited 1", o.Name)
+		}
+		if !strings.Contains(o.Output, o.Name+" spoke") {
+			t.Errorf("%s did not capture its output: %q", o.Name, o.Output)
+		}
+	}
+}
+
+// Output arrives whole: stderr is where both `go test` and
+// golangci-lint say the things a repair session needs most.
+func TestRunCapturesBothStreamsAndTheExitStatus(t *testing.T) {
+	outcomes := Run(t.TempDir(), []Command{
+		{Name: "test", Args: []string{"sh", "-c", "echo to stdout; echo to stderr 1>&2; exit 2"}},
+		{Name: "lint", Args: []string{"sh", "-c", "exit 0"}},
+	})
+
+	if len(outcomes) != 2 {
+		t.Fatalf("ran %d commands, want 2: %+v", len(outcomes), outcomes)
+	}
+	failed := outcomes[0]
+	for _, want := range []string{"to stdout", "to stderr"} {
+		if !strings.Contains(failed.Output, want) {
+			t.Errorf("output is missing %q: %q", want, failed.Output)
+		}
+	}
+	if failed.Command != "sh -c echo to stdout; echo to stderr 1>&2; exit 2" {
+		t.Errorf("Command = %q, which is not what a reader would re-run", failed.Command)
+	}
+	if outcomes[1].Failed {
+		t.Error("a command that exited 0 was recorded as failed")
+	}
+}
+
+// A command that cannot start at all — no such binary — is a failure,
+// not a silent pass. This is the shape of a runner missing make or
+// golangci-lint, and it must turn the check red.
+func TestRunTreatsAnUnstartableCommandAsAFailure(t *testing.T) {
+	outcomes := Run(t.TempDir(), []Command{
+		{Name: "test", Args: []string{"definitely-not-a-real-binary-9f3a"}},
+	})
+
+	if len(outcomes) != 1 {
+		t.Fatalf("ran %d commands, want 1: %+v", len(outcomes), outcomes)
+	}
+	if !outcomes[0].Failed {
+		t.Fatal("a command that could not start was recorded as a success")
+	}
+	v := Convert(outcomes)
+	if v.Status != "fail" {
+		t.Errorf("status = %q, want fail", v.Status)
+	}
+	if len(v.Findings) == 0 {
+		t.Error("a command that could not start produced no findings to explain it")
+	}
+}
+
+// With no commands named, the check measures what the repository
+// measures.
+func TestRunFallsBackToTheDefaultCommands(t *testing.T) {
+	dir := t.TempDir()
+
+	outcomes := Run(dir, nil)
+
+	if len(outcomes) != len(DefaultCommands()) {
+		t.Fatalf("ran %d commands, want %d: %+v", len(outcomes), len(DefaultCommands()), outcomes)
+	}
+	for i, c := range DefaultCommands() {
+		if outcomes[i].Command != strings.Join(c.Args, " ") {
+			t.Errorf("command %d ran %q, want %q", i, outcomes[i].Command, strings.Join(c.Args, " "))
+		}
+	}
+}

--- a/internal/checksverdict/testdata/lint-fail.txt
+++ b/internal/checksverdict/testdata/lint-fail.txt
@@ -1,0 +1,15 @@
+internal/config/load.go:11:5: Error return value of `os.Create` is not checked (errcheck)
+	f, _ := os.Create(path)
+	   ^
+internal/config/load.go:12:15: Error return value of `f.WriteString` is not checked (errcheck)
+	f.WriteString(Name())
+	             ^
+internal/config/load.go:13:9: Error return value of `f.Close` is not checked (errcheck)
+	f.Close()
+	       ^
+internal/config/load.go:8:6: func unusedHelper is unused (unused)
+func unusedHelper() string { return "nobody calls me" }
+     ^
+4 issues:
+* errcheck: 3
+* unused: 1

--- a/internal/checksverdict/testdata/test-build-fail.txt
+++ b/internal/checksverdict/testdata/test-build-fail.txt
@@ -1,0 +1,8 @@
+=== RUN   TestLoadMergesRepoOverGlobal
+--- PASS: TestLoadMergesRepoOverGlobal (0.00s)
+PASS
+ok  	github.com/partio-io/cli/internal/config	(cached)
+# github.com/partio-io/cli/internal/attribution [github.com/partio-io/cli/internal/attribution.test]
+internal/attribution/lines.go:3:37: undefined: undefinedThing
+FAIL	github.com/partio-io/cli/internal/attribution [build failed]
+FAIL

--- a/internal/checksverdict/testdata/test-clean.txt
+++ b/internal/checksverdict/testdata/test-clean.txt
@@ -1,0 +1,10 @@
+=== RUN   TestLoadMergesRepoOverGlobal
+--- PASS: TestLoadMergesRepoOverGlobal (0.00s)
+PASS
+ok  	github.com/partio-io/cli/internal/config	(cached)
+=== RUN   TestCalculateSplitsAgentAndHumanLines
+--- PASS: TestCalculateSplitsAgentAndHumanLines (0.00s)
+=== RUN   TestCalculateHandlesEmptyDiff
+--- PASS: TestCalculateHandlesEmptyDiff (0.00s)
+PASS
+ok  	github.com/partio-io/cli/internal/attribution	0.001s

--- a/internal/checksverdict/testdata/test-fail-subtest.txt
+++ b/internal/checksverdict/testdata/test-fail-subtest.txt
@@ -1,0 +1,16 @@
+=== RUN   TestLoadMergesLayers
+=== RUN   TestLoadMergesLayers/repo_over_global
+=== RUN   TestLoadMergesLayers/local_over_repo
+    load_test.go:17: merged value = "global", want "local"
+=== RUN   TestLoadMergesLayers/env_over_local
+    load_test.go:17: merged value = "global", want "local"
+--- FAIL: TestLoadMergesLayers (0.00s)
+    --- PASS: TestLoadMergesLayers/repo_over_global (0.00s)
+    --- FAIL: TestLoadMergesLayers/local_over_repo (0.00s)
+    --- FAIL: TestLoadMergesLayers/env_over_local (0.00s)
+=== RUN   TestPanicsAreCaptured
+    load_test.go:24: this one is fine
+--- PASS: TestPanicsAreCaptured (0.00s)
+FAIL
+FAIL	github.com/partio-io/cli/internal/config	0.001s
+FAIL

--- a/internal/checksverdict/testdata/test-fail-subtests.txt
+++ b/internal/checksverdict/testdata/test-fail-subtests.txt
@@ -1,0 +1,24 @@
+=== RUN   TestToMetadataCarriesTheSessionID
+    checkpoint_test.go:9: metadata session id = "", want "s-42"
+--- FAIL: TestToMetadataCarriesTheSessionID (0.00s)
+=== RUN   TestNewID
+--- PASS: TestNewID (0.00s)
+=== RUN   TestShard
+--- PASS: TestShard (0.00s)
+=== RUN   TestToMetadata
+--- PASS: TestToMetadata (0.00s)
+=== RUN   TestFindByBranch
+=== RUN   TestFindByBranch/single_match
+=== RUN   TestFindByBranch/multiple_matches
+=== RUN   TestFindByBranch/no_match
+=== RUN   TestFindByBranch/partial_branch_name_does_not_match
+--- PASS: TestFindByBranch (0.11s)
+    --- PASS: TestFindByBranch/single_match (0.03s)
+    --- PASS: TestFindByBranch/multiple_matches (0.04s)
+    --- PASS: TestFindByBranch/no_match (0.02s)
+    --- PASS: TestFindByBranch/partial_branch_name_does_not_match (0.02s)
+=== RUN   TestFindByBranchNoBranch
+--- PASS: TestFindByBranchNoBranch (0.00s)
+FAIL
+FAIL	github.com/partio-io/cli/internal/checkpoint	0.115s
+FAIL

--- a/internal/checksverdict/testdata/test-fail.txt
+++ b/internal/checksverdict/testdata/test-fail.txt
@@ -1,0 +1,12 @@
+=== RUN   TestLoadMergesRepoOverGlobal
+--- PASS: TestLoadMergesRepoOverGlobal (0.00s)
+PASS
+ok  	github.com/partio-io/cli/internal/config	0.001s
+=== RUN   TestCalculateSplitsAgentAndHumanLines
+    lines_test.go:7: Calculate(diff) agent lines = 4, want 5
+--- FAIL: TestCalculateSplitsAgentAndHumanLines (0.00s)
+=== RUN   TestCalculateHandlesEmptyDiff
+--- PASS: TestCalculateHandlesEmptyDiff (0.00s)
+FAIL
+FAIL	github.com/partio-io/cli/internal/attribution	0.001s
+FAIL

--- a/internal/checksverdict/testdata/unparseable.txt
+++ b/internal/checksverdict/testdata/unparseable.txt
@@ -1,0 +1,1 @@
+make: *** No rule to make target 'test'.  Stop.

--- a/internal/checksverdict/workflow_test.go
+++ b/internal/checksverdict/workflow_test.go
@@ -1,0 +1,168 @@
+package checksverdict
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/partio-io/cli/internal/repairround"
+)
+
+// workflowPath is the checks workflow, read from the repository rather
+// than from a copy: the guarantees below are about what CI actually
+// runs, and a copy would drift away from that silently.
+const workflowPath = "../../.github/workflows/checks.yml"
+
+func workflow(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(workflowPath))
+	if err != nil {
+		t.Fatalf("read checks workflow: %v", err)
+	}
+	return string(data)
+}
+
+// The check has to cover every pull request, including hand-written
+// ones. The audits guard on the "minion" label; this one must not, or
+// a broken build merges whenever a human opens the pull request.
+func TestChecksRunOnEveryPullRequest(t *testing.T) {
+	wf := workflow(t)
+
+	if !strings.Contains(wf, "pull_request:") {
+		t.Error("the workflow does not trigger on pull requests")
+	}
+	for _, event := range []string{"opened", "synchronize", "reopened"} {
+		if !strings.Contains(wf, event) {
+			t.Errorf("the workflow does not trigger on %q, so it would miss those pull requests", event)
+		}
+	}
+	if strings.Contains(wf, "github.event.pull_request.labels") {
+		t.Error("the workflow guards on a label, so unlabelled pull requests would go unchecked")
+	}
+}
+
+// Nothing in this workflow moves a branch by hand. Repair pushes only
+// through the shared applier, which fetches the true head, proves the
+// tree, and pushes with the token that starts the follow-up run. Inline
+// git writes would be a second implementation of that sequence, and the
+// checkouts keep no credentials so a stray step cannot push at all.
+func TestChecksPushOnlyThroughTheSharedApplier(t *testing.T) {
+	wf := workflow(t)
+
+	for _, forbidden := range []string{"git push", "git commit"} {
+		if strings.Contains(wf, forbidden) {
+			t.Errorf("the checks workflow runs %q inline; the shared applier owns apply-prove-push", forbidden)
+		}
+	}
+	if !strings.Contains(wf, "persist-credentials: false") {
+		t.Error("a checkout persists credentials, so a later step could push without meaning to")
+	}
+}
+
+// The tracer: the whole repair chain, end to end, in the order it has
+// to happen. The guard decides whether this pull request may be
+// repaired at all and which round it is, the verdict decides whether
+// there is anything to repair, the fix session produces a patch, the
+// shared applier proves and pushes it, and the gate reports the round.
+// A link missing here is a repair loop that stops halfway and says
+// nothing.
+func TestChecksRepairChain(t *testing.T) {
+	wf := workflow(t)
+
+	links := []struct {
+		fragment string
+		why      string
+	}{
+		{"minion-repair-round", "nothing counts the repair rounds, so the loop has no cap"},
+		{"--check checks", "rounds are not counted under this check's own name"},
+		{"--repairable", "nothing decides whether this pull request may be repaired at all"},
+		{"needs.guard.outputs.repairable == 'true'", "the repair job is not gated on that decision"},
+		{"needs.guard.outputs.skip != 'true'", "the repair job ignores a spent repair budget"},
+		{"minions run .minions/programs/checks-fix.md", "no fix session runs, so nothing produces a patch"},
+		{"minion-apply-fix", "no patch is applied, proven, or pushed"},
+		{"--round", "the gate cannot tell a spent budget from a first-pass failure"},
+	}
+	for _, link := range links {
+		if !strings.Contains(wf, link.fragment) {
+			t.Errorf("the workflow is missing %q: %s", link.fragment, link.why)
+		}
+	}
+}
+
+// Each check gets its own three rounds. A dead-code repair must not
+// spend the budget a failing test needs, and the counting is by name,
+// so the two workflows have to count under different ones.
+func TestChecksKeepsItsOwnRepairBudget(t *testing.T) {
+	wf := workflow(t)
+
+	audit, err := os.ReadFile(filepath.Clean("../../.github/workflows/deadcode-audit.yml"))
+	if err != nil {
+		t.Fatalf("read the dead-code workflow: %v", err)
+	}
+
+	if strings.Contains(wf, "--check dead-code") {
+		t.Error("the checks workflow counts rounds under the dead-code name, so the two budgets interfere")
+	}
+	if !strings.Contains(string(audit), "--check dead-code") {
+		t.Error("the dead-code workflow no longer counts under its own name")
+	}
+	// The cap comes from the shared default. A workflow that passes
+	// --max sets a second cap the gate does not know about, and the two
+	// sides of one round would disagree about when the budget is spent.
+	if strings.Contains(wf, "--max") {
+		t.Error("the checks workflow overrides the round cap; the gate still assumes the default")
+	}
+	if repairround.DefaultMaxRounds != 3 {
+		t.Errorf("the shared cap is %d rounds, and this check is specified at three",
+			repairround.DefaultMaxRounds)
+	}
+}
+
+// The give-up comment needs the number of rounds that have already run.
+// This gate reports before its own run's repair, so that number is the
+// count on the branch — prior, never the round about to start. Reading
+// the wrong one would announce a spent budget a round early.
+func TestChecksGivesTheGateTheRoundsAlreadyRun(t *testing.T) {
+	wf := workflow(t)
+
+	if !strings.Contains(wf, "needs.guard.outputs.prior") {
+		t.Error("the gate is not given the rounds already on the branch, so it cannot say the pipeline gave up")
+	}
+	if strings.Contains(wf, `--round "${ROUND`) {
+		t.Error("the gate is given the round about to start; it would report a spent budget a round early")
+	}
+}
+
+// The outcome belongs to the gate, not to the step that runs the
+// commands: a converter that crashes must still leave the gate to fail
+// the check closed and say so on the pull request.
+func TestTheGateOwnsTheOutcome(t *testing.T) {
+	wf := workflow(t)
+
+	if !strings.Contains(wf, "minion-checks-verdict") {
+		t.Error("the workflow never writes a verdict")
+	}
+	if !strings.Contains(wf, "minion-audit-gate") || !strings.Contains(wf, "--audit checks") {
+		t.Error("the workflow does not report through the existing verdict gate")
+	}
+	if !strings.Contains(wf, "if: always()") {
+		t.Error("the gate step is skippable, so a crashed converter would report nothing at all")
+	}
+}
+
+// The commands are the repository's own targets. If these drift, the
+// check stops measuring what the developers measure.
+func TestDefaultCommandsAreTheRepositoryTargets(t *testing.T) {
+	cmds := DefaultCommands()
+
+	if len(cmds) != 2 {
+		t.Fatalf("got %d default commands, want lint and test: %+v", len(cmds), cmds)
+	}
+	want := map[string]string{"lint": "make lint", "test": "make test"}
+	for _, c := range cmds {
+		if got := strings.Join(c.Args, " "); got != want[c.Name] {
+			t.Errorf("command %q runs %q, want %q", c.Name, got, want[c.Name])
+		}
+	}
+}

--- a/internal/checksverdict/write.go
+++ b/internal/checksverdict/write.go
@@ -1,0 +1,28 @@
+package checksverdict
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/partio-io/cli/internal/auditgate"
+)
+
+// Write saves the verdict where the gate expects to find it, creating
+// the directory if the check runs before anything else has.
+func Write(path string, v auditgate.Verdict) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("create verdict directory: %w", err)
+		}
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode verdict: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write verdict: %w", err)
+	}
+	return nil
+}

--- a/internal/patchapply/git.go
+++ b/internal/patchapply/git.go
@@ -1,0 +1,98 @@
+package patchapply
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// git runs git in dir and returns its combined output either way, so a
+// caller can report what git said without running the command again.
+//
+// The error names no argument. A fetch and a push carry the token in
+// their argument list, and an error travels further than the output
+// does.
+func git(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(out))
+	if err != nil {
+		return text, fmt.Errorf("git: %w", err)
+	}
+	return text, nil
+}
+
+// worktree is a detached checkout of the pull request head.
+type worktree struct {
+	dir     string
+	repoDir string
+}
+
+// detach fetches ref from remote and checks it out, detached, in its
+// own worktree.
+//
+// The fetch is what makes the round operate on the pull request's real
+// head. The job's own checkout is a merge commit or a stale tip, and a
+// patch applied there pushes work the author never wrote.
+func detach(repoDir, dir, remote, ref string) (*worktree, error) {
+	if out, err := git(repoDir, "fetch", "--no-tags", remote, ref); err != nil {
+		return nil, fmt.Errorf("fetch %s: %w: %s", ref, err, tail(out))
+	}
+
+	if dir == "" {
+		parent, err := os.MkdirTemp("", "patchapply-")
+		if err != nil {
+			return nil, fmt.Errorf("create worktree directory: %w", err)
+		}
+		dir = filepath.Join(parent, "head")
+	}
+
+	// A worktree left behind by an earlier round blocks the add.
+	w := &worktree{dir: dir, repoDir: repoDir}
+	w.remove()
+
+	if out, err := git(repoDir, "worktree", "add", "--detach", dir, "FETCH_HEAD"); err != nil {
+		return nil, fmt.Errorf("detach %s: %w: %s", ref, err, tail(out))
+	}
+	return w, nil
+}
+
+// remove unregisters the worktree and deletes its directory.
+//
+// It is best effort by design. It runs before the add and again on the
+// way out of every path, and the wanted state is "this directory is
+// not a worktree" — which a failure to remove one that was never there
+// already satisfies.
+func (w *worktree) remove() {
+	if _, err := git(w.repoDir, "worktree", "remove", "--force", w.dir); err != nil {
+		slog.Debug("removing repair worktree", "dir", w.dir, "error", err)
+	}
+	if err := os.RemoveAll(w.dir); err != nil {
+		slog.Debug("deleting repair worktree directory", "dir", w.dir, "error", err)
+	}
+}
+
+// commit records the applied patch under the marker that names the
+// check.
+//
+// The identity is explicit because a CI worktree inherits none, and
+// signing is off because the runner holds no key.
+func commit(dir, subject, body string) error {
+	args := []string{
+		"-c", "user.name=minion audit",
+		"-c", "user.email=minions@partio.io",
+		"-c", "commit.gpgsign=false",
+		"commit", "-m", subject,
+	}
+	if body != "" {
+		args = append(args, "-m", body)
+	}
+	if out, err := git(dir, args...); err != nil {
+		return fmt.Errorf("commit the repair: %w: %s", err, tail(out))
+	}
+	return nil
+}

--- a/internal/patchapply/head.go
+++ b/internal/patchapply/head.go
@@ -1,0 +1,84 @@
+package patchapply
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// prHead is the branch a repair round pushes to, and the repository
+// that branch lives in.
+type prHead struct {
+	repo string // owner/name
+	ref  string // branch name
+}
+
+// resolveHead reports the pull request's head.
+//
+// A caller that already knows the head says so and no request is made.
+// That is how the tests stay off the network, and how a workflow that
+// has already read the head avoids asking for it twice.
+func resolveHead(cfg Config) (prHead, error) {
+	if cfg.HeadRepo != "" && cfg.HeadRef != "" {
+		return prHead{repo: cfg.HeadRepo, ref: cfg.HeadRef}, nil
+	}
+	if cfg.APIBaseURL == "" {
+		return prHead{}, errors.New("the pull request head is unknown and no GitHub API root is set")
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/pulls/%d", cfg.APIBaseURL, cfg.Repo, cfg.PRNumber)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return prHead{}, fmt.Errorf("read pull request head: %w", err)
+	}
+
+	var pr struct {
+		Head struct {
+			Ref  string `json:"ref"`
+			Repo struct {
+				FullName string `json:"full_name"`
+			} `json:"repo"`
+		} `json:"head"`
+	}
+	if err := doGitHub(cfg, req, &pr); err != nil {
+		return prHead{}, fmt.Errorf("read pull request head: %w", err)
+	}
+	if pr.Head.Ref == "" || pr.Head.Repo.FullName == "" {
+		return prHead{}, fmt.Errorf(
+			"read pull request head: GitHub named no branch or no repository for pull request %d", cfg.PRNumber)
+	}
+	return prHead{repo: pr.Head.Repo.FullName, ref: pr.Head.Ref}, nil
+}
+
+// doGitHub executes one GitHub API request and decodes the response
+// into out.
+func doGitHub(cfg Config, req *http.Request, out any) error {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			slog.Debug("closing response body", "url", req.URL.Path, "error", closeErr)
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		detail, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if readErr != nil {
+			detail = fmt.Appendf(nil, "(error body unreadable: %v)", readErr)
+		}
+		return fmt.Errorf("github: %s %s: %s: %s", req.Method, req.URL.Path, resp.Status, detail)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/patchapply/prove.go
+++ b/internal/patchapply/prove.go
@@ -1,0 +1,38 @@
+package patchapply
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// defaultProve is how a repair is proved when a caller names no
+// commands: the repository's own targets, in the order CI runs them.
+// Lint comes first because it is the cheaper of the two.
+func defaultProve() [][]string {
+	return [][]string{
+		{"make", "lint"},
+		{"make", "test"},
+	}
+}
+
+// prove runs each command in dir and stops at the first failure. It
+// returns that command's output, so the caller can say why the patch
+// was dropped rather than only that it was.
+func prove(dir string, commands [][]string) (string, error) {
+	if len(commands) == 0 {
+		commands = defaultProve()
+	}
+	for _, args := range commands {
+		if len(args) == 0 {
+			continue
+		}
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return strings.TrimSpace(string(out)), fmt.Errorf("%s: %w", strings.Join(args, " "), err)
+		}
+	}
+	return "", nil
+}

--- a/internal/patchapply/remote.go
+++ b/internal/patchapply/remote.go
@@ -1,0 +1,34 @@
+package patchapply
+
+import (
+	"fmt"
+	"strings"
+)
+
+// pushRemote is the target the round fetches from and pushes to. An
+// explicit remote wins, which is what lets a test drive the whole
+// round against a bare repository on disk.
+func pushRemote(cfg Config) string {
+	if cfg.Remote != "" {
+		return cfg.Remote
+	}
+	return remoteURL(cfg.Repo, cfg.Token)
+}
+
+// remoteURL is the HTTPS URL for repo, carrying token.
+//
+// The token must be the personal access token. A push made with the
+// default Actions token triggers no follow-up workflow run, and the
+// next repair round is a follow-up run: the fix would land, the loop
+// would stop, and nothing would say so.
+func remoteURL(repo, token string) string {
+	return fmt.Sprintf("https://x-access-token:%s@github.com/%s.git", token, repo)
+}
+
+// redact removes the token from text that reaches a job log.
+func redact(text, token string) string {
+	if token == "" {
+		return text
+	}
+	return strings.ReplaceAll(text, token, "***")
+}

--- a/internal/patchapply/remote_test.go
+++ b/internal/patchapply/remote_test.go
@@ -1,0 +1,50 @@
+package patchapply
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPushRemoteUsesThePersonalAccessToken pins which credential the
+// round pushes with.
+//
+// A push made with the default Actions token triggers no follow-up
+// workflow run, and the next repair round is a follow-up run. The fix
+// would land, the loop would stop, and nothing would say so.
+func TestPushRemoteUsesThePersonalAccessToken(t *testing.T) {
+	cfg := Config{Repo: "partio-io/cli", Token: "ghp_example"}
+
+	want := "https://x-access-token:ghp_example@github.com/partio-io/cli.git"
+	if got := pushRemote(cfg); got != want {
+		t.Errorf("pushRemote = %q, want %q", got, want)
+	}
+
+	cfg.Remote = "/srv/origin.git"
+	if got := pushRemote(cfg); got != cfg.Remote {
+		t.Errorf("pushRemote = %q, want the configured remote %q", got, cfg.Remote)
+	}
+}
+
+// TestRunKeepsTheTokenOutOfWhatItReports drives a real failure whose
+// output echoes the remote, because that is how a token reaches a job
+// log: git prints the URL it could not read from.
+func TestRunKeepsTheTokenOutOfWhatItReports(t *testing.T) {
+	f := newFixture(t, false)
+	patch := f.makePatch(t, "notes.txt", "one\ntwo\n")
+
+	cfg := f.config(patch)
+	cfg.Token = "ghp_example"
+	cfg.Remote = filepath.Join(t.TempDir(), "ghp_example-missing.git")
+
+	res, err := Run(cfg)
+	if err == nil {
+		t.Fatalf("Run succeeded against a remote that does not exist: %+v", res)
+	}
+	if strings.Contains(err.Error(), "ghp_example") {
+		t.Errorf("the error carries the token: %v", err)
+	}
+	if !strings.Contains(err.Error(), "***") {
+		t.Errorf("error = %v, want the token replaced", err)
+	}
+}

--- a/internal/patchapply/run.go
+++ b/internal/patchapply/run.go
@@ -1,0 +1,169 @@
+// Package patchapply turns a repair session's patch into one pushed
+// commit, or into a stated reason why nothing was pushed.
+//
+// A repair session never commits and never pushes: it writes a patch
+// and stops. Everything after that is deterministic, and it lives here
+// so that every gate shares one implementation. Run fetches the pull
+// request's real head, detaches a worktree onto it, applies the patch,
+// proves the result with the repository's own lint and test targets,
+// commits it with the marker internal/repairround counts, and pushes
+// it with the personal access token.
+//
+// A patch that does not apply, or that leaves the checks red, is a
+// spent round and not a job error. Run reports it and pushes nothing.
+package patchapply
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/partio-io/cli/internal/repairround"
+)
+
+// Config carries everything one apply-prove-push run needs.
+type Config struct {
+	RepoDir     string // repository the worktree is added from; "" means the current directory
+	WorktreeDir string // where the head is detached; "" means a new temporary directory
+	PatchPath   string // patch the repair session exported
+	Body        string // commit body, usually the session's fix summary
+
+	Repo     string // owner/name the workflow runs in
+	PRNumber int    // pull request the patch repairs
+	Check    string // check that produced the patch, e.g. "dead-code"
+
+	HeadRepo string // owner/name of the pull request head; empty means ask the API
+	HeadRef  string // head branch name; empty means ask the API
+
+	Token  string // personal access token; the push must use it
+	Remote string // fetch and push target; "" means the GitHub URL for Repo
+
+	Prove [][]string // commands that prove the applied patch; nil means make lint and make test
+
+	APIBaseURL string       // GitHub API root, e.g. https://api.github.com
+	HTTPClient *http.Client // nil means http.DefaultClient
+}
+
+// Result is what the round did. A false Pushed is an outcome and not a
+// failure: Reason says why nothing was pushed.
+type Result struct {
+	Pushed bool
+	Reason string
+}
+
+// Run applies the patch to the pull request's real head, proves it,
+// and pushes one marked commit.
+func Run(cfg Config) (Result, error) {
+	res, err := run(cfg)
+
+	// One choke point for the token: git echoes the remote URL when a
+	// fetch or a push fails, and both the reason and the error reach
+	// a job log.
+	res.Reason = redact(res.Reason, cfg.Token)
+	if err != nil {
+		err = errors.New(redact(err.Error(), cfg.Token))
+	}
+	return res, err
+}
+
+func run(cfg Config) (Result, error) {
+	if cfg.Repo == "" || cfg.Check == "" || cfg.PRNumber == 0 {
+		return Result{}, errors.New("repository, check name and pull request number are required")
+	}
+
+	head, err := resolveHead(cfg)
+	if err != nil {
+		return Result{}, err
+	}
+
+	// The fork is refused before the fetch. The workflow holds no
+	// write access to a fork, so a round started there can only fail
+	// after doing all of the work.
+	if head.repo != cfg.Repo {
+		return Result{Reason: fmt.Sprintf(
+			"the pull request head lives in %s and not in %s; a repair round cannot push to a fork",
+			head.repo, cfg.Repo)}, nil
+	}
+
+	patch, err := patchFile(cfg.PatchPath)
+	if err != nil {
+		return Result{}, err
+	}
+	if patch == "" {
+		return Result{Reason: "the repair session exported no patch"}, nil
+	}
+
+	remote := pushRemote(cfg)
+
+	wt, err := detach(cfg.RepoDir, cfg.WorktreeDir, remote, head.ref)
+	if err != nil {
+		return Result{}, err
+	}
+	defer wt.remove()
+
+	if out, err := git(wt.dir, "apply", "--index", patch); err != nil {
+		return Result{Reason: "the patch did not apply to the pull request head: " + tail(out)}, nil
+	}
+
+	if out, err := prove(wt.dir, cfg.Prove); err != nil {
+		return Result{Reason: fmt.Sprintf("the applied patch left the checks red (%v): %s", err, tail(out))}, nil
+	}
+
+	subject := repairround.Subject(cfg.Check, cfg.PRNumber)
+	if err := commit(wt.dir, subject, cfg.Body); err != nil {
+		return Result{}, err
+	}
+
+	if out, err := git(wt.dir, "push", remote, "HEAD:"+head.ref); err != nil {
+		return Result{}, fmt.Errorf("push to %s: %w: %s", head.ref, err, tail(out))
+	}
+
+	return Result{
+		Pushed: true,
+		Reason: fmt.Sprintf("pushed one %s repair commit to %s", cfg.Check, head.ref),
+	}, nil
+}
+
+// patchFile returns the absolute path of a patch that has content, or
+// "" when the repair session exported nothing.
+//
+// The path must be absolute. Git runs with the worktree as its working
+// directory, and would resolve a relative path against that instead of
+// against the job's workspace.
+func patchFile(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve patch path: %w", err)
+	}
+	info, err := os.Stat(abs)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read patch: %w", err)
+	}
+	if info.Size() == 0 {
+		return "", nil
+	}
+	return abs, nil
+}
+
+// maxReportLines bounds what a reason carries out of a failed round. A
+// full `make test` log buries the reason it is attached to.
+const maxReportLines = 20
+
+// tail returns the last lines of out, which is where a failing tool
+// says what went wrong.
+func tail(out string) string {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) <= maxReportLines {
+		return strings.Join(lines, "\n")
+	}
+	return "...\n" + strings.Join(lines[len(lines)-maxReportLines:], "\n")
+}

--- a/internal/patchapply/run_test.go
+++ b/internal/patchapply/run_test.go
@@ -1,0 +1,331 @@
+package patchapply
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/partio-io/cli/internal/repairround"
+)
+
+// headRef is the pull request head branch every fixture pushes to.
+const headRef = "feature"
+
+// gitRun runs git in dir and returns its trimmed output. It fails the
+// test on a non-zero exit, because every call here is fixture setup or
+// an assertion, and neither has a meaningful failure mode.
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitOutput is gitRun for output that must stay byte-exact. A patch
+// loses its trailing newline under TrimSpace, and git then rejects it.
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v", args, dir, err)
+	}
+	return string(out)
+}
+
+// gitEnv pins the identity and drops the developer's own git config,
+// so a global setting cannot change what these tests observe.
+func gitEnv() []string {
+	return append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// makefile returns a Makefile with the two targets the default prove
+// step runs. It is real, so the tests exercise the real default rather
+// than a stubbed one.
+func makefile(lintFails bool) string {
+	lint := "\t@true\n"
+	if lintFails {
+		lint = "\t@echo 'lint found problems' >&2; exit 1\n"
+	}
+	return ".PHONY: lint test\n\nlint:\n" + lint + "\ntest:\n\t@true\n"
+}
+
+// fixture is a self-contained stand-in for the pull request the gate
+// repairs. Nothing in it touches the network.
+type fixture struct {
+	// origin is a bare repository standing in for GitHub.
+	origin string
+	// seed is the clone that authors the branch and the patch.
+	seed string
+	// runner is the checkout the package operates from. It is left
+	// deliberately behind origin, so a run that reads the checkout
+	// instead of fetching the real head is visible in the result.
+	runner string
+}
+
+func newFixture(t *testing.T, lintFails bool) *fixture {
+	t.Helper()
+	root := t.TempDir()
+	f := &fixture{
+		origin: filepath.Join(root, "origin.git"),
+		seed:   filepath.Join(root, "seed"),
+		runner: filepath.Join(root, "runner"),
+	}
+
+	gitRun(t, root, "init", "--bare", f.origin)
+	gitRun(t, root, "init", f.seed)
+	writeFile(t, filepath.Join(f.seed, "Makefile"), makefile(lintFails))
+	writeFile(t, filepath.Join(f.seed, "notes.txt"), "one\n")
+	gitRun(t, f.seed, "add", "-A")
+	gitRun(t, f.seed, "commit", "-m", "initial")
+	gitRun(t, f.seed, "branch", "-M", headRef)
+	gitRun(t, f.seed, "push", f.origin, headRef)
+	gitRun(t, root, "clone", "--branch", headRef, f.origin, f.runner)
+
+	return f
+}
+
+// advanceHead pushes a further commit to the branch, so the pull
+// request head is ahead of the runner checkout.
+func (f *fixture) advanceHead(t *testing.T, content string) {
+	t.Helper()
+	writeFile(t, filepath.Join(f.seed, "notes.txt"), content)
+	gitRun(t, f.seed, "add", "-A")
+	gitRun(t, f.seed, "commit", "-m", "real head")
+	gitRun(t, f.seed, "push", f.origin, headRef)
+}
+
+// makePatch exports the same patch a repair session exports, then
+// restores the seed clone.
+func (f *fixture) makePatch(t *testing.T, name, content string) string {
+	t.Helper()
+	writeFile(t, filepath.Join(f.seed, name), content)
+	gitRun(t, f.seed, "add", "-A")
+	patch := gitOutput(t, f.seed, "diff", "--cached", "--binary")
+	gitRun(t, f.seed, "reset", "--hard", "HEAD")
+
+	path := filepath.Join(t.TempDir(), "fix.patch")
+	writeFile(t, path, patch)
+	return path
+}
+
+func (f *fixture) headSHA(t *testing.T) string {
+	t.Helper()
+	return gitRun(t, f.origin, "rev-parse", headRef)
+}
+
+func (f *fixture) headSubject(t *testing.T) string {
+	t.Helper()
+	return gitRun(t, f.origin, "log", "-1", "--format=%s", headRef)
+}
+
+func (f *fixture) fileAtHead(t *testing.T, name string) string {
+	t.Helper()
+	return gitRun(t, f.origin, "show", headRef+":"+name)
+}
+
+// config returns the configuration every test starts from: a local
+// remote, an explicit head, and the dead-code check.
+func (f *fixture) config(patch string) Config {
+	return Config{
+		RepoDir:   f.runner,
+		PatchPath: patch,
+		Body:      "removed the unused helper",
+		Repo:      "partio-io/cli",
+		HeadRepo:  "partio-io/cli",
+		HeadRef:   headRef,
+		PRNumber:  622,
+		Check:     "dead-code",
+		Remote:    f.origin,
+	}
+}
+
+// TestRunAppliesProvesAndPushes is the end-to-end path: the package
+// fetches the real head, applies the patch, proves it with the
+// repository's own targets, and pushes one marked commit.
+func TestRunAppliesProvesAndPushes(t *testing.T) {
+	f := newFixture(t, false)
+	f.advanceHead(t, "one\ntwo\n")
+	patch := f.makePatch(t, "notes.txt", "one\ntwo\nthree\n")
+	realHead := f.headSHA(t)
+
+	res, err := Run(f.config(patch))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.Pushed {
+		t.Fatalf("nothing pushed: %s", res.Reason)
+	}
+
+	if got, want := f.headSubject(t), "audit(dead-code): fix findings (#622)"; got != want {
+		t.Errorf("commit subject = %q, want %q", got, want)
+	}
+
+	// The subject is only useful if the package that counts rounds
+	// reads the check back out of it. Asserting the literal alone
+	// would survive a marker change that stops the counting.
+	if check, ok := repairround.CheckOf(f.headSubject(t)); !ok || check != "dead-code" {
+		t.Errorf("repairround.CheckOf(%q) = %q, %t; want \"dead-code\", true",
+			f.headSubject(t), check, ok)
+	}
+	if got, want := f.fileAtHead(t, "notes.txt"), "one\ntwo\nthree"; got != want {
+		t.Errorf("notes.txt at head = %q, want %q", got, want)
+	}
+	if got := gitRun(t, f.origin, "rev-parse", headRef+"^"); got != realHead {
+		t.Errorf("parent = %s, want the real head %s", got, realHead)
+	}
+}
+
+// TestRunReportsAPatchThatDoesNotApply covers the round that races the
+// author: the patch was built against a tree the head no longer has.
+// Nothing is pushed, and the round says so instead of failing the job.
+func TestRunReportsAPatchThatDoesNotApply(t *testing.T) {
+	f := newFixture(t, false)
+	patch := f.makePatch(t, "notes.txt", "one\ntwo\n")
+	f.advanceHead(t, "something else entirely\n")
+	before := f.headSHA(t)
+
+	res, err := Run(f.config(patch))
+	if err != nil {
+		t.Fatalf("Run failed the job, want a reported round: %v", err)
+	}
+	if res.Pushed {
+		t.Fatal("pushed a patch that does not apply")
+	}
+	if !strings.Contains(res.Reason, "did not apply") {
+		t.Errorf("reason = %q, want it to say the patch did not apply", res.Reason)
+	}
+	if got := f.headSHA(t); got != before {
+		t.Errorf("head moved to %s, want it left at %s", got, before)
+	}
+}
+
+// TestRunPushesNothingWhenTheChecksFail covers the repair that applies
+// cleanly and is still wrong. The default prove step is the
+// repository's own `make lint`, and this fixture's lint target fails.
+func TestRunPushesNothingWhenTheChecksFail(t *testing.T) {
+	f := newFixture(t, true)
+	f.advanceHead(t, "one\ntwo\n")
+	patch := f.makePatch(t, "notes.txt", "one\ntwo\nthree\n")
+	before := f.headSHA(t)
+
+	res, err := Run(f.config(patch))
+	if err != nil {
+		t.Fatalf("Run failed the job, want a reported round: %v", err)
+	}
+	if res.Pushed {
+		t.Fatal("pushed a patch that leaves the checks red")
+	}
+	if !strings.Contains(res.Reason, "checks red") || !strings.Contains(res.Reason, "make lint") {
+		t.Errorf("reason = %q, want it to name the red check", res.Reason)
+	}
+	if got := f.headSHA(t); got != before {
+		t.Errorf("head moved to %s, want it left at %s", got, before)
+	}
+}
+
+// TestRunRefusesAForkHeadBeforeFetching proves the order, not only the
+// refusal: the remote is a path that does not exist, so a run that
+// fetched first would fail instead of reporting the fork.
+func TestRunRefusesAForkHeadBeforeFetching(t *testing.T) {
+	f := newFixture(t, false)
+	patch := f.makePatch(t, "notes.txt", "one\ntwo\n")
+
+	cfg := f.config(patch)
+	cfg.HeadRepo = "someone-else/cli"
+	cfg.Remote = filepath.Join(t.TempDir(), "no-such-remote.git")
+
+	res, err := Run(cfg)
+	if err != nil {
+		t.Fatalf("Run failed the job, want a reported round: %v", err)
+	}
+	if res.Pushed {
+		t.Fatal("pushed to a fork head")
+	}
+	if !strings.Contains(res.Reason, "fork") || !strings.Contains(res.Reason, "someone-else/cli") {
+		t.Errorf("reason = %q, want it to name the fork", res.Reason)
+	}
+	if _, err := os.Stat(filepath.Join(f.runner, ".git", "FETCH_HEAD")); !errors.Is(err, os.ErrNotExist) {
+		t.Error("the run fetched before it refused the fork head")
+	}
+}
+
+// TestRunReadsTheHeadFromTheAPI covers the production path, where the
+// workflow supplies a pull request number and nothing else. The head
+// branch and the head repository come from GitHub, and the fork
+// refusal is made on what GitHub reports.
+func TestRunReadsTheHeadFromTheAPI(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullName string
+		wantPush bool
+		wantIn   string
+	}{
+		{name: "same repository", fullName: "partio-io/cli", wantPush: true},
+		{name: "fork", fullName: "someone-else/cli", wantIn: "fork"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFixture(t, false)
+			f.advanceHead(t, "one\ntwo\n")
+			patch := f.makePatch(t, "notes.txt", "one\ntwo\nthree\n")
+
+			// Only the one path answers. A run that asks for
+			// anything else gets a 404 and fails the test.
+			mux := http.NewServeMux()
+			mux.HandleFunc("/repos/partio-io/cli/pulls/622", func(w http.ResponseWriter, _ *http.Request) {
+				body := fmt.Sprintf(`{"head":{"ref":%q,"repo":{"full_name":%q}}}`, headRef, tt.fullName)
+				if _, err := w.Write([]byte(body)); err != nil {
+					t.Errorf("write pull request response: %v", err)
+				}
+			})
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			cfg := f.config(patch)
+			cfg.HeadRepo = ""
+			cfg.HeadRef = ""
+			cfg.APIBaseURL = srv.URL
+			cfg.HTTPClient = srv.Client()
+
+			res, err := Run(cfg)
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if res.Pushed != tt.wantPush {
+				t.Fatalf("pushed = %t, want %t (%s)", res.Pushed, tt.wantPush, res.Reason)
+			}
+			if tt.wantIn != "" && !strings.Contains(res.Reason, tt.wantIn) {
+				t.Errorf("reason = %q, want it to mention %q", res.Reason, tt.wantIn)
+			}
+		})
+	}
+}

--- a/internal/repairround/commits.go
+++ b/internal/repairround/commits.go
@@ -1,0 +1,118 @@
+package repairround
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// perPage is GitHub's maximum page size for the pull-request commits
+// endpoint.
+const perPage = 100
+
+// maxPages bounds the walk. The endpoint serves at most 250 commits,
+// so three pages cover every branch it can describe. Undercounting
+// would hand out rounds the cap already spent, so the bound is
+// deliberately above what the API can return rather than at it.
+const maxPages = 3
+
+// prSubjects returns the subject line of every commit on the pull
+// request's branch.
+func prSubjects(cfg Config) ([]string, error) {
+	var subjects []string
+	for page := 1; page <= maxPages; page++ {
+		url := fmt.Sprintf("%s/repos/%s/pulls/%d/commits?per_page=%d&page=%d",
+			cfg.APIBaseURL, cfg.Repo, cfg.PRNumber, perPage, page)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("list pull request commits: %w", err)
+		}
+		var commits []struct {
+			Commit struct {
+				Message string `json:"message"`
+			} `json:"commit"`
+		}
+		if err := doGitHub(cfg, req, &commits); err != nil {
+			return nil, fmt.Errorf("list pull request commits: %w", err)
+		}
+		for _, c := range commits {
+			subjects = append(subjects, subjectOf(c.Commit.Message))
+		}
+		if len(commits) < perPage {
+			break
+		}
+	}
+	return subjects, nil
+}
+
+// prMeta returns the pull request's label names and the repository its
+// head branch lives in.
+//
+// The head repository is empty when GitHub reports none, which is what
+// a deleted fork looks like. That is an unknown head, not a local one,
+// and Eligible refuses it.
+func prMeta(cfg Config) (labels []string, headRepo string, err error) {
+	url := fmt.Sprintf("%s/repos/%s/pulls/%d", cfg.APIBaseURL, cfg.Repo, cfg.PRNumber)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("read pull request: %w", err)
+	}
+	var pr struct {
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		Head struct {
+			Repo struct {
+				FullName string `json:"full_name"`
+			} `json:"repo"`
+		} `json:"head"`
+	}
+	if err := doGitHub(cfg, req, &pr); err != nil {
+		return nil, "", fmt.Errorf("read pull request: %w", err)
+	}
+	for _, l := range pr.Labels {
+		labels = append(labels, l.Name)
+	}
+	return labels, pr.Head.Repo.FullName, nil
+}
+
+// subjectOf returns a commit message's first line. A body that quotes
+// a marker must not read as one, so only the subject is kept.
+func subjectOf(message string) string {
+	subject, _, _ := strings.Cut(message, "\n")
+	return subject
+}
+
+// doGitHub executes one GitHub API request and decodes the response
+// into out when out is non-nil.
+func doGitHub(cfg Config, req *http.Request, out any) error {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			slog.Debug("closing response body", "url", req.URL.Path, "error", closeErr)
+		}
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		detail, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if readErr != nil {
+			detail = fmt.Appendf(nil, "(error body unreadable: %v)", readErr)
+		}
+		return fmt.Errorf("github: %s %s: %s: %s", req.Method, req.URL.Path, resp.Status, detail)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/repairround/decide.go
+++ b/internal/repairround/decide.go
@@ -1,0 +1,40 @@
+package repairround
+
+// DefaultMaxRounds is the repair budget one check gets on one pull
+// request. Each check counts separately, so a dead-code repair never
+// spends the budget a failing test would need.
+const DefaultMaxRounds = 3
+
+// Decision answers "may another repair round start for this check, and
+// which round is it?".
+type Decision struct {
+	// Allowed reports whether another round may start.
+	Allowed bool
+	// Round is the round this run would be; 1 is the first attempt.
+	// It is reported even when Allowed is false, where it names the
+	// round that was declined.
+	Round int
+	// Prior is the number of rounds for this check already on the
+	// branch.
+	Prior int
+}
+
+// Decide counts the repair rounds for check already present in
+// subjects — the commit subjects on the pull request's branch — and
+// reports whether another may start under maxRounds.
+//
+// Only commits carrying this check's marker count. Rounds spent by
+// another check, and commits a human wrote, are ignored.
+func Decide(subjects []string, check string, maxRounds int) Decision {
+	prior := 0
+	for _, s := range subjects {
+		if c, ok := CheckOf(s); ok && c == check {
+			prior++
+		}
+	}
+	return Decision{
+		Allowed: prior < maxRounds,
+		Round:   prior + 1,
+		Prior:   prior,
+	}
+}

--- a/internal/repairround/decide_test.go
+++ b/internal/repairround/decide_test.go
@@ -1,0 +1,112 @@
+package repairround
+
+import "testing"
+
+func TestDecide(t *testing.T) {
+	const check = "dead-code"
+	repair := Subject(check, 41)
+	other := Subject("lint-test", 41)
+
+	tests := []struct {
+		name      string
+		subjects  []string
+		maxRounds int
+		want      Decision
+	}{
+		{
+			name:      "empty branch",
+			subjects:  nil,
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 1, Prior: 0},
+		},
+		{
+			name:      "no prior rounds",
+			subjects:  []string{"feat: add the thing", "test: cover it"},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 1, Prior: 0},
+		},
+		{
+			name:      "one prior round",
+			subjects:  []string{"feat: add the thing", repair},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 2, Prior: 1},
+		},
+		{
+			name:      "at the cap",
+			subjects:  []string{"feat: add the thing", repair, repair, repair},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: false, Round: 4, Prior: 3},
+		},
+		{
+			name:      "over the cap",
+			subjects:  []string{repair, repair, repair, repair},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: false, Round: 5, Prior: 4},
+		},
+		{
+			name:      "another check's rounds interleaved",
+			subjects:  []string{other, repair, other, other},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 2, Prior: 1},
+		},
+		{
+			name:      "another check at its own cap",
+			subjects:  []string{other, other, other},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 1, Prior: 0},
+		},
+		{
+			name: "human commits interleaved",
+			subjects: []string{
+				"feat: add the thing",
+				repair,
+				"fix: address review",
+				"docs: mention audit(dead-code): in the runbook",
+				"revert: audit(dead-code): fix findings (#41)",
+			},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 2, Prior: 1},
+		},
+		{
+			name:      "near-miss subject only",
+			subjects:  []string{"audit: fix dead-code findings (#620)"},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 1, Prior: 0},
+		},
+		{
+			name:      "the last allowed round",
+			subjects:  []string{repair, repair},
+			maxRounds: DefaultMaxRounds,
+			want:      Decision{Allowed: true, Round: 3, Prior: 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Decide(tt.subjects, check, tt.maxRounds)
+			if got != tt.want {
+				t.Errorf("Decide = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The cap is three rounds per check, so the third attempt is the last
+// one allowed and the fourth is declined.
+func TestDefaultMaxRoundsIsThree(t *testing.T) {
+	if DefaultMaxRounds != 3 {
+		t.Fatalf("DefaultMaxRounds = %d, want 3", DefaultMaxRounds)
+	}
+	repair := Subject("dead-code", 41)
+	var branch []string
+	for round := 1; round <= DefaultMaxRounds; round++ {
+		d := Decide(branch, "dead-code", DefaultMaxRounds)
+		if !d.Allowed || d.Round != round {
+			t.Fatalf("round %d: Decide = %+v, want allowed round %d", round, d, round)
+		}
+		branch = append(branch, repair)
+	}
+	if d := Decide(branch, "dead-code", DefaultMaxRounds); d.Allowed {
+		t.Errorf("after %d rounds: Decide = %+v, want declined", DefaultMaxRounds, d)
+	}
+}

--- a/internal/repairround/eligible.go
+++ b/internal/repairround/eligible.go
@@ -1,0 +1,64 @@
+package repairround
+
+import (
+	"fmt"
+	"slices"
+)
+
+// RepairLabel marks a pull request the pipeline opened and may
+// therefore repair. It is the same label the audit workflows guard on.
+const RepairLabel = "minion"
+
+// Eligibility answers the question that comes before the round count:
+// may this pull request receive a repair commit at all?
+//
+// It is separate from Decision because the two refusals mean different
+// things. A spent budget is a pull request the pipeline tried and gave
+// up on; an ineligible one was never the pipeline's to touch.
+type Eligibility struct {
+	// Allowed reports whether a repair round may push to this pull
+	// request.
+	Allowed bool
+	// Reason states the decision in one line. It is written to the
+	// workflow log, which is the only place a skipped repair is
+	// visible, so it is never empty.
+	Reason string
+}
+
+// Eligible reports whether a repair round may push to a pull request
+// carrying labels, whose head branch lives in headRepo, opened against
+// baseRepo. Both repositories are "owner/name".
+//
+// Two conditions, both required:
+//
+//   - The pull request carries the repair label. Work a person wrote
+//     gets the check's verdict and nothing else — a bot that commits
+//     on top of a hand-written branch is a bot the operator has to
+//     undo.
+//   - The head branch lives in the base repository. A fork head cannot
+//     be pushed to, so it is refused here, before anything is fetched.
+func Eligible(labels []string, headRepo, baseRepo string) Eligibility {
+	if !hasLabel(labels, RepairLabel) {
+		return Eligibility{Allowed: false, Reason: fmt.Sprintf(
+			"the pull request carries no %q label, so it is reported and not repaired", RepairLabel)}
+	}
+	if headRepo == "" {
+		return Eligibility{Allowed: false, Reason: fmt.Sprintf(
+			"the head repository is unknown, so a repair would push to a branch it cannot name; %q label ignored",
+			RepairLabel)}
+	}
+	if headRepo != baseRepo {
+		return Eligibility{Allowed: false, Reason: fmt.Sprintf(
+			"the head branch lives in %s and not in %s, and this workflow cannot push to a fork",
+			headRepo, baseRepo)}
+	}
+	return Eligibility{Allowed: true, Reason: fmt.Sprintf(
+		"the pull request carries the %q label and its head branch lives in %s", RepairLabel, baseRepo)}
+}
+
+// hasLabel reports whether want is among labels. The match is exact:
+// it replaces a workflow expression that compared the same way, and a
+// label that merely looks like the marker is not the marker.
+func hasLabel(labels []string, want string) bool {
+	return slices.Contains(labels, want)
+}

--- a/internal/repairround/eligible_test.go
+++ b/internal/repairround/eligible_test.go
@@ -1,0 +1,201 @@
+package repairround
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestEligible(t *testing.T) {
+	const base = "partio-io/cli"
+
+	tests := []struct {
+		name        string
+		labels      []string
+		headRepo    string
+		wantAllowed bool
+		wantReason  string // a fragment the reason must name
+	}{
+		{
+			name:        "labelled branch in this repository",
+			labels:      []string{"minion"},
+			headRepo:    base,
+			wantAllowed: true,
+			wantReason:  "minion",
+		},
+		{
+			name:        "labelled among other labels",
+			labels:      []string{"enhancement", "minion", "needs-review"},
+			headRepo:    base,
+			wantAllowed: true,
+			wantReason:  "minion",
+		},
+		{
+			name:        "no labels at all",
+			labels:      nil,
+			headRepo:    base,
+			wantAllowed: false,
+			wantReason:  "minion",
+		},
+		{
+			name:        "labelled, but not with the repair label",
+			labels:      []string{"bug", "documentation"},
+			headRepo:    base,
+			wantAllowed: false,
+			wantReason:  "minion",
+		},
+		// The operator's own branch is the case this rule exists for:
+		// a hand-written pull request gets the red or green signal and
+		// no bot commit on top of work a person wrote.
+		{
+			name:        "a near miss is not the label",
+			labels:      []string{"minions", "Minion"},
+			headRepo:    base,
+			wantAllowed: false,
+			wantReason:  "minion",
+		},
+		// A fork head cannot be pushed to, so the refusal has to come
+		// before anything is fetched — not as a push that fails.
+		{
+			name:        "head branch lives in a fork",
+			labels:      []string{"minion"},
+			headRepo:    "someone-else/cli",
+			wantAllowed: false,
+			wantReason:  "someone-else/cli",
+		},
+		{
+			name:        "fork head without the label",
+			labels:      nil,
+			headRepo:    "someone-else/cli",
+			wantAllowed: false,
+			wantReason:  "minion",
+		},
+		// GitHub reports no head repository for a deleted fork. An
+		// unknown head is refused rather than assumed to be ours.
+		{
+			name:        "head repository unknown",
+			labels:      []string{"minion"},
+			headRepo:    "",
+			wantAllowed: false,
+			wantReason:  "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Eligible(tt.labels, tt.headRepo, base)
+
+			if got.Allowed != tt.wantAllowed {
+				t.Errorf("Eligible(%q, %q, %q).Allowed = %t, want %t",
+					tt.labels, tt.headRepo, base, got.Allowed, tt.wantAllowed)
+			}
+			if got.Reason == "" {
+				t.Fatal("Eligible returned no reason; the workflow log is the only place this decision is visible")
+			}
+			if !strings.Contains(got.Reason, tt.wantReason) {
+				t.Errorf("reason %q does not name %q", got.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// The base repository is the one the workflow runs in, so a head that
+// matches it is pushable whatever either is called.
+func TestEligibleComparesHeadAgainstTheGivenBase(t *testing.T) {
+	got := Eligible([]string{"minion"}, "other-org/other-name", "other-org/other-name")
+
+	if !got.Allowed {
+		t.Errorf("Eligible refused a head in the base repository: %q", got.Reason)
+	}
+}
+
+// fakePR serves one pull request. The labels and the head repository
+// come from the API rather than from a workflow expression, so the
+// decision has one implementation and the workflow carries no label
+// logic of its own.
+func fakePR(t *testing.T, labels []string, headRepo string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/partio-io/cli/pulls/41", func(w http.ResponseWriter, _ *http.Request) {
+		body := map[string]any{"labels": []map[string]any{}, "head": map[string]any{}}
+		named := []map[string]any{}
+		for _, l := range labels {
+			named = append(named, map[string]any{"name": l})
+		}
+		body["labels"] = named
+		if headRepo != "" {
+			body["head"] = map[string]any{"repo": map[string]any{"full_name": headRepo}}
+		}
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Errorf("encode pull request: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestRunEligibility(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      []string
+		headRepo    string
+		wantAllowed bool
+	}{
+		{name: "minion pull request in this repository", labels: []string{"minion"}, headRepo: "partio-io/cli", wantAllowed: true},
+		{name: "hand-written pull request", labels: []string{"bug"}, headRepo: "partio-io/cli"},
+		{name: "fork head", labels: []string{"minion"}, headRepo: "someone-else/cli"},
+		{name: "no head repository", labels: []string{"minion"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := fakePR(t, tt.labels, tt.headRepo)
+
+			got, err := RunEligibility(Config{
+				Repo:       "partio-io/cli",
+				PRNumber:   41,
+				Check:      "checks",
+				APIBaseURL: srv.URL,
+				Token:      "test-token",
+				HTTPClient: srv.Client(),
+			})
+			if err != nil {
+				t.Fatalf("RunEligibility: %v", err)
+			}
+
+			if got.Allowed != tt.wantAllowed {
+				t.Errorf("RunEligibility = %+v, want allowed %t", got, tt.wantAllowed)
+			}
+			if got.Reason == "" {
+				t.Error("RunEligibility returned no reason")
+			}
+		})
+	}
+}
+
+// A pull request the API will not describe leaves the decision unknown.
+// Guessing "repairable" there would push a commit on no evidence, so
+// the error travels up and the caller declines.
+func TestRunEligibilityReportsAnUnreadablePullRequest(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/partio-io/cli/pulls/41", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	_, err := RunEligibility(Config{
+		Repo:       "partio-io/cli",
+		PRNumber:   41,
+		Check:      "checks",
+		APIBaseURL: srv.URL,
+		Token:      "test-token",
+		HTTPClient: srv.Client(),
+	})
+	if err == nil {
+		t.Fatal("RunEligibility accepted a pull request it could not read")
+	}
+}

--- a/internal/repairround/marker.go
+++ b/internal/repairround/marker.go
@@ -1,0 +1,58 @@
+package repairround
+
+import (
+	"fmt"
+	"strings"
+)
+
+// markerPrefix opens a repair commit's subject. What follows, up to
+// the closing parenthesis and ": ", names the check that produced the
+// commit.
+const markerPrefix = "audit("
+
+// markerInfix closes the check name and opens the human-readable rest
+// of the subject.
+const markerInfix = "): "
+
+// Subject returns the commit subject a repair round must use. The
+// check name is part of the subject so that a later run can tell which
+// check spent the round by reading the branch's subjects alone.
+func Subject(check string, pr int) string {
+	return fmt.Sprintf("%s%s%sfix findings (#%d)", markerPrefix, check, markerInfix, pr)
+}
+
+// CheckOf reports the check named by a repair commit's subject.
+//
+// The match is deliberately strict, because miscounting here spends a
+// budget that belongs to someone else. The marker must open the
+// subject, the check name must be lowercase kebab-case, and the
+// closing "): " must be present. A subject that merely mentions a
+// marker, an older unqualified "audit:" subject, or a human commit
+// with a similar shape all report false.
+func CheckOf(subject string) (string, bool) {
+	rest, ok := strings.CutPrefix(subject, markerPrefix)
+	if !ok {
+		return "", false
+	}
+	check, _, ok := strings.Cut(rest, markerInfix)
+	if !ok || !validCheck(check) {
+		return "", false
+	}
+	return check, true
+}
+
+// validCheck reports whether name is a well-formed check name:
+// non-empty lowercase letters, digits and hyphens.
+func validCheck(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/repairround/marker_test.go
+++ b/internal/repairround/marker_test.go
@@ -1,0 +1,51 @@
+package repairround
+
+import "testing"
+
+func TestSubjectNamesItsCheck(t *testing.T) {
+	got := Subject("dead-code", 622)
+	want := "audit(dead-code): fix findings (#622)"
+	if got != want {
+		t.Errorf("Subject = %q, want %q", got, want)
+	}
+	check, ok := CheckOf(got)
+	if !ok || check != "dead-code" {
+		t.Errorf("CheckOf(%q) = %q, %v; want \"dead-code\", true", got, check, ok)
+	}
+}
+
+func TestCheckOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+		want    string
+		wantOK  bool
+	}{
+		{"marker", "audit(dead-code): fix findings (#622)", "dead-code", true},
+		{"other check", "audit(lint-test): fix findings (#622)", "lint-test", true},
+		{"digits in the name", "audit(e2e-need): fix findings (#622)", "e2e-need", true},
+
+		// Near misses. Each of these must count for nothing.
+		{"unqualified predecessor", "audit: fix dead-code findings (#620)", "", false},
+		{"human scope", "fix(audit): tighten the loop guard", "", false},
+		{"quoted mid-subject", "docs: explain audit(dead-code): markers", "", false},
+		{"no space after colon", "audit(dead-code):fix findings", "", false},
+		{"no colon", "audit(dead-code) fix findings", "", false},
+		{"empty check", "audit(): fix findings (#622)", "", false},
+		{"unclosed check", "audit(dead-code fix findings", "", false},
+		{"capitalized check", "audit(Dead-Code): fix findings (#622)", "", false},
+		{"spaced check", "audit(dead code): fix findings (#622)", "", false},
+		{"leading whitespace", " audit(dead-code): fix findings (#622)", "", false},
+		{"ordinary commit", "feat: add the thing", "", false},
+		{"empty subject", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := CheckOf(tt.subject)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("CheckOf(%q) = %q, %v; want %q, %v", tt.subject, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/repairround/run.go
+++ b/internal/repairround/run.go
@@ -1,0 +1,51 @@
+// Package repairround decides whether a pull request may receive
+// another automated repair round for one check, and which round it
+// would be.
+//
+// The decision is accounting, not prohibition: repair commits carry a
+// marker naming the check that produced them, and a run counts the
+// markers already on the branch. Under the cap the run proceeds and
+// knows its round number; at the cap it declines. Each check keeps its
+// own budget.
+package repairround
+
+import "net/http"
+
+// Config carries everything one accounting run needs.
+type Config struct {
+	Repo       string       // owner/name
+	PRNumber   int          // pull request whose branch is counted
+	Check      string       // check whose budget is in question, e.g. "dead-code"
+	MaxRounds  int          // cap for this check; zero means DefaultMaxRounds
+	APIBaseURL string       // GitHub API root, e.g. https://api.github.com
+	Token      string       // token for the commits read
+	HTTPClient *http.Client // nil means http.DefaultClient
+}
+
+// RunEligibility reads the pull request's labels and head repository
+// and reports whether a repair round may push to it at all.
+//
+// This is the question that comes before the count. An error means the
+// pull request could not be read, and the caller must decline rather
+// than assume: a wrong "yes" here is a commit on someone's branch.
+func RunEligibility(cfg Config) (Eligibility, error) {
+	labels, headRepo, err := prMeta(cfg)
+	if err != nil {
+		return Eligibility{}, err
+	}
+	return Eligible(labels, headRepo, cfg.Repo), nil
+}
+
+// Run reads the pull request branch's commit subjects and reports
+// whether another repair round for cfg.Check may start.
+func Run(cfg Config) (Decision, error) {
+	subjects, err := prSubjects(cfg)
+	if err != nil {
+		return Decision{}, err
+	}
+	maxRounds := cfg.MaxRounds
+	if maxRounds <= 0 {
+		maxRounds = DefaultMaxRounds
+	}
+	return Decide(subjects, cfg.Check, maxRounds), nil
+}

--- a/internal/repairround/run_test.go
+++ b/internal/repairround/run_test.go
@@ -1,0 +1,67 @@
+package repairround
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeGitHub is a minimal pull-request-commits API double. It serves
+// the commit messages it is seeded with on the first page and an empty
+// page after that, so the pagination loop terminates.
+type fakeGitHub struct {
+	messages []string
+	pages    int
+}
+
+func (f *fakeGitHub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/partio-io/cli/pulls/41/commits", func(w http.ResponseWriter, r *http.Request) {
+		f.pages++
+		body := []map[string]any{}
+		if page := r.URL.Query().Get("page"); page == "" || page == "1" {
+			for _, m := range f.messages {
+				body = append(body, map[string]any{"commit": map[string]any{"message": m}})
+			}
+		}
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Errorf("encode commits: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The tracer bullet: a branch carrying one dead-code repair, one
+// repair for a different check, and human work reads as "round 2 of
+// dead-code may start".
+func TestRunCountsRepairsForOneCheckOnly(t *testing.T) {
+	fake := &fakeGitHub{messages: []string{
+		"feat: add the thing",
+		Subject("dead-code", 41),
+		Subject("lint-test", 41),
+		"fix: address review\n\nA body that mentions audit(dead-code): markers.",
+	}}
+	srv := fake.server(t)
+
+	got, err := Run(Config{
+		Repo:       "partio-io/cli",
+		PRNumber:   41,
+		Check:      "dead-code",
+		MaxRounds:  DefaultMaxRounds,
+		APIBaseURL: srv.URL,
+		Token:      "test-token",
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	want := Decision{Allowed: true, Round: 2, Prior: 1}
+	if got != want {
+		t.Errorf("Run = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
Slices 2 to 7 of
[2026-08-06-minion-ci-self-repair](docs/2026-08-06-minion-ci-self-repair/prd.md).
Slice 1 landed in #636.

## The problem

A gate found a defect, wrote a comment, and went red. One repair
attempt was the ceiling, and lint and test ran nowhere a reviewer saw.
A minion pull request could break the build and still look clean.

## What changes

- **Repair rounds are counted, not banned.** A per-check cap replaces
  the "any bot commit blocks a repair" rule. The dead-code gate and the
  checks gate keep separate budgets.
- **Lint and test run as a pull request check.** Output is parsed into
  a verdict. A missing or malformed verdict fails closed.
- **Failing lint and tests get repaired.** Capped at three rounds.
- **One applier lands every patch.** It applies in a scratch worktree,
  proves with `make lint && make test`, and pushes only when both pass.
- **A gate that gives up says so**, naming the survivors and the round
  count.
- **The gates share one concurrency group**, keyed on the pull request
  number, so only one gate writes a branch at a time.

## The two rules that keep this safe

**The repair session never writes git.** It produces a patch. Every
write goes through the shared applier, behind `make lint && make test`.
A patch that does not build reaches no branch.

**The session may not touch a test that predates the pull request.** It
may correct a test the pull request itself added — a minion's own new
test being wrong is the common case. A pre-existing test that fails is
a surviving finding and goes red. This blocks the classic failure where
a bot reaches green by deleting an assertion. `added_tests` decides this
from the diff, in tested Go, not by the session's judgment.

Repair runs only on a labelled pull request whose head branch lives in
this repository. No bot commit is pushed to work the operator wrote.

## Verification

- `make test` — 15 packages, 0 failures.
- `make lint` — 0 issues.
- All 7 commits compile independently.
- New table-driven tests: `repairround/eligible_test.go` (label and fork
  gating), `checksverdict/added_tests_test.go` (added, modified, deleted,
  renamed, copied).

The repair programs are model-driven and not unit-testable; the PRD
names this. Their contract is enforced downstream — a bad patch fails
the applier and pushes nothing.

## One criterion stays open after merge

Slice 6's last criterion is a post-merge check: a pull request whose
failing test the minion itself wrote goes green with no human edit. It
needs this workflow live on `main`. Watch the first minion pull request
that breaks its own test, then check the row in
`docs/2026-08-06-minion-ci-self-repair/issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
