### PR TITLE
[minion] Replace O(N) tree walk with git diff-tree in post-commit hook

### DIFF
--- a/internal/attribution/calculate.go
+++ b/internal/attribution/calculate.go
@@ -9,14 +9,10 @@ import (
 
 // Calculate computes attribution for a commit based on whether an agent was active.
 func Calculate(commitHash string, agentActive bool) (*Result, error) {
-	// Get numstat for the commit
+	// DiffNumstat uses git diff-tree --root, which handles initial commits natively.
 	numstat, err := git.DiffNumstat(commitHash)
 	if err != nil {
-		// If this is the first commit, try diff against empty tree
-		numstat, err = git.ExecGit("diff", "--numstat", "4b825dc642cb6eb9a060e54bf899d69f82cf7ee2", commitHash)
-		if err != nil {
-			return &Result{}, nil
-		}
+		return &Result{}, nil
 	}
 
 	totalAdded := 0

--- a/internal/git/diff_name_only.go
+++ b/internal/git/diff_name_only.go
@@ -1,15 +1,13 @@
 package git
 
-import "strings"
-
 // DiffNameOnly returns the list of file paths changed in a specific commit.
 func DiffNameOnly(commitHash string) ([]string, error) {
-	out, err := execGit("diff", "--name-only", commitHash+"~1", commitHash)
+	lines, err := diffTree("", commitHash, "--name-only")
 	if err != nil {
 		return nil, err
 	}
-	if out == "" {
+	if len(lines) == 0 {
 		return nil, nil
 	}
-	return strings.Split(out, "\n"), nil
+	return lines, nil
 }

--- a/internal/git/diff_name_only_test.go
+++ b/internal/git/diff_name_only_test.go
@@ -1,0 +1,81 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestDiffNameOnly(t *testing.T) {
+	t.Run("initial commit", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "hello.txt", "hello\n")
+		run("git", "add", "hello.txt")
+		run("git", "commit", "-m", "initial")
+		hash := run("git", "rev-parse", "HEAD")
+
+		t.Chdir(dir)
+
+		files, err := DiffNameOnly(hash)
+		if err != nil {
+			t.Fatalf("DiffNameOnly() error: %v", err)
+		}
+		if len(files) != 1 || files[0] != "hello.txt" {
+			t.Errorf("DiffNameOnly() = %v, want [hello.txt]", files)
+		}
+	})
+
+	t.Run("regular commit", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "a.txt", "first\n")
+		run("git", "add", "a.txt")
+		run("git", "commit", "-m", "initial")
+
+		writeFile(t, dir, "b.txt", "second\n")
+		run("git", "add", "b.txt")
+		run("git", "commit", "-m", "add b")
+		hash := run("git", "rev-parse", "HEAD")
+
+		t.Chdir(dir)
+
+		files, err := DiffNameOnly(hash)
+		if err != nil {
+			t.Fatalf("DiffNameOnly() error: %v", err)
+		}
+		if len(files) != 1 || files[0] != "b.txt" {
+			t.Errorf("DiffNameOnly() = %v, want [b.txt]", files)
+		}
+	})
+
+	t.Run("merge commit returns nil", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "base.txt", "base\n")
+		run("git", "add", "base.txt")
+		run("git", "commit", "-m", "base")
+
+		run("git", "checkout", "-b", "feature")
+		writeFile(t, dir, "feature.txt", "feature\n")
+		run("git", "add", "feature.txt")
+		run("git", "commit", "-m", "feature commit")
+
+		run("git", "checkout", "-")
+
+		writeFile(t, dir, "main_change.txt", "main\n")
+		run("git", "add", "main_change.txt")
+		run("git", "commit", "-m", "main commit")
+
+		run("git", "merge", "--no-edit", "feature")
+		mergeHash := run("git", "rev-parse", "HEAD")
+
+		t.Chdir(dir)
+
+		files, err := DiffNameOnly(mergeHash)
+		if err != nil {
+			t.Fatalf("DiffNameOnly() error: %v", err)
+		}
+		if files != nil {
+			t.Errorf("DiffNameOnly() on merge = %v, want nil", files)
+		}
+	})
+}

--- a/internal/git/diff_numstat.go
+++ b/internal/git/diff_numstat.go
@@ -1,6 +1,12 @@
 package git
 
+import "strings"
+
 // DiffNumstat returns numstat for a specific commit.
 func DiffNumstat(commitHash string) (string, error) {
-	return execGit("diff", "--numstat", commitHash+"~1", commitHash)
+	lines, err := diffTree("", commitHash, "--numstat")
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(lines, "\n"), nil
 }

--- a/internal/git/diff_numstat_test.go
+++ b/internal/git/diff_numstat_test.go
@@ -1,0 +1,84 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiffNumstat(t *testing.T) {
+	t.Run("initial commit", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "hello.txt", "hello\nworld\n")
+		run("git", "add", "hello.txt")
+		run("git", "commit", "-m", "initial")
+		hash := run("git", "rev-parse", "HEAD")
+
+		// Change cwd to the test repo so execGit-based helpers work.
+		t.Chdir(dir)
+
+		out, err := DiffNumstat(hash)
+		if err != nil {
+			t.Fatalf("DiffNumstat() error: %v", err)
+		}
+		// numstat format: "<added>\t<deleted>\t<path>"
+		if !strings.Contains(out, "hello.txt") {
+			t.Errorf("DiffNumstat() = %q, want output containing hello.txt", out)
+		}
+	})
+
+	t.Run("regular commit", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "a.txt", "line1\n")
+		run("git", "add", "a.txt")
+		run("git", "commit", "-m", "initial")
+
+		writeFile(t, dir, "b.txt", "line2\nline3\n")
+		run("git", "add", "b.txt")
+		run("git", "commit", "-m", "add b")
+		hash := run("git", "rev-parse", "HEAD")
+
+		t.Chdir(dir)
+
+		out, err := DiffNumstat(hash)
+		if err != nil {
+			t.Fatalf("DiffNumstat() error: %v", err)
+		}
+		if !strings.Contains(out, "b.txt") {
+			t.Errorf("DiffNumstat() = %q, want output containing b.txt", out)
+		}
+	})
+
+	t.Run("merge commit returns empty", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "base.txt", "base\n")
+		run("git", "add", "base.txt")
+		run("git", "commit", "-m", "base")
+
+		run("git", "checkout", "-b", "feature")
+		writeFile(t, dir, "feature.txt", "feature\n")
+		run("git", "add", "feature.txt")
+		run("git", "commit", "-m", "feature commit")
+
+		run("git", "checkout", "-")
+
+		writeFile(t, dir, "main_change.txt", "main\n")
+		run("git", "add", "main_change.txt")
+		run("git", "commit", "-m", "main commit")
+
+		run("git", "merge", "--no-edit", "feature")
+		mergeHash := run("git", "rev-parse", "HEAD")
+
+		t.Chdir(dir)
+
+		out, err := DiffNumstat(mergeHash)
+		if err != nil {
+			t.Fatalf("DiffNumstat() error: %v", err)
+		}
+		if out != "" {
+			t.Errorf("DiffNumstat() on merge = %q, want empty string", out)
+		}
+	})
+}

--- a/internal/git/diff_tree.go
+++ b/internal/git/diff_tree.go
@@ -1,0 +1,39 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// diffTree invokes git diff-tree with the standard plumbing flags
+// (--no-commit-id -r --root) plus any extra args against the given commit hash.
+// It returns the output as a slice of non-empty lines.
+//
+// Empty output (e.g. merge commits, which have multiple parents) is returned as
+// an empty slice, not an error. Merge commits intentionally produce no output
+// because they introduce no original content; callers must not add -m or --cc
+// to change this behaviour without deliberate design consideration.
+//
+// repoPath sets the working directory for the subprocess; pass "" to use the
+// process's current working directory (consistent with execGit).
+func diffTree(repoPath, commitHash string, extraArgs ...string) ([]string, error) {
+	args := append([]string{"diff-tree", "--no-commit-id", "-r", "--root"}, extraArgs...)
+	args = append(args, commitHash)
+
+	cmd := exec.Command("git", args...)
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return []string{}, nil
+	}
+
+	return strings.Split(raw, "\n"), nil
+}

--- a/internal/git/diff_tree_bench_test.go
+++ b/internal/git/diff_tree_bench_test.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// BenchmarkDiffNumstat measures DiffNumstat performance on a repo with 1000+ files.
+// Run with: go test -bench=BenchmarkDiffNumstat ./internal/git/
+func BenchmarkDiffNumstat(b *testing.B) {
+	dir := b.TempDir()
+
+	run := func(args ...string) string {
+		b.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			b.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	writef := func(name, content string) {
+		b.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			b.Fatalf("WriteFile(%s): %v", name, err)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "bench@example.com")
+	run("git", "config", "user.name", "Bench")
+
+	// Create and commit 1000 files so the repo is large.
+	for i := range 1000 {
+		writef(fmt.Sprintf("file%04d.txt", i), fmt.Sprintf("content %d\n", i))
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "initial commit with 1000 files")
+
+	// Add one changed file; benchmark DiffNumstat against this commit.
+	writef("changed.txt", "changed content\n")
+	run("git", "add", "changed.txt")
+	run("git", "commit", "-m", "add changed file")
+	hash := run("git", "rev-parse", "HEAD")
+
+	// Change working directory so execGit resolves the repo correctly.
+	b.Chdir(dir)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := DiffNumstat(hash)
+		if err != nil {
+			b.Fatalf("DiffNumstat() error: %v", err)
+		}
+	}
+}

--- a/internal/git/diff_tree_test.go
+++ b/internal/git/diff_tree_test.go
@@ -1,0 +1,113 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupTestRepo(t *testing.T) (dir string, run func(args ...string) string) {
+	t.Helper()
+	dir = t.TempDir()
+
+	run = func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test")
+
+	return dir, run
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("writeFile(%s): %v", name, err)
+	}
+}
+
+func TestDiffTree(t *testing.T) {
+	t.Run("initial commit", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "hello.txt", "hello\n")
+		run("git", "add", "hello.txt")
+		run("git", "commit", "-m", "initial")
+		hash := run("git", "rev-parse", "HEAD")
+
+		lines, err := diffTree(dir, hash, "--name-only")
+		if err != nil {
+			t.Fatalf("diffTree() error: %v", err)
+		}
+		if len(lines) != 1 || lines[0] != "hello.txt" {
+			t.Errorf("diffTree() = %v, want [hello.txt]", lines)
+		}
+	})
+
+	t.Run("regular commit", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "a.txt", "first\n")
+		run("git", "add", "a.txt")
+		run("git", "commit", "-m", "initial")
+
+		writeFile(t, dir, "b.txt", "second\n")
+		run("git", "add", "b.txt")
+		run("git", "commit", "-m", "add b")
+		hash := run("git", "rev-parse", "HEAD")
+
+		lines, err := diffTree(dir, hash, "--name-only")
+		if err != nil {
+			t.Fatalf("diffTree() error: %v", err)
+		}
+		if len(lines) != 1 || lines[0] != "b.txt" {
+			t.Errorf("diffTree() = %v, want [b.txt]", lines)
+		}
+	})
+
+	t.Run("merge commit returns empty slice", func(t *testing.T) {
+		dir, run := setupTestRepo(t)
+
+		writeFile(t, dir, "base.txt", "base\n")
+		run("git", "add", "base.txt")
+		run("git", "commit", "-m", "base")
+
+		// create feature branch from current HEAD
+		run("git", "checkout", "-b", "feature")
+		writeFile(t, dir, "feature.txt", "feature\n")
+		run("git", "add", "feature.txt")
+		run("git", "commit", "-m", "feature commit")
+
+		// return to the branch we started from
+		run("git", "checkout", "-")
+
+		// add a commit on the base branch to create a divergence
+		writeFile(t, dir, "main_change.txt", "main\n")
+		run("git", "add", "main_change.txt")
+		run("git", "commit", "-m", "main commit")
+
+		// merge feature (no -m flag in diff-tree means merge commits produce empty output)
+		run("git", "merge", "--no-edit", "feature")
+		mergeHash := run("git", "rev-parse", "HEAD")
+
+		lines, err := diffTree(dir, mergeHash, "--name-only")
+		if err != nil {
+			t.Fatalf("diffTree() on merge commit error: %v", err)
+		}
+		// diff-tree without -m returns empty for merge commits — this is intentional
+		if len(lines) != 0 {
+			t.Errorf("diffTree() on merge commit = %v, want empty slice", lines)
+		}
+	})
+}

--- a/internal/session/cleanup_test.go
+++ b/internal/session/cleanup_test.go
@@ -64,7 +64,10 @@ func TestCleanupStale_RecentActiveSession(t *testing.T) {
 		t.Error("should not clean up a recently updated session")
 	}
 
-	cur, _ := mgr.Current()
+	cur, err := mgr.Current()
+	if err != nil {
+		t.Fatalf("unexpected error reading current session: %v", err)
+	}
 	if cur.State != StateActive {
 		t.Errorf("expected state=active, got %s", cur.State)
 	}
@@ -96,7 +99,10 @@ func TestCleanupStale_OldActiveSession_NoPID(t *testing.T) {
 		t.Fatal("expected session to be set in result")
 	}
 
-	cur, _ := mgr.Current()
+	cur, err := mgr.Current()
+	if err != nil {
+		t.Fatalf("unexpected error reading current session: %v", err)
+	}
 	if cur.State != StateEnded {
 		t.Errorf("expected state=ended after cleanup, got %s", cur.State)
 	}
@@ -131,7 +137,10 @@ func TestCleanupStale_OldIdleSession_NoPID(t *testing.T) {
 		t.Error("expected stale idle session to be cleaned up")
 	}
 
-	cur, _ := mgr.Current()
+	cur, err := mgr.Current()
+	if err != nil {
+		t.Fatalf("unexpected error reading current session: %v", err)
+	}
 	if cur.State != StateEnded {
 		t.Errorf("expected state=ended after cleanup, got %s", cur.State)
 	}


### PR DESCRIPTION
## Objective

Replaces `git diff` (porcelain) calls in `DiffNumstat` and `DiffNameOnly` with `git diff-tree --no-commit-id -r --root` (plumbing) to reduce post-commit hook latency on large repos.

**Changes:**
- New `internal/git/diff_tree.go`: unexported `diffTree` helper that centralizes the `diff-tree` invocation with correct flags (`--no-commit-id -r --root`)
- `DiffNumstat` and `DiffNameOnly` now delegate to `diffTree` instead of calling `git diff`
- `attribution.Calculate`: removed the empty-tree retry fallback (`4b825dc...`) — `--root` handles initial commits natively
- Merge commits correctly produce empty output (no `-m` flag), which is semantically correct

**Key decisions:**
- `--root` flag eliminates the need for the `commitHash~1` parent reference and the empty-tree fallback, handling initial commits uniformly
- Merge commits intentionally return empty output; a comment documents why `-m` must not be added
- Public signatures of `DiffNumstat` and `DiffNameOnly` are unchanged — no caller updates required

**Testing:**
- Unit tests cover initial commit, regular commit, and merge commit for `diffTree`, `DiffNumstat`, and `DiffNameOnly`
- `BenchmarkDiffNumstat` in `diff_tree_bench_test.go` creates a 1000-file repo and measures per-call latency: `go test -bench=BenchmarkDiffNumstat ./internal/git/`
- `make test` passes with no regressions

## Acceptance Criteria

- [ ] All changes match what the issue describes
- [ ] make test passes
- [ ] make lint passes
- [ ] PR description clearly explains what changed and why
- [ ] Commit messages are meaningful and describe the change

---

Automated PR by [partio-io/cli](https://github.com/partio-io/cli) · Task: `implement-implement-30`

*Created by an unattended coding agent. Please review carefully.*

Closes #30