### PR TITLE
Fix first-commit attribution, and gate proposals on a checked premise

### DIFF
--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -58,7 +58,36 @@ jobs:
           go install github.com/partio-io/minions/cmd/minions@v0.0.13
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      # The premise is checked before the build starts, not inside it. The
+      # runtime creates the branch before the agent session runs and pushes
+      # unconditionally, so a build that stops partway still leaves a branch
+      # and a pull request behind. Stopping here leaves neither.
+      - name: Run premise gate
+        id: gate
+        if: steps.program.outputs.issue_num != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          MINION_ISSUE_NUMBER: ${{ steps.program.outputs.issue_num }}
+        run: |
+          ISSUE_NUM="${{ steps.program.outputs.issue_num }}"
+          REPO="${{ github.repository }}"
+
+          minions run .minions/programs/premise-gate.md --issue "$ISSUE_NUM"
+
+          # The gate reports its verdict by labelling the issue — the same
+          # signal the approval program already treats as a skip condition.
+          # Read the label back rather than the run's exit code: the gate
+          # succeeds whether the premise held or not.
+          if gh issue view "$ISSUE_NUM" --repo "$REPO" --json labels \
+              --jq '.labels[].name' | grep -qx 'do-not-build'; then
+            echo "::notice::Premise does not hold for #${ISSUE_NUM}; skipping the build."
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run program
+        if: steps.gate.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -71,8 +100,11 @@ jobs:
           fi
           minions $ARGS
 
+      # A blocked run is not a completion and not a failure. Both of the
+      # steps below are skipped so the gate's comment stays the only account
+      # of what happened, and the issue is neither closed nor marked failed.
       - name: Mark done
-        if: success() && steps.program.outputs.issue_num != ''
+        if: success() && steps.program.outputs.issue_num != '' && steps.gate.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -106,7 +138,7 @@ jobs:
             --comment "Minion completed — see PR #${PR}."
 
       - name: Mark failed
-        if: failure() && steps.program.outputs.issue_num != ''
+        if: failure() && steps.program.outputs.issue_num != '' && steps.gate.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/.minions/ingest-prompt.md
+++ b/.minions/ingest-prompt.md
@@ -32,9 +32,19 @@ For each feature idea, output a JSON object with these fields:
   "user_relevance": "Why this change is relevant to Partio users — how it improves their experience, workflow, or the value they get from Partio.",
   "target_repos": ["cli"],
   "context_hints": ["cli/internal/relevant/path/"],
-  "acceptance_criteria": ["specific testable criterion 1", "specific testable criterion 2"]
+  "acceptance_criteria": ["specific testable criterion 1", "specific testable criterion 2"],
+  "premise": [
+    {
+      "claim": "one factual statement about Partio that this idea depends on",
+      "evidence": "the path, symbol or command that settles the claim, e.g. 'cli/internal/hooks/post_commit.go' or 'go doc ./internal/attribution'"
+    }
+  ]
 }
 ```
+
+`premise` lists what the idea assumes to be true about Partio today. State each assumption as one claim, and attach the evidence that decides it. A claim you cannot attach evidence to is not written with an empty `evidence` field: find the evidence, or drop the idea. A claim about Partio's current behavior is a premise; a statement about what Partio should do next is not — that belongs in `description`.
+
+**Ground every claim in the checked-out tree, not in the source material.** The source describes a different product. Its problems are not Partio's problems until you have seen them here. Write a claim only about what the checked-out tree shows, and name the path, symbol or command in that tree that shows it. Do not infer Partio's current behavior from how the source product behaves, from the wording of a changelog entry or issue, or from how projects of this kind usually work. A claim you cannot ground this way is dropped along with the idea that needed it.
 
 Do NOT include `docs` in `target_repos`. Documentation updates are handled automatically by the doc minion after code PRs merge — speculative docs PRs created alongside code changes become stale during review and get orphaned if the code PR is rejected.
 

--- a/.minions/premise-verifier.md
+++ b/.minions/premise-verifier.md
@@ -1,0 +1,118 @@
+# Premise verifier
+
+<!-- partio:premise-verifier:v1 -->
+
+Verification is described here, once. The propose, research and implement
+programs apply this description. They do not each carry their own idea of what
+verification means, and they do not restate the procedure below.
+
+Given a premise block and a checked-out tree, gather the evidence each claim
+names and return a verdict plus what was found.
+
+## Inputs
+
+1. **A set of claims.** Normally a premise block: the `## Premise` section that
+   carries the `<!-- partio:premise:v1 -->` marker, one claim per line, each
+   naming the path, symbol or command that settles it. When the issue carries
+   that marker, the block is everything you need, and you do not verify the
+   prose around it. When it carries no marker, read `## When there is no
+   block` below.
+2. **A checked-out tree.** The repository the claims are about, already on
+   disk in your working directory. Read it. Do not answer from the source
+   material the idea came from, and do not answer from memory of how similar
+   projects work.
+
+## When there is no block
+
+Hundreds of proposals were filed before the block format existed. They state
+their facts in prose, and they are not exempt.
+
+When the issue carries no `<!-- partio:premise:v1 -->` marker, extract the
+factual claims from the issue prose and verify those. A factual claim is a
+statement about this repository that the tree can settle. Take each one word
+for word from the body, and name the path, symbol or command that settles it.
+
+Extract these:
+
+- what the code does today, or does not do
+- how it behaves, performs or is structured
+
+Leave these, because no tree settles them:
+
+- what the proposal wants to build, and its acceptance criteria
+- what a sibling product does, and where the idea came from
+- whether the idea is worth doing
+
+Then verify the claims you extracted by the same procedure, the same verdicts
+and the same output as a block's claims. Nothing below this section changes
+because the claims came from prose. An older proposal meets the same bar as one
+filed today.
+
+Some proposals only describe what to build. If the prose makes no checkable
+factual claim, there is nothing to verify: continue. This is not `unresolved`.
+An unresolved claim is one you could not settle; here there was no claim to
+settle, and treating the two alike would block most of the backlog at once.
+Say so in your report: state that the prose makes no checkable claim, and name
+what you read to decide that.
+
+Check the proposal in front of you, and no other. The backlog is not swept: a
+proposal is checked when a stage next touches it, so nothing is listed, closed
+or relabelled ahead of time.
+
+Extraction happens here, at check time, and leaves nothing behind. Do not
+rewrite the issue body. Do not backfill a premise block into it, and do not
+add one to an issue that passes. The proposal keeps its own words; the claims
+you extracted live in your report and nowhere else.
+
+## Procedure
+
+For each claim, in order, whether it came from a block or from the prose:
+
+1. **Gather the evidence the claim names.**
+   - A path: read the file. If the path is a directory, list it and read the
+     files the claim is about.
+   - A symbol: find it, for example with `grep -rn '<symbol>' .`, then read
+     where it is defined.
+   - A command: run it and keep the output.
+2. **Decide the claim against what you gathered, and against nothing else.**
+3. **Record the verdict and the excerpt that produced it** — the path and the
+   lines you read, or the command and the output it printed.
+
+Gather first, decide second. A claim you gathered no evidence for is
+`unresolved`. It is never `holds`.
+
+## Verdicts
+
+For one claim:
+
+- `holds` — the gathered evidence confirms the claim.
+- `fails` — the gathered evidence contradicts the claim.
+- `unresolved` — the named evidence does not settle the claim. The path is
+  missing, the symbol is absent, or the command printed nothing to read.
+
+For the block: `fails` if any claim fails. Otherwise `unresolved` if any claim
+is unresolved. Otherwise `holds`.
+
+## Output
+
+Report every claim, whichever way it went:
+
+- the claim, word for word
+- the evidence the claim named
+- the verdict
+- the excerpt that produced the verdict
+
+Report this for a block that holds as well as for one that does not. A stage
+that passes carries its evidence too.
+
+## What the caller does
+
+Only a premise that `holds` lets the work continue. One that `fails` or is
+`unresolved` stops the calling stage. Where its claims came from makes no
+difference: an extracted claim that fails stops the stage exactly as a
+block claim that fails does.
+
+What "stop" means belongs to the caller: the proposer drops the idea before it
+becomes an issue, and a later stage labels the issue and hands control back to
+the operator. No caller treats `fails` or `unresolved` as a pass, and no caller
+decides a claim it did not gather evidence for.

--- a/.minions/programs/implement.md
+++ b/.minions/programs/implement.md
@@ -21,27 +21,6 @@ Follow existing code patterns and conventions. Read the relevant code before mak
 
 After implementation, run the appropriate checks (`make test`, `make lint`) and fix any failures.
 
-## Slice builds
-
-An issue that carries a slice plan (a `minion:research-slices` comment) is built one slice per session. Your prompt then names your slice under "Your Slice" — build only that slice: implement its acceptance criteria and nothing from any other slice, even when adjacent code invites it. Earlier slices are already committed on your branch — build on their work, never redo or undo it. Later slices belong to their own sessions.
-
-- The acceptance criteria above apply to your slice's changes, not the whole issue at once.
-- Leave the tree green at your boundary: checks (`make test`, `make lint`) run after every slice.
-- Commit your work with the same message quality as below; anything left uncommitted is swept into a generic `slice N/M` commit by the runtime.
-- The runtime pushes each slice and opens the single PR after the final slice — never open a PR yourself.
-
-## PR and commit quality
-
-A human will review your PR. Make it easy for them:
-
-- **Commit messages** should describe what changed and why, not just "implement feature". Use conventional commit format (e.g., `feat: add codex agent detection`).
-- **PR title** should be a clear summary of what the PR does (not the issue title verbatim if it doesn't make sense as a PR title).
-- **PR description** must include:
-  - A summary of what was implemented
-  - Key design decisions you made
-  - How to test the changes
-  - Reference to the source issue (e.g., "Resolves #120")
-
 ## Agents
 
 ### implement
@@ -52,3 +31,24 @@ checks: true
 retry_on_fail: true
 retry_max_turns: 20
 ```
+
+The premise behind this issue was verified against this tree before you
+started. You do not check it again — build what the issue describes.
+
+**Slice builds.** An issue that carries a slice plan (a `minion:research-slices` comment) is built one slice per session. Your prompt then names your slice under "Your Slice" — build only that slice: implement its acceptance criteria and nothing from any other slice, even when adjacent code invites it. Earlier slices are already committed on your branch — build on their work, never redo or undo it. Later slices belong to their own sessions.
+
+- The acceptance criteria above apply to your slice's changes, not the whole issue at once.
+- Leave the tree green at your boundary: checks (`make test`, `make lint`) run after every slice.
+- Commit your work with the same message quality as below; anything left uncommitted is swept into a generic `slice N/M` commit by the runtime.
+- The runtime pushes each slice and opens the single PR after the final slice — never open a PR yourself.
+
+**PR and commit quality.** A human will review your PR. Make it easy for
+them:
+
+- **Commit messages** should describe what changed and why, not just "implement feature". Use conventional commit format (e.g., `feat: add codex agent detection`).
+- **PR title** should be a clear summary of what the PR does (not the issue title verbatim if it doesn't make sense as a PR title).
+- **PR description** must include:
+  - A summary of what was implemented
+  - Key design decisions you made
+  - How to test the changes
+  - Reference to the source issue (e.g., "Resolves #120")

--- a/.minions/programs/premise-gate.md
+++ b/.minions/programs/premise-gate.md
@@ -1,0 +1,100 @@
+---
+id: premise-gate
+target_repos:
+  - cli
+---
+
+# Premise gate
+
+Decide whether a build may start. This program writes no code and opens
+no pull request. It runs before the implement program, against the tree
+that build is about to modify.
+
+The build is the most expensive stage to waste. Issue #30 reached three
+builds and produced a pull request that improves nothing: measured
+directly, the change it delivers is level with the original on a
+thousand-file repository and roughly thirty to forty percent slower on a
+ten-thousand-file one. Every minute of that was spent after the premise
+had already been false for months.
+
+Research checking the premise earlier does not settle it. A claim that
+was true in March can be false in August, and a build can be triggered
+by hand long after any research ran. This stage gathers the evidence
+again, against the tree in front of it.
+
+## Context
+
+- `cli/.minions/premise-verifier.md`
+- `cli/.minions/stage-gate.md`
+
+## Agents
+
+### premise-checker
+
+```capabilities
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+max_turns: 60
+```
+
+You check the parent issue's premise against the tree in front of you,
+before this build writes anything. Only your verdict decides whether the
+build proceeds.
+
+The repository the claims are about is already checked out in your
+working directory. Read it. Do not decide a claim from the issue text,
+and do not decide it from memory of how similar projects work.
+
+1. Read the parent issue body, which is provided under the "Issue"
+   section of your prompt, and take the `## Premise` section that
+   carries the `<!-- partio:premise:v1 -->` marker. That block is what
+   you verify.
+
+2. Apply `.minions/premise-verifier.md` to that block against the
+   checked-out tree. It describes verification once, for every stage
+   that needs it. Follow it as written — gather the evidence each claim
+   names, then decide, then record the excerpt that decided it. Do not
+   restate its procedure and do not invent your own.
+
+3. Apply `.minions/stage-gate.md` to the verdict it produced. That file
+   describes what a stage does when a premise does not hold, and what it
+   does when it holds. Follow it as written.
+
+4. When the block does not hold, the gate has already labelled the issue
+   and posted the comment naming what you checked and what you found.
+   Stop there. Write no code, produce no further artifact, and do not
+   close the issue. Which label the gate applies, and how the operator
+   overrules it, are the gate's to state — not this program's, and not
+   yours to decide from the issue's current labels. Verify against the
+   tree on every run, whatever labels the issue already carries.
+
+5. When the block holds, refresh the premise section in the parent issue
+   with the evidence you just gathered, and record every claim, the
+   evidence it named, its verdict, and the excerpt that produced it — for
+   a block that holds as well as for one that does not. A build that
+   proceeds carries the evidence it rests on.
+
+   Read the current body, replace the evidence excerpts inside the
+   `## Premise` section with what you read on this run, and keep the
+   section's marker and every claim. Leave the rest of the body untouched
+   — you are refreshing evidence, not rewriting the proposal. Then write
+   the whole body to the shared path and put it back:
+
+   ```
+   REFRESHED_BODY="/tmp/minion-build-body-${MINION_ISSUE_NUMBER:-0}.md"
+   gh issue edit "$MINION_ISSUE_NUMBER" --repo partio-io/cli --body-file "$REFRESHED_BODY"
+   ```
+
+A parent issue whose body carries no `## Premise` section at all is out
+of scope for this program and is not your call to make. Leave the issue
+alone and stop.
+
+Do not create or modify any file in the working directory. Every file
+you write goes under `/tmp`. A file left in the working directory is
+read as build output and turns this check into a pull request, which is
+the outcome this program exists to prevent. Do not run `git`, and do not
+open a PR.

--- a/.minions/programs/propose.md
+++ b/.minions/programs/propose.md
@@ -8,11 +8,45 @@ target_repos:
 
 Scan monitored sources for new content and create feature proposals.
 
-## Steps
+This program runs one agent, `proposer`, as a single one-shot Claude
+session. The agent reads the monitored-source cursors, fetches what is
+new since each cursor, applies the ingest prompt to decide what is
+relevant to this project, and files one proposal per relevant idea as a
+program file plus a GitHub issue. It then advances the cursors and
+commits the result.
+
+The repository for all `gh` calls against this project is
+`partio-io/cli`.
+
+## Context
+
+- `.minions/sources.yaml`
+- `.minions/ingest-prompt.md`
+- `.minions/premise-verifier.md`
+- `.minions/project.yaml`
+
+## Agents
+
+### proposer
+
+```capabilities
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - WebFetch
+max_turns: 80
+```
+
+You are the proposer. Scan the monitored sources for new content and
+create feature proposals. Work through the steps below in order.
 
 1. **Read sources config** from `.minions/sources.yaml` in this repo. It lists changelog URLs, GitHub issue/PR repos, and the `last_version` cursor for each.
 
-2. **Read the ingest prompt** from `.minions/ingest-prompt.md` — it describes the project and how to extract features.
+2. **Read the ingest prompt** from `.minions/ingest-prompt.md` — it describes the project and how to extract features. Read `.minions/premise-verifier.md` as well: it describes how to check a premise against the checked-out tree, and step 4 applies it before anything is filed.
 
 3. **For each source**, fetch new content since `last_version`:
    - **changelog** sources: fetch the URL, find version headers newer than `last_version`
@@ -22,22 +56,66 @@ Scan monitored sources for new content and create feature proposals.
 4. **For each source with new content**, use the ingest prompt to analyze what's relevant to this project. For each relevant feature idea:
    - Generate a kebab-case ID
    - Check if a proposal already exists: `gh issue list --repo <this-repo> --label minion-proposal --search "<feature-id>" --limit 1`
-   - If not, write a program file to `.minions/programs/<id>.md` with frontmatter (id, target_repos, acceptance_criteria, pr_labels) and description
-   - Create a GitHub issue: `gh issue create --repo <this-repo> --label minion-proposal --title "<title>" --body "<description + link to program file + <!-- program: .minions/programs/<id>.md --> marker>"`
+   - Build the premise section from the idea's `premise` field. Use this format exactly:
+
+     ```markdown
+     ## Premise
+
+     <!-- partio:premise:v1 -->
+
+     - <one factual claim this proposal depends on> [evidence: `<path, symbol or command that settles it>`]
+     ```
+
+     One claim per line, and every claim names the path, symbol or command that settles it. A claim you cannot attach evidence to is not filed with an empty field: find the evidence, or drop the idea.
+   - **Verify the premise before you file anything.** This repository is already checked out in your working directory. Apply `.minions/premise-verifier.md` to the premise section you just built, against that tree. Gather the evidence each claim names — read the file, find the symbol, run the command — and decide each claim from what you gathered. The ideas come from a sibling product, so a claim that is true of that product is not thereby true here. Verify it here.
+   - **If the block does not hold, drop the idea.** Write no program file and create no issue for it. A `fails` or `unresolved` verdict is not a pass. Keep the claim, the evidence and the verdict for the summary.
+   - **Record every rejection in `.minions/rejections.md`.** Append one entry per dropped idea. Never rewrite an entry that is already there. Use this format exactly:
+
+     ```markdown
+     ## <what the idea was, in one line>
+
+     <!-- partio:rejection:v1 -->
+
+     - source: `<source name and the item within it>`
+     - reason: `premise-failed`
+     - claim: <the claim that failed> [evidence: `<the path, symbol or command it named>`]
+     - verdict: `fails`
+     - found: <what the evidence actually showed>
+     ```
+
+     The cursor moves past this idea in step 5, so the source item is never offered again. This entry is the only record that the idea was seen at all. Write it for a reader: someone who wants to know whether the bar is set right reads this file and nothing else.
+   - **Record a skipped source item in the same log, under its own reason.** An item the ingest prompt found irrelevant was never an idea, and no claim was ever checked against this repository. Its entry carries no claim, no verdict and no finding — only why it was not about this project:
+
+     ```markdown
+     ## <what the source item proposed, in one line>
+
+     <!-- partio:rejection:v1 -->
+
+     - source: `<source name and the item within it>`
+     - reason: `irrelevant`
+     - note: <why this project has no use for it>
+     ```
+
+     Keep the two kinds apart. A dropped idea was checked and this repository contradicted it; a skipped item was never about this project. A reader who cannot tell them apart cannot tell a bar set too high from a source that has gone quiet, which is the one question this log answers.
+   - If the block holds, write a program file to `.minions/programs/<id>.md` with frontmatter (id, target_repos, acceptance_criteria, pr_labels) and description
+   - Create a GitHub issue: `gh issue create --repo <this-repo> --label minion-proposal --title "<title>" --body "<description + premise section + gathered evidence + link to program file + <!-- program: .minions/programs/<id>.md --> marker>"`
+
+     The gathered evidence is the verifier's output: each claim, the evidence it named, the verdict, and the excerpt that produced it. A proposal that passed the check carries the evidence that passed it.
 
 5. **Update `last_version`** in `.minions/sources.yaml` for each processed source (latest version string for changelogs, highest item number for issues/pulls).
 
-6. **Commit and push** all new program files and the updated sources.yaml:
+6. **Commit and push** all new program files, the updated sources.yaml and the rejection log, in one commit:
    ```bash
-   git add .minions/programs/ .minions/sources.yaml
+   git add .minions/programs/ .minions/sources.yaml .minions/rejections.md
    git commit -m "chore: add minion proposals"
    git push
    ```
 
-7. **Print summary** of what was created.
+   The log and the cursor travel together. The cursor advances past a rejected idea whether or not the log survives, so a commit that carries one without the other loses the idea silently. If this run rejected nothing, the log is unchanged and `git add` stages nothing from it; commit the cursor as usual.
 
-## Context
+7. **Print summary** of what the run did. Report these three outcomes separately, with a count for each:
+   - **filed** — ideas whose premise held. One issue each.
+   - **dropped** — ideas the ingest prompt produced whose premise did not hold. Name the claim, the evidence it named, and the verdict for each one.
+   - **skipped** — source items the ingest prompt found irrelevant to this project. These never became ideas.
 
-- `.minions/sources.yaml`
-- `.minions/ingest-prompt.md`
-- `.minions/project.yaml`
+   A dropped idea and a skipped item are not the same event. An idea was dropped because this repository contradicted it; an item was skipped because it was never about this project. Do not merge the two counts. The cursor advances past both, so this summary is the only place the difference survives the run.

--- a/.minions/programs/research.md
+++ b/.minions/programs/research.md
@@ -10,8 +10,13 @@ Unattended research pipeline for complex `partio-io/cli` issues. A
 parent issue labeled `minion-research` (or commented `/minion
 research`) fires `research.yml`, which runs this program.
 
-This program runs the research → PRD → slice → publish pipeline:
+This program runs the verify → research → PRD → slice → publish
+pipeline:
 
+- `premise-checker` rechecks the parent issue's premise against the
+  checked-out tree before anything is planned, and stops the run when
+  the premise no longer holds. A premise checked at filing time says
+  nothing about the tree months later.
 - `researcher` drives a `/code-research`-style interview against the
   parent issue and writes the questions to a shared transcript.
 - `persona` answers each question the way jcleira would, grounded in
@@ -45,10 +50,17 @@ between agents. State is therefore exchanged through stable paths
 outside any worktree. The stable paths used across agents are:
 
 ```
+PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"
 TRANSCRIPT="/tmp/minion-research-transcript-${MINION_ISSUE_NUMBER:-0}.md"
 PRD_DRAFT="/tmp/minion-research-prd-draft-${MINION_ISSUE_NUMBER:-0}.md"
 SLICES="/tmp/minion-research-slices-${MINION_ISSUE_NUMBER:-0}.md"
 ```
+
+`$PREMISE` carries the premise verdict forward. Every agent after
+`premise-checker` reads its first line and stops immediately unless it
+reads `PREMISE_OK`. That line is how a blocked run produces no plan:
+each agent is its own session, so a stopped stage is every later agent
+declining to work, not one agent returning early.
 
 The parent issue number is in `$MINION_ISSUE_NUMBER`. The parent
 issue body is also provided to every agent under an "Issue" section of
@@ -60,12 +72,97 @@ changes" and the run ends without a PR. That is intended.
 
 ## Context
 
+- `cli/.minions/premise-verifier.md`
+- `cli/.minions/stage-gate.md`
 - `cli/.minions/persona/telos/MISSION.md`
 - `cli/.minions/persona/telos/GOALS.md`
 - `cli/.minions/persona/telos/PROJECTS.md`
 - `cli/.minions/persona/telos/BELIEFS.md`
 
 ## Agents
+
+### premise-checker
+
+```capabilities
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+max_turns: 60
+```
+
+You recheck the parent issue's premise against the tree in front of
+you, before this run plans anything. Issue #30 was filed on 2026-03-26
+and built on 2026-08-10 — four and a half months in which this codebase
+moved underneath it. The proposer's verdict was about March. Yours is
+about today, and only yours decides whether this run continues.
+
+The repository the claims are about is already checked out in your
+working directory. Read it. Do not decide a claim from the issue text,
+and do not decide it from memory of how similar projects work.
+
+1. Read the parent issue body, which is provided under the "Issue"
+   section of your prompt, and take the `## Premise` section that
+   carries the `<!-- partio:premise:v1 -->` marker. That block is what
+   you verify.
+
+2. Apply `.minions/premise-verifier.md` to that block against the
+   checked-out tree. It describes verification once, for every stage
+   that needs it. Follow it as written — gather the evidence each claim
+   names, then decide, then record the excerpt that decided it. Do not
+   restate its procedure and do not invent your own.
+
+3. Apply `.minions/stage-gate.md` to the verdict it produced. That file
+   describes what a stage does when a premise does not hold, and what it
+   does when it holds. Follow it as written.
+
+4. Compute the shared path and write the verdict where the later agents
+   read it:
+
+   ```
+   PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"
+   ```
+
+   Write `$PREMISE` fresh, truncating any stale content from a previous
+   run. Its first line is exactly `PREMISE_OK` when the block holds, and
+   exactly `PREMISE_BLOCKED` when it does not. Below that first line,
+   record every claim, the evidence it named, its verdict, and the
+   excerpt that produced it — for a block that holds as well as for one
+   that does not. A run that passed carries its evidence too.
+
+5. When the block does not hold, the gate has already labelled the
+   issue and posted the comment naming what you checked and what you
+   found. Stop there. Produce no PRD, no slice plan and no further
+   artifact, and do not close the issue. Which label the gate applies,
+   and how the operator overrules it, are the gate's to state — not
+   this program's, and not yours to decide from the issue's current
+   labels. Verify against the tree on every run, whatever labels the
+   issue already carries.
+
+6. When the block holds, refresh the premise section in the parent issue
+   with the evidence you just gathered, so the build stage checks against
+   today's facts rather than the filing-time ones.
+
+   Read the current body, replace the evidence excerpts inside the
+   `## Premise` section with what you read on this run, and keep the
+   section's marker and every claim. Leave the rest of the body untouched
+   — you are refreshing evidence, not rewriting the proposal. Then write
+   the whole body to the shared path and put it back:
+
+   ```
+   REFRESHED_BODY="/tmp/minion-research-body-${MINION_ISSUE_NUMBER:-0}.md"
+   gh issue edit "$MINION_ISSUE_NUMBER" --repo partio-io/cli --body-file "$REFRESHED_BODY"
+   ```
+
+A parent issue whose body carries no `## Premise` section at all is out
+of scope for this program and is not your call to make. Write
+`PREMISE_OK` and continue.
+
+Write only `$PREMISE` and the refreshed issue body. Do not create or
+modify any file in the working directory, do not run `git`, and do not
+open a PR.
 
 ### researcher
 
@@ -78,6 +175,19 @@ tools:
   - Bash
 max_turns: 40
 ```
+
+Before anything else, read the premise verdict and stop unless it
+passed:
+
+```
+PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"
+head -1 "$PREMISE"
+```
+
+If that first line is not exactly `PREMISE_OK`, the premise-checker
+blocked this run. Write nothing, ask nothing, and stop immediately.
+Producing a plan for a premise the tree contradicts is the outcome this
+gate exists to stop.
 
 You are the researcher. Interview the parent issue relentlessly, in
 the spirit of the `/code-research` skill: walk down every branch of
@@ -130,6 +240,17 @@ tools:
 max_turns: 40
 ```
 
+Before anything else, read the premise verdict and stop unless it
+passed:
+
+```
+PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"
+head -1 "$PREMISE"
+```
+
+If that first line is not exactly `PREMISE_OK`, the premise-checker
+blocked this run. Write nothing and stop immediately.
+
 You answer each research question as jcleira would.
 
 Privacy directive (load-bearing — must not be edited away): Use TELOS
@@ -179,6 +300,17 @@ tools:
   - Bash
 max_turns: 20
 ```
+
+Before anything else, read the premise verdict and stop unless it
+passed:
+
+```
+PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"
+head -1 "$PREMISE"
+```
+
+If that first line is not exactly `PREMISE_OK`, the premise-checker
+blocked this run. Write no PRD and stop immediately.
 
 You synthesize the completed research transcript into a PRD body. You
 do NOT interview, ask questions, or modify the transcript — the
@@ -238,6 +370,17 @@ tools:
   - Bash
 max_turns: 20
 ```
+
+Before anything else, read the premise verdict and stop unless it
+passed:
+
+```
+PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"
+head -1 "$PREMISE"
+```
+
+If that first line is not exactly `PREMISE_OK`, the premise-checker
+blocked this run. Write no slice plan and stop immediately.
 
 You decompose the PRD that `prd-writer` produced into vertical slices,
 one block per slice. You do NOT interview, synthesize a new PRD, or
@@ -303,6 +446,20 @@ tools:
   - Bash
 max_turns: 30
 ```
+
+Before anything else, read the premise verdict and stop unless it
+passed:
+
+```
+PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"
+head -1 "$PREMISE"
+```
+
+If that first line is not exactly `PREMISE_OK`, the premise-checker
+blocked this run. Post no comment, add no label, and stop immediately.
+The gate has already posted the comment that explains the block; a
+`minion-research-completed` label on a blocked issue would say the
+opposite of what happened.
 
 You publish the research output: post the PRD as a comment, post the
 slice plan as a second comment, and mark the parent issue as

--- a/.minions/rejections.md
+++ b/.minions/rejections.md
@@ -1,0 +1,5 @@
+# Rejections
+
+Ideas the proposer did not file, and why. Each run appends; nothing here
+is ever rewritten. The cursor has already moved past every item below, so
+this file is the only record that the idea was seen at all.

--- a/.minions/stage-gate.md
+++ b/.minions/stage-gate.md
@@ -1,0 +1,87 @@
+# Stage gate
+
+<!-- partio:stage-gate:v1 -->
+
+What a stage does with a premise verdict is described here, once. The research
+and implement programs apply this description. They do not each invent a way to
+stop, and they do not restate the procedure below.
+
+Verification is a separate description: `.minions/premise-verifier.md` decides
+whether each claim holds. This file starts from its verdict.
+
+A premise is checked at every stage, against the tree in front of that stage.
+A claim that was true when the issue was filed can be false months later, so no
+stage trusts an earlier stage's verdict. Each one gathers the evidence again.
+
+## Inputs
+
+1. **A verdict for the block**, from `.minions/premise-verifier.md`: `holds`,
+   `fails` or `unresolved`, plus every claim, the evidence it named, and the
+   excerpt that produced its verdict.
+2. **The issue** the premise belongs to, in `$MINION_ISSUE_NUMBER`.
+
+## When the premise does not hold
+
+`fails` and `unresolved` both stop the stage. A claim nothing settled has not
+been checked, so it is not a pass.
+
+1. **Stop before you produce anything.** No PRD, no slice plan, no branch, no
+   pull request. The stage ends here.
+2. **Add the `do-not-build` label** to the issue. The approval program already
+   treats this label as a skip condition, so blocking needs no new label:
+
+   ```
+   gh issue edit "$MINION_ISSUE_NUMBER" --repo partio-io/cli --remove-label do-not-build
+   gh issue edit "$MINION_ISSUE_NUMBER" --repo partio-io/cli --add-label do-not-build
+   ```
+
+   Remove it first, every time, including when the issue does not carry it — a
+   label that is already present fires no fresh trigger, so adding it twice
+   leaves the pipeline silent and the operator with no signal that this run
+   also blocked. `--remove-label` on an issue without the label is not an error.
+3. **Post one comment saying what you checked and what you found.** This
+   comment is the operator's whole account of the decision. Its first line is
+   exactly the marker:
+
+   ```
+   <!-- partio:premise-gate:v1 -->
+   ```
+
+   Then, for every claim you checked, whichever way it went — and whether it
+   came from a block or was extracted from the issue prose:
+
+   - the claim, word for word
+   - the evidence the claim named
+   - the verdict for that claim
+   - the excerpt that produced it — the path and the lines you read, or the
+     command and the output it printed
+
+   Name the claims that failed and the evidence that contradicted them. A
+   verdict with nothing behind it is the prose assertion the premise block
+   replaced.
+4. **Do not close the issue.** Do not add `minion-done`. The operator decides
+   what happens to a blocked proposal; the stage only reports.
+
+## How the operator overrules
+
+The operator removes the `do-not-build` label. That is the whole mechanism.
+
+A stage never reads the label as a decision it can trust. It re-verifies
+against the current tree on every run and reaches its own verdict, so a wrong
+verdict is corrected by removing the label and running again, and a correct one
+is reached again from the same evidence.
+
+## When the premise holds
+
+1. **Refresh the premise block in the issue**, but only if the issue carries
+   one, with the evidence you just gathered, so the next stage checks against
+   today's facts rather than the ones the proposer recorded. Keep the
+   `## Premise` section and its `<!-- partio:premise:v1 -->` marker; replace the
+   evidence excerpts with what this run read.
+
+   An issue with no block gets none. You extracted its claims from its prose,
+   and that extraction is not written back: leave the body as the operator
+   wrote it and record the evidence in step 2 instead.
+2. **Record the verdict.** A run that passed carries its evidence too — the
+   claims, the evidence, the `holds` verdict, and the excerpts behind it.
+3. **Continue.** Only a block that `holds` lets the stage go on.

--- a/docs/2026-08-13-proposal-premise-gate/issues.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues.md
@@ -1,0 +1,42 @@
+# Issues — 2026-08-13-proposal-premise-gate
+
+Source: [prd.md](./prd.md)
+
+| Done | # | Title | Blocked by |
+|------|---|-------|------------|
+| [x]  | 1 | [Program shape check](./issues/01-program-shape-check.md) | None |
+| [x]  | 2 | [Propose instructions reach the model](./issues/02-propose-instructions-reach-model.md) | [#1](./issues/01-program-shape-check.md) |
+| [x]  | 3 | [Proposals carry a premise](./issues/03-proposals-carry-premise.md) | [#2](./issues/02-propose-instructions-reach-model.md) |
+| [x]  | 4 | [The proposer checks before it files](./issues/04-proposer-checks-before-filing.md) | [#3](./issues/03-proposals-carry-premise.md) |
+| [x]  | 5 | [Rejected ideas leave a record](./issues/05-rejection-log.md) | [#4](./issues/04-proposer-checks-before-filing.md) |
+| [x]  | 6 | [Research rechecks and refreshes](./issues/06-research-rechecks-premise.md) | [#4](./issues/04-proposer-checks-before-filing.md) |
+| [x]  | 7 | [The build refuses a stale premise](./issues/07-build-refuses-stale-premise.md) | [#4](./issues/04-proposer-checks-before-filing.md) |
+| [x]  | 8 | [Older proposals are not exempt](./issues/08-legacy-proposals-checked.md) | [#4](./issues/04-proposer-checks-before-filing.md) |
+
+## User story coverage
+
+| Slice | PRD stories |
+|---|---|
+| 1 | 20, 21, 30 |
+| 2 | 19, 24 |
+| 3 | 1, 2, 26 |
+| 4 | 3, 4, 15, 22, 23 |
+| 5 | 12, 13, 14, 34 |
+| 6 | 5, 7, 8, 9, 10, 11, 25, 26, 27, 29 |
+| 7 | 6, 7, 8, 9, 10, 11, 28, 29 |
+| 8 | 16, 17, 18 |
+
+**Not covered by any slice: stories 31, 32, 33.** They describe the
+first-commit attribution fix and the benchmark baseline that belong to
+the separate issue #30 salvage, which the PRD's Out of Scope section
+names as its own work. The gap is recorded here so it stays visible
+rather than reading as covered.
+
+## Notes
+
+- Slices 5, 6, 7 and 8 all depend only on slice 4, so once the verifier
+  exists they can proceed in parallel or in any order.
+- No slice requires a human handoff. Every slice is verifiable by the
+  session that builds it, using `make test` or a dry run of the program
+  it changes.
+- Do not commit or push. That stays with the operator.

--- a/docs/2026-08-13-proposal-premise-gate/issues/01-program-shape-check.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/01-program-shape-check.md
@@ -1,0 +1,72 @@
+# 01 — Program shape check
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+A test that fails when a minion program hides its instructions in a
+section the program format discards.
+
+Background you need, because it is not obvious from the files: the
+minions program parser keeps only four things from a program's Markdown
+body — the H1 heading and the prose directly under it, a `## Context`
+section, a `## Planner` section, and a `## Agents` section with its H3
+sub-sections. Every other heading and its body are dropped silently. If
+a program defines no agents, the executor synthesizes one whose entire
+instruction set is the prose under the H1.
+
+The practical effect is that a program written with a `## Steps`
+section runs on one or two sentences and improvises the rest. Four
+programs in this repository are in that state today.
+
+The test reads every program in the repository's minions programs
+directory and fails any that carries instruction-bearing content in a
+dropped section. Programs already known to be broken are recorded as
+accepted so the suite is green on arrival; the point is to stop new
+ones appearing and to give later slices a checklist to work down.
+
+When it fails it must name the offending program and the heading that
+was dropped, so the fix needs no bisecting of format rules.
+
+## User stories covered
+
+PRD stories 20, 21, 30.
+
+## Acceptance criteria
+
+- [x] A Go test reads every `.md` program in the minions programs directory of this repo
+- [x] The test fails a program that has instruction content under a heading the parser drops and no `## Agents` section
+- [x] The test passes a program that carries its instructions in an `## Agents` section
+- [x] The test passes a program whose entire instruction set is the prose under the H1, since that text does reach the model
+- [x] A failure message names the offending program file and the dropped heading
+- [x] The four currently-broken programs are recorded as accepted exceptions in one obvious place, each with a one-line reason
+      — the scan found **eight**, not four: the five `## Steps` programs (the
+      four named in the PRD's Out of Scope, plus `propose.md`) and three
+      `e2e-*` feature programs the PRD never counted. All eight are in
+      `knownUnreachable` with a one-line reason.
+- [x] Adding a new program with a `## Steps` section and no `## Agents` section turns the suite red
+- [x] `make test` and `make lint` pass
+
+## Modules touched
+
+`program-shape-test`.
+
+## Test prior art
+
+- Table-driven tests using only the standard library `testing` package,
+  with `t.TempDir()` for filesystem isolation — the house pattern
+  described in this repo's `CLAUDE.md` and used throughout `internal/`.
+- The minions engine repository has parser tests covering section
+  handling in its program package; they are the closest model for how
+  to structure cases around heading levels.
+
+## Out of scope
+
+- Fixing any of the four broken programs. Slice 2 fixes the propose
+  program; the other three are named in the PRD's Out of Scope section
+  and left for separate work.
+- Changing the minions engine or its parser. This test encodes the
+  parser's existing behaviour; it does not alter it.
+- Validating anything about a program's content beyond where its
+  instructions live.

--- a/docs/2026-08-13-proposal-premise-gate/issues/02-propose-instructions-reach-model.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/02-propose-instructions-reach-model.md
@@ -1,0 +1,79 @@
+# 02 — Propose instructions reach the model
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [01 — Program shape check](./01-program-shape-check.md)
+
+## What to build
+
+Make the propose program actually run the workflow it describes.
+
+Today the propose program carries seven numbered steps under a
+`## Steps` heading and defines no agents. The parser discards that
+section, so the executor synthesizes a single implicit agent whose
+whole instruction set is the one sentence under the H1 — "Scan
+monitored sources for new content and create feature proposals." — plus
+the file paths listed under `## Context`. The steps that tell it to
+apply the ingest prompt, to check whether a proposal already exists, to
+advance the source cursor, and to commit the result never reach the
+model at all. It reads the three context files and invents the rest.
+
+Move those instructions into an `## Agents` section, which the format
+does carry, so the program behaves as written. This is a faithful
+move, not a redesign: the workflow stays what the steps already
+describe. Later slices change what the workflow does.
+
+Once the program is fixed, drop it from the accepted-exceptions list
+that slice 1 established.
+
+## User stories covered
+
+PRD stories 19, 24.
+
+## Acceptance criteria
+
+- [x] The propose program defines an `## Agents` section carrying its full workflow
+      — one agent, `proposer`.
+- [x] Every instruction previously under `## Steps` survives the move, with no step silently lost
+      — all seven steps kept verbatim, including every `gh` and `git`
+      command; verified by 14 literal probes against the rendered prompt.
+- [x] The program no longer contains an instruction-bearing dropped section
+- [x] The propose program is removed from slice 1's accepted-exceptions list, and the shape test still passes
+- [x] A dry run of the program renders a prompt that visibly contains the workflow instructions
+- [x] The rendered prompt is materially longer than before the change, confirming the instructions now reach the model
+      — `AGENTS: 0` → `AGENTS: 1`; total prompt 5307 → 7587 chars; the
+      agent instruction component 68 → 1905 chars, a 28× increase.
+- [x] The agent is granted the tools the workflow needs, including reading files and running shell commands
+      — Read, Write, Edit, Glob, Grep, Bash, WebFetch; the engine joins
+      the list into the session's `--allowedTools`.
+- [x] No change is made to the minions engine, so no release, tag or version pin bump is required
+      — the engine repository is clean; it was read, never edited.
+- [x] `make test` and `make lint` pass
+
+## Modules touched
+
+`propose-program`, `program-shape-test`.
+
+## Test prior art
+
+- Slice 1's shape test is the automated guard for this change; it
+  should go green for the propose program without an exception entry.
+- Programs already written correctly in this repository — the research,
+  implement, checks-fix and audit programs — are the reference for how
+  an `## Agents` section is laid out, what an agent definition carries,
+  and how tools and turn limits are declared.
+
+## Out of scope
+
+- Changing what the proposer does. Premise emission is slice 3,
+  verification is slice 4, and the rejection log is slice 5.
+- The ingest prompt's content. It is a template read as context, not a
+  parsed program, so it is untouched here.
+- The approval, ingest, documentation-update and readme-update
+  programs. They share the defect and stay on the exceptions list.
+
+## Verification note
+
+A dry run renders the prompt without creating issues or pushing. Use it
+rather than waiting for the twice-daily schedule, and read the rendered
+prompt directly — the character count alone is the signal that
+instructions are now included.

--- a/docs/2026-08-13-proposal-premise-gate/issues/03-proposals-carry-premise.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/03-proposals-carry-premise.md
@@ -1,0 +1,95 @@
+# 03 — Proposals carry a premise
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [02 — Propose instructions reach the model](./02-propose-instructions-reach-model.md)
+
+## What to build
+
+Give every filed proposal a machine-checkable statement of what it
+believes about this repository.
+
+A proposal today states its case in prose. Issue #30 opened with
+"Partio's post-commit hook currently performs a full tree walk… O(N) in
+the number of tracked files". That sentence is false here, and nothing
+downstream could tell, because prose cannot be rechecked.
+
+Add a premise section to every proposal the program files. It lists the
+factual claims the proposal depends on, one per line, and pairs each
+with the evidence that settles it — a path, a symbol, or a command
+whose output decides the matter. A later stage needs nothing but this
+block in order to recheck; it does not have to parse the surrounding
+prose.
+
+The ingest prompt's output schema grows the matching fields, so the
+model producing feature ideas produces claims and evidence alongside
+them rather than having them bolted on afterwards.
+
+This slice establishes the format and emits it. Verifying the claims
+is slice 4.
+
+## User stories covered
+
+PRD stories 1, 2, 26.
+
+## Acceptance criteria
+
+- [x] The ingest prompt's output schema carries the premise claims and the evidence for each
+      — `.minions/ingest-prompt.md` grows a `premise` array of
+      `{claim, evidence}`; the test unmarshals the schema and asserts both
+      fields.
+- [x] Every proposal the program files contains a premise section
+      — the `gh issue create` body in `propose.md` now composes the premise
+      section in; the guard test was confirmed red without that edit.
+- [x] Each claim occupies one line and names the path or command that proves it
+      — the claim line is ``- <statement> [evidence: `<path or command>`]``;
+      a claim continued onto a second line, and prose inside the section,
+      are both rejected.
+- [x] A claim with no evidence attached is rejected rather than filed with an empty field
+      — `Render` returns `ErrNoEvidence` and emits nothing; `Parse` returns
+      `ErrNoEvidence` for a missing, empty or blank evidence field.
+- [x] The section is placed and headed consistently, so a later stage can find it without guessing
+      — `## Premise` plus the `<!-- partio:premise:v1 -->` marker; `Find`
+      locates it anywhere in a body, stops at the next `##` heading, and
+      refuses a hand-written heading that carries no marker.
+- [x] A dry run shows the premise section in the issue body the program would create
+      — `minions run .minions/programs/propose.md --dry-run`, run against the
+      pinned `v0.0.13` that CI installs, renders `AGENTS: 1`, the premise
+      template at lines 49-53, and the `gh issue create` body that composes
+      the section in.
+- [x] The premise of issue #30 is captured as a fixture, since it is a known-false claim with known evidence
+      — `internal/premise/testdata/issue-30.md` holds its two claims; the
+      test parses them and confirms each evidence path exists in this
+      repository. Verifying the claims stays with slice 4.
+- [x] Existing proposal behaviour is otherwise unchanged — same title, body and labels
+      — a guard test pins the repo, label, title, description, program-file
+      link and program marker on the `gh issue create` line, plus the
+      duplicate check and the program-file write. It passed on arrival: the
+      premise section is an addition, and nothing was removed.
+- [x] `make test` and `make lint` pass
+      — both exit 0; `golangci-lint` reports 0 issues.
+
+## Modules touched
+
+`premise-block`, `ingest-prompt`, `propose-program`.
+
+## Test prior art
+
+- Table-driven standard-library tests with `t.TempDir()`, the house
+  pattern in this repository.
+- Slice 1's shape test is the model for a test that reads repository
+  files and asserts something about their structure; a premise-block
+  test is the same shape applied to issue bodies rather than programs.
+
+## Out of scope
+
+- Verifying that a claim is true. That is slice 4.
+- Backfilling a premise onto the 534 existing proposals. Slice 8
+  handles pre-block proposals by reading their prose instead.
+- Stopping or gating anything. No slice before 6 changes what happens
+  when a premise is wrong.
+
+## Verification note
+
+Use a dry run to inspect the issue body the program would file. Do not
+wait for the twice-daily schedule, and do not create real issues to
+test the format.

--- a/docs/2026-08-13-proposal-premise-gate/issues/04-proposer-checks-before-filing.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/04-proposer-checks-before-filing.md
@@ -1,0 +1,123 @@
+# 04 — The proposer checks before it files
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [03 — Proposals carry a premise](./03-proposals-carry-premise.md)
+
+## What to build
+
+Make the proposer read this repository before it describes this
+repository, and file only ideas whose premise survives.
+
+The source tree is already checked out when the proposer runs — the
+workflow checks it out and then never looks at it. The proposer draws
+feature ideas from a sibling product's changelog and issue list, and
+asserts that product's problems as this product's problems. That is how
+a proposal came to describe a tree walk this codebase has never had.
+
+This slice defines verification once and uses it here: given a premise
+block and a checked-out tree, gather the evidence each claim names and
+produce a verdict plus what was found. Claims that hold let the idea
+through. Claims that fail drop the idea before it becomes an issue.
+
+Verification is described as a single behaviour, not copied per
+caller — slices 6, 7 and 8 reuse it without re-deciding what
+verification means.
+
+The ingest prompt also gains its grounding rule here: a claim must be
+grounded in the checked-out tree, not inferred from the source
+material. Adaptation from a sibling product stays the goal; importing
+its premises does not.
+
+Volume falls as a result of this slice. That is the intended mechanism —
+the operator chose to raise the bar at the source rather than cap
+output or prune the backlog.
+
+## User stories covered
+
+PRD stories 3, 4, 15, 22, 23.
+
+## Acceptance criteria
+
+- [x] Verification is described once as a single behaviour: premise block plus checked-out tree in, verdict plus evidence out
+      — `.minions/premise-verifier.md`, marked `<!-- partio:premise-verifier:v1 -->`,
+      states the two inputs, the gather-then-decide procedure, and the closed
+      verdict set. `internal/premise/verifier.go` holds the shared contract
+      (`VerifierPath`, `VerifierMarker`, `Holds`/`Fails`/`Unresolved`). A test
+      walks `.minions/` and fails if a second file carries the marker, so a
+      caller cannot paste its own copy.
+- [x] The proposer gathers the evidence each claim names before deciding
+      — the verifier's procedure covers all three evidence kinds the claim
+      grammar admits (path, symbol, command) and sits ahead of the verdict
+      section; the proposer is told the tree is already checked out. That last
+      assertion was red before the propose-program edit.
+- [x] An idea whose premise fails is not filed as an issue
+      — the proposer's steps are ordered verify → drop → write program file →
+      `gh issue create`, and the drop step states no program file and no issue.
+      The test was confirmed red on ordering before the token was made specific.
+- [x] An idea whose premise holds is filed, carrying the evidence that was
+      gathered — the `gh issue create` body now composes in `gathered evidence`
+      alongside the premise section.
+- [x] The ingest prompt requires each claim to be grounded in the checked-out
+      tree rather than the source material — a grounding rule sits next to the
+      existing `premise` rule under `## Instructions`. Confirmed red first: the
+      prompt mentioned neither the tree nor the source material.
+- [x] The issue #30 premise fixture is verified as false against this
+      repository — both claims verify as `fails`. The hook names changed files
+      with `git.DiffNameOnly(commitHash)` and contains no `filepath.Walk`,
+      `filepath.WalkDir`, `os.ReadDir` or `ls-files`; `attribution.Calculate`
+      iterates `git.DiffNumstat` output, which carries one line per changed
+      file, not per tracked file. The test re-reads both files on every run, so
+      the record cannot rot into a stale comment.
+- [x] A claim that genuinely holds for this repository is verified as true, so
+      the bar does not reject everything — `testdata/holds.md` claims
+      attribution is binary; `internal/attribution/calculate.go` sets
+      `result.AgentPercent = 100` under `if agentActive`, so it verifies as
+      `holds`. Both fixtures run in one table, so the passing direction cannot
+      be dropped without the failing one noticing.
+- [x] A source item that is simply irrelevant is still skipped, and is
+      distinguishable from one dropped for a false premise — the run summary
+      now reports `filed`, `dropped` and `skipped` as three separate counts,
+      and a dropped idea names its claim, evidence and verdict. The ingest
+      prompt's existing skip rule is pinned so raising the premise bar cannot
+      turn "not relevant" into "rejected". Confirmed red on all three counts.
+- [x] The agent has the tools it needs to read files and run commands in the
+      checked-out tree — `Read`, `Glob`, `Grep` and `Bash` were already
+      granted; a test now pins them so a later edit cannot narrow the grant
+      silently. `max_turns` was raised from 40 to 80, because verification adds
+      several tool calls per idea and the old budget would truncate a run.
+- [x] `make test` and `make lint` pass
+      — both exit 0; `golangci-lint` reports 0 issues. The slice-1 shape test
+      still passes, so the new propose-program prose reaches the model.
+      `minions run .minions/programs/propose.md --dry-run` renders `AGENTS: 1`
+      and the whole instruction set, including the verify step, the drop rule
+      and the three-outcome summary.
+
+## Modules touched
+
+`premise-verifier`, `ingest-prompt`, `propose-program`.
+
+## Test prior art
+
+- Table-driven standard-library tests with `t.TempDir()` to build a
+  small repository fixture and assert a verdict against it. This repo
+  already exercises real git invocations against temporary
+  repositories in its git package tests, which is the closest prior
+  art for evidence-gathering that shells out.
+- Slice 3's premise-block fixture supplies the known-false case.
+
+## Out of scope
+
+- Recording what was rejected. That is slice 5, and until it lands a
+  dropped idea leaves no trace beyond the run output.
+- Any gating in the research or build stages. Those are slices 6 and 7.
+- Proposals filed before the block format existed. That is slice 8.
+- Capping proposals per run or closing any of the 534 existing
+  proposals. Both are named in the PRD's Out of Scope section.
+
+## Verification note
+
+Use a dry run against real source content so the verdicts are produced
+from genuine material rather than a hand-written premise. Confirm both
+directions — something correctly dropped and something correctly
+filed — because a bar that rejects everything looks identical to a
+working one until you check.

--- a/docs/2026-08-13-proposal-premise-gate/issues/05-rejection-log.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/05-rejection-log.md
@@ -1,0 +1,109 @@
+# 05 — Rejected ideas leave a record
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [04 — The proposer checks before it files](./04-proposer-checks-before-filing.md)
+
+## What to build
+
+Write down what the proposer threw away, and why.
+
+Slice 4 makes the proposer drop ideas. The run that drops an idea also
+advances the cursor that tracks how far it has read each source, so the
+source item is never revisited. Without a record, a dropped idea is
+gone with no trace, and a bar set too high is indistinguishable from a
+source that has gone quiet.
+
+Append each rejection to a log the run commits alongside the cursor
+update it already performs. Each entry carries enough to judge the
+decision later: what the idea was, where it came from, and the reason
+it was dropped — a failed claim with the evidence that killed it, or
+simple irrelevance.
+
+This is the only surface that shows whether the gate is catching the
+right things, so it is written for reading, not just for auditing.
+
+## User stories covered
+
+PRD stories 12, 13, 14, 34.
+
+## Acceptance criteria
+
+- [x] Each rejected idea appends an entry to a log file in this repository
+      — `internal/rejection` defines `LogPath = .minions/rejections.md` and
+      `Append`, which creates the log on the first rejection ever recorded and
+      appends below it after that. The propose program gains a record step next
+      to its existing drop rule.
+- [x] An entry records the idea, its source, and the reason it was dropped
+      — all three are required. `Append` refuses an entry missing any of them,
+      or carrying a reason outside `Reasons`, and returns before it opens the
+      log, so a refused entry leaves no half-written block behind.
+- [x] A rejection caused by a failed claim records the claim and the evidence
+      that contradicted it — a `premise-failed` entry must carry the claim, the
+      evidence the claim named, a verdict that rejects, and what the evidence
+      actually showed. Confirmed red first: `Render` accepted an empty claim and
+      wrote an unreadable entry. A `holds` verdict is refused too, because a
+      claim the tree confirmed did not cause the rejection.
+- [x] A rejection caused by irrelevance is distinguishable from one caused by a
+      failed premise — the difference is structural, not a label. An
+      `irrelevant` entry must carry a note and must carry no claim, no verdict
+      and no finding; `Append` refuses one that does. The proposer is shown both
+      entry formats. Confirmed red first, twice: the first version of the test
+      passed on the word "irrelevant" already sitting in the run summary, so it
+      was tightened to the exact reason field the parser reads, which the
+      program did not yet carry.
+- [x] The log is committed by the same run that advances the source cursor, so
+      a dropped idea is never lost silently — one `git add` stages the log, the
+      cursor and the program files, and the run makes exactly one commit. The
+      cursor advance is pinned ahead of that commit. This criterion was already
+      satisfied by the tracer-bullet edit; the single-commit and ordering
+      assertions are added guards, not new behaviour.
+- [x] Entries append rather than overwrite, so history accumulates across runs
+      — three successive appends, each asserting the previous log is still a
+      byte prefix of the new one, plus the header appearing exactly once and
+      entries reading back oldest first. Proved by mutation: swapping
+      `os.O_APPEND` for `os.O_TRUNC` fails the test at run 2.
+- [x] A run that rejects nothing leaves the log unchanged and still commits
+      cleanly — the log is staged unconditionally, so it must exist:
+      `git add` on a never-created path fails and takes the cursor commit down
+      with it, on every run rather than only quiet ones. Confirmed red first —
+      `.minions/rejections.md` did not exist. It now ships with its header, and
+      the program tells the agent to commit the cursor as usual when it rejected
+      nothing.
+- [x] A dry run writes and commits nothing — every write, `git add`,
+      `git commit` and `git push` is pinned inside the `## Agents` steps and
+      absent from the program body, so the runner performs none of them.
+      Verified for real: `minions run .minions/programs/propose.md --dry-run`
+      exits 0 and renders `AGENTS: 1` plus both entry formats, with
+      `git status --porcelain -uall` and `git rev-parse HEAD` identical either
+      side.
+- [x] `make test` and `make lint` pass
+      — both exit 0. All 18 packages pass with no FAIL lines, and
+      `golangci-lint` reports 0 issues. Two issues it did raise on the new
+      package were fixed: an unchecked `f.Close` on the log write handle, which
+      can lose the entry just written, and a regex that escaped twice.
+
+## Modules touched
+
+`rejection-log`, `propose-program`.
+
+## Test prior art
+
+- Table-driven standard-library tests with `t.TempDir()` for the
+  append-and-read behaviour.
+- The proposer already commits the source cursor file in the same run;
+  that existing commit step is the pattern the log follows rather than
+  introducing a second commit.
+
+## Out of scope
+
+- Any user interface over the log. It is a file, read directly.
+- Re-proposing something previously rejected. The cursor still moves
+  past it; recovering an idea from the log is a manual act.
+- Pruning or rotating the log. It accumulates.
+- Changing what gets rejected. That behaviour is slice 4's.
+
+## Verification note
+
+Run a dry run first to confirm nothing is written or committed, then a
+real run to confirm the entry lands and the commit carries both the log
+and the cursor.

--- a/docs/2026-08-13-proposal-premise-gate/issues/06-research-rechecks-premise.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/06-research-rechecks-premise.md
@@ -1,0 +1,136 @@
+# 06 — Research rechecks and refreshes
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [04 — The proposer checks before it files](./04-proposer-checks-before-filing.md)
+
+## What to build
+
+Make the research stage verify a proposal's premise before it plans
+anything, and stop when the premise no longer holds.
+
+Checking once at filing time is worthless by the time a build runs.
+Issue #30 was filed on 2026-03-26 and built on 2026-08-10 — four and a
+half months in which the codebase moved underneath it. A claim that was
+true in March can be false in August, so every stage rechecks against
+the tree in front of it.
+
+Research reuses the verification behaviour defined in slice 4. It does
+not carry its own idea of what verification means.
+
+When the premise fails, the stage stops: it adds the blocking label the
+pipeline already understands, comments the claims it checked and the
+evidence that contradicted them, and ends without planning. It does not
+close the issue — the operator decides what happens next, and can
+overrule by removing the label. Nothing here changes state the operator
+has not seen.
+
+When the premise holds, research refreshes the block with the evidence
+it just gathered, so the build stage checks against the newest facts
+rather than the filing-time ones. A holding verdict is recorded too, so
+a green plan carries its evidence.
+
+## User stories covered
+
+PRD stories 5, 7, 8, 9, 10, 11, 25, 26, 27, 29.
+
+## Acceptance criteria
+
+- [x] The research stage verifies the premise before producing any plan
+      — a new `premise-checker` agent runs first in `.minions/programs/research.md`.
+      The tracer-bullet test pins the verifier reference ahead of all four
+      producing agents (`researcher`, `prd-writer`, `slicer`, `publisher`), so
+      an agent reordered in front of the check fails the build. Confirmed red
+      first: the gate contract did not compile.
+- [x] Verification reuses the behaviour from slice 4 rather than restating it
+      — the checker is told to apply `.minions/premise-verifier.md` "as
+      written". A test fails if the research program carries either
+      `VerifierMarker` or `GateMarker`, which is what a pasted copy looks like.
+      Green on arrival, so proved by mutation: appending the gate marker to the
+      program fails both this test and `TestGatingIsDescribedOnce`.
+- [x] A failed premise adds the existing `do-not-build` label
+      — `internal/premise/gate.go` holds `BlockingLabel`, and the test scans
+      every `--add-label` in the gate's failing path and rejects any label that
+      is not it. Proved by mutation: renaming the label to `premise-blocked`
+      fails the test.
+- [x] A failed premise posts a comment naming the claims checked and the
+      evidence found — the comment opens with `GateCommentMarker` and carries,
+      per claim, the claim word for word, the evidence it named, the verdict,
+      and the excerpt behind it, including for claims that held. Proved by
+      mutation: replacing "the evidence that contradicted them" with "the
+      reason" fails the test.
+- [x] A failed premise stops the stage, and no plan is produced
+      — each agent is its own session in a discarded worktree, so there is no
+      early return to take. The checker writes `PREMISE_BLOCKED` or
+      `PREMISE_OK` to a stable `/tmp` path, and every later agent reads it
+      first and stops. The test enumerates the agent headings rather than a
+      fixed list, so an agent added later without the check fails: appending a
+      `### summarizer` with no gate read produced three failures.
+- [x] The stage never closes the issue
+      — no `gh issue close` and no `--add-label minion-done` anywhere in the
+      research program, and the gate forbids both. Proved by mutation:
+      appending a `gh issue close` line fails the test.
+- [x] Removing the label lets a subsequent run proceed, so the operator can
+      overrule a wrong verdict — the override works because no stage stores a
+      verdict: the program never names the label at all, so it cannot skip on
+      it, and re-verifies against the tree on every run whatever labels the
+      issue carries. Confirmed red first — the checker named `do-not-build`
+      itself, which is exactly the read that would let a later edit turn the
+      label into a skip condition. The gate also removes the label before
+      adding it, because a label already present fires no fresh trigger and a
+      repeat block would otherwise be silent.
+- [x] A holding premise is refreshed in the issue with the newly gathered
+      evidence — the checker rewrites the `## Premise` section with what this
+      run read, keeps the marker and every claim, and leaves the rest of the
+      body alone. Confirmed red first, and it caught a real defect: the refresh
+      called `gh issue edit --body-file "$REFRESHED_BODY"` with nothing setting
+      that variable, which at run time expands to the empty string and
+      overwrites the issue body with nothing. The test now checks every shell
+      variable the checker expands against the ones the program assigns.
+- [x] A holding premise records what was verified, so a successful run carries
+      its evidence — `$PREMISE` records every claim, its evidence, its verdict
+      and the excerpt behind it for a block that holds as well as one that does
+      not. Confirmed red first: the excerpt was not recorded on the passing
+      path.
+- [x] The research program's instructions live where the parser carries them,
+      and the shape test stays green — every addition sits in `## Agents` prose,
+      the H1 prose, or `## Context`; nothing was added under a `## Steps`
+      heading, which the runner drops. `go test ./internal/programshape/` passes.
+      Verified for real: `minions run .minions/programs/research.md --dry-run`
+      renders `AGENTS: 6` with `premise-checker` first at 3425 chars of
+      instructions, and carries both `cli/.minions/premise-verifier.md` (2758
+      chars) and `cli/.minions/stage-gate.md` (3617 chars) into every agent.
+- [x] `make test` and `make lint` pass
+      — both exit 0. All 18 packages pass with no FAIL lines, and
+      `golangci-lint` reports 0 issues.
+
+## Modules touched
+
+`stage-gate`, `premise-verifier`, `research-program`, `premise-block`.
+
+## Test prior art
+
+- Slice 4's verifier fixtures supply the known-false and known-true
+  premises; this slice reuses them rather than inventing new ones.
+- The research program already writes structured comments that a
+  downstream parser reads strictly. Treat the comment this slice adds
+  with the same care: a format change there has broken a build before.
+
+## Out of scope
+
+- The build stage's own check. That is slice 7, and it repeats this
+  behaviour rather than depending on it.
+- Proposals that carry no premise block. That is slice 8.
+- Changing how research slices a plan, or the format of the slice plan
+  comment.
+- Closing, labelling or otherwise touching the 534 existing proposals
+  ahead of time.
+
+## Verification note
+
+The label the gate applies is `do-not-build`, chosen because the
+approval program already treats it as a skip condition. Do not
+introduce a new label.
+
+Be careful when re-running: a label already present on an issue does
+not fire a fresh trigger, so a re-run needs the label removed and added
+again rather than added twice.

--- a/docs/2026-08-13-proposal-premise-gate/issues/07-build-refuses-stale-premise.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/07-build-refuses-stale-premise.md
@@ -1,0 +1,149 @@
+# 07 — The build refuses a stale premise
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [04 — The proposer checks before it files](./04-proposer-checks-before-filing.md)
+
+## What to build
+
+Make the build stage verify the premise before it writes any code, and
+refuse to open a pull request for work already known to be void.
+
+This is the last gate and the most expensive one to skip. Issue #30
+reached three builds and produced a pull request that improves nothing:
+measured directly, the change it delivers is level with the original on
+a thousand-file repository and roughly thirty to forty percent slower
+on a ten-thousand-file one. Every minute of that was spent after the
+premise had already been false for months.
+
+The build stage reuses the verification behaviour from slice 4 and the
+stop behaviour from slice 6 — the same label, the same comment shape,
+the same refusal to close the issue. It checks against the tree it is
+about to modify, which is the whole reason this repeats rather than
+trusting the research stage's earlier verdict.
+
+A holding premise records what was verified before the build proceeds,
+so a pull request carries the evidence its work rests on.
+
+## User stories covered
+
+PRD stories 6, 7, 8, 9, 10, 11, 28, 29.
+
+## Acceptance criteria
+
+- [x] The build stage verifies the premise before writing any code
+      — the premise is checked by its own program, `.minions/programs/premise-gate.md`,
+      which `.github/workflows/minion.yml` runs in a step ahead of the one that
+      runs `implement.md`. The tracer-bullet test compares step positions rather
+      than positions in the file, because the build program's path is named in an
+      earlier `Determine program` step than the step that runs it. Confirmed red
+      first: the gate program did not exist.
+- [x] Verification reuses the behaviour from slice 4
+      — the gate program's `### premise-checker` names `.minions/premise-verifier.md`
+      and applies it "as written", and the program carries neither `VerifierMarker`
+      nor `GateMarker`, which is what a pasted copy looks like. Proved by mutation:
+      dropping "as written" fails the test. A dry run shows both shared documents
+      arriving in `## Pre-Read Context` in full, 7848 characters.
+- [x] The stop behaviour matches slice 6 — same label, same comment shape
+      — one test covers both programs at once: each must reference `GatePath`, and
+      neither may carry `GateMarker`, `BlockingLabel` or `GateCommentMarker`. The
+      label, the comment marker and the override all reach the agent from
+      `stage-gate.md`, confirmed in the rendered dry run. `stage-gate.md` needed no
+      edit: it already reads "The research and implement programs apply this
+      description". Proved by mutation: naming the label in the program fails this
+      test and the override test.
+- [x] A failed premise opens no pull request and creates no branch
+      — this is why the gate is its own program run by the workflow rather than an
+      agent inside `implement.md`. The runtime creates the branch before the agent
+      session starts (`slice.go:139`), commits `--allow-empty` for the slice marker
+      (`:214`), then pushes (`:217`) and opens the PR (`:225`) with no guard, so a
+      build stopped from inside still leaves a branch and a marker-only PR. The
+      workflow skips the build step entirely instead. The gate's own run takes the
+      non-slice path, where an unmodified worktree returns `Skipped` before any
+      push (`executor.go:320-325`) — which is why the program forbids writing into
+      the working directory, since `git status --porcelain` counts untracked files.
+      Proved by mutation on all three: the guard, `slices: true`, and the rule.
+- [x] A failed premise stops before any slice of the plan is executed, not partway
+      through — the same guard, one layer up. `minions run implement.md` never
+      executes, so slice 1 never starts and no worktree is made. Re-verification
+      between slices stays out, as the issue asks: the check runs once, in its own
+      workflow step.
+- [x] The stage never closes the issue
+      — the gate program carries neither `gh issue close` nor `minion-done`. The
+      workflow does close the issue on a normal run, so the test also requires
+      every step carrying `gh issue close`, `minion-done` or `minion-failed` to be
+      guarded by the gate's verdict. Without that, a blocked run would have failed
+      red on the `Mark done` step's "no PR exists" check and labelled the issue
+      `minion-failed` — a blocked premise is neither done nor failed. Proved by
+      mutation: unguarding `Mark done` fails the test.
+- [x] Removing the label lets a subsequent run proceed
+      — the gate program never names `do-not-build`, so it cannot skip on it and
+      re-verifies against the tree on every run. The workflow reads the label only
+      after the gate has run, which the test pins by comparing positions inside
+      that step, so the verdict acted on is this run's rather than one left over.
+      Proved by mutation: naming the label in the program fails the test.
+- [x] A holding premise records what was verified, and the build proceeds unchanged
+      — the checker records every claim, its evidence, its verdict and the excerpt
+      behind it for a block that holds as well as one that does not, and refreshes
+      the issue's premise section with what this run read. The build step carries
+      exactly one condition, the blocked verdict and nothing else, which the test
+      checks line by line so a second condition cannot be added quietly.
+- [x] The implement program's instructions live where the parser carries them, and
+      the shape test stays green — this was genuinely red, and it was a live defect
+      rather than a formality: `## Slice builds` and `## PR and commit quality` sat
+      under second-level headings the parser drops, so none of that prose ever
+      reached the model. `programshape.Check` could not catch it, because it
+      returns nil for any program that defines an `## Agents` section. Both sections
+      now sit inside the `### implement` agent. The first attempt used `####`
+      sub-headings and the dry run showed them dropped too — `splitSections` splits
+      on every heading level and a level-4 section matches no case, so its body is
+      discarded silently. Bold labels replaced them. The test now pins both rules,
+      and `go test ./internal/programshape/` passes.
+- [x] `make test` and `make lint` pass
+      — both exit 0; `golangci-lint` reports 0 issues, and no package fails.
+      `minions run cli/.minions/programs/implement.md --dry-run` renders `AGENTS: 1`
+      and carries the whole instruction set into `## Agent Instructions`;
+      `premise-gate.md` renders `AGENTS: 1` with both shared documents pre-read.
+
+## Modules touched
+
+`stage-gate`, `premise-verifier`, `implement-program`, `build-workflow`,
+`premise-gate-program`.
+
+The last two were added during execution, with the operator's decision,
+because the first three cannot satisfy "opens no pull request and creates
+no branch" on their own. The pinned runtime offers a program no way to
+stop a slice build before it pushes: `skip_marker` is read only on the
+non-slice path, `stage_files` and `depends_on` are parsed and never read,
+unknown capability keys are ignored in silence, and the agent loop
+continues past a failed agent by design. The check therefore runs as its
+own program, `.minions/programs/premise-gate.md`, in a
+`.github/workflows/minion.yml` step ahead of the build.
+
+`stage-gate` and `premise-verifier` needed no edit. Both already name the
+implement program as a caller, which is what "described once" was for.
+
+## Test prior art
+
+- Slice 4's verifier fixtures and slice 6's gate behaviour. This slice
+  should not invent a second way to express either.
+- The implement program already runs the repository's own checks
+  between plan slices; the premise check belongs before the first
+  slice, alongside the existing setup rather than inside the loop.
+
+## Out of scope
+
+- The research stage's check. That is slice 6. Neither stage depends on
+  the other having run.
+- Proposals with no premise block. That is slice 8.
+- Any change to how the build slices a plan, resumes, or counts slice
+  markers.
+- Re-verifying between individual plan slices. One check before the
+  build starts is what this slice delivers.
+
+## Verification note
+
+Verify the failure path without spending a real build: confirm that no
+branch and no pull request appear, not merely that the run reports a
+stop. A run reporting success while having done almost nothing is the
+exact failure this whole PRD exists to prevent, so check the artefacts
+rather than the run banner.

--- a/docs/2026-08-13-proposal-premise-gate/issues/08-legacy-proposals-checked.md
+++ b/docs/2026-08-13-proposal-premise-gate/issues/08-legacy-proposals-checked.md
@@ -1,0 +1,129 @@
+# 08 — Older proposals are not exempt
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [04 — The proposer checks before it files](./04-proposer-checks-before-filing.md)
+
+## What to build
+
+Apply the gate to proposals that were filed before the premise block
+existed.
+
+There are 534 open proposals in this repository and 56 of them already
+carry the approved label, meaning they will build when something
+touches them. None has a premise block. Without this slice the gate
+protects only new work, and every existing proposal keeps its exemption
+until someone rewrites it by hand.
+
+When a stage meets a proposal that has no premise block, it extracts
+the factual claims from the issue prose and verifies those instead,
+with the same stop behaviour on failure. The proposal is not rewritten
+and not backfilled — extraction happens at check time, so nothing needs
+a bulk edit.
+
+The operator's decision was explicit: the backlog is not swept ahead of
+time and not pruned. Each proposal is checked when a stage next touches
+it, which means the 56 approved ones are covered without any special
+pass over them.
+
+## User stories covered
+
+PRD stories 16, 17, 18.
+
+## Acceptance criteria
+
+- [x] A proposal with no premise block has its factual claims extracted from the
+      issue prose — `premise.ClaimSource` routes a body with no
+      `<!-- partio:premise:v1 -->` marker to `SourceProse`, and the verifier's
+      `## When there is no block` section says what to extract (what the code
+      does today) and what to leave (wishes, acceptance criteria, the sibling
+      product). Both were red first: the selector did not exist, and the
+      verifier had no such section.
+- [x] Extracted claims are verified by the same behaviour as block-carried
+      claims — the verifier's procedure now reads "For each claim, in order,
+      whether it came from a block or from the prose", and the extraction
+      section routes into it rather than restating it. A test counts the
+      gathering description and fails at anything but one. In Go, the fixture
+      table gathers and decides in one loop for both inputs. Red first on two
+      counts: the procedure said "in the block", and the section claimed no
+      sameness.
+- [x] A failed extracted claim triggers the same stop, label and comment as a
+      failed block claim — the verifier's caller section now says "Only a
+      premise that `holds`" instead of "Only a block", and the gate's comment
+      covers "every claim you checked ... whether it came from a block or was
+      extracted from the issue prose". The extraction section sits above the
+      caller section, which is what makes its "nothing below this section
+      changes" true; a test pins that order. Both were red.
+- [x] The proposal body is not rewritten and no premise block is backfilled into
+      it — the extraction section states it, and the gate's passing path now
+      refreshes the block "only if the issue carries one", with an explicit "an
+      issue with no block gets none". That second edit is in `stage-gate.md`,
+      outside this slice's modules; see the note below.
+- [x] A proposal that carries a block uses the block and does not fall back to
+      prose extraction — `premise.ClaimSource` returns `SourceBlock` whenever
+      `Find` locates the marker, so precedence is one decision, not a rule each
+      stage repeats. A body carrying issue #30's prose *and* a block yields the
+      block's claim only. This passed on first run, since the tracer bullet's
+      selector already keyed on the marker, so a mutation check confirmed the
+      assertions bite: forcing `ClaimSource` to always answer `prose` fails both
+      tests.
+- [x] A proposal whose prose contains no checkable factual claim proceeds rather
+      than stopping, and says so in the run output — the verifier states that
+      this is not `unresolved` ("an unresolved claim is one you could not
+      settle; here there was no claim to settle") and to say so in the report.
+      An empty *block* stays an error, so the two cases remain distinct. Red on
+      all four phrases.
+- [x] Issue #30's original body is used as a fixture, since its prose carries a
+      claim already proven false — `testdata/issue-30-body.md` is the body as
+      filed, fetched with `gh issue view 30`, machine block and all. It routes
+      to `SourceProse`, and its prose claims verify as `fails` against today's
+      tree on the same evidence the block fixture uses. The test re-reads the
+      quoted prose from the fixture, so an extracted claim cannot drift into one
+      the proposal never made.
+- [x] No pass is made over the 534 existing proposals, and none is closed or
+      relabelled by this work — the verifier says the backlog is not swept and a
+      proposal is checked when a stage next touches it. A test fails if either
+      description reaches for `gh issue list` or `gh issue close`, or if a
+      `gh issue edit` line names anything but `$MINION_ISSUE_NUMBER`. No issue
+      was listed, closed or relabelled while building this slice; the only `gh`
+      call made was a read of issue #30.
+- [x] `make test` and `make lint` pass — 18 packages ok with no failures, and
+      `golangci-lint` reports 0 issues. `minions run
+      .minions/programs/research.md --dry-run` still renders, and names
+      `premise-verifier.md` and `stage-gate.md`, so the edited documents still
+      reach the model.
+
+## Modules touched
+
+`premise-verifier`, `premise-block`.
+
+`stage-gate` was also edited, with the operator's approval during the run. Two
+of its lines were written for a proposal that carries a block: the blocked-stage
+comment reported "every claim in the block", and the passing path refreshed the
+premise block unconditionally. On an old proposal the first leaves an extracted
+claim unreported, and the second reads as an instruction to write a block into
+an issue that never had one — the opposite of this slice's fourth criterion.
+Both are one-line conditionals now.
+
+## Test prior art
+
+- Slice 4's verifier fixtures. This slice adds a prose-input case
+  beside the existing block-input cases rather than building a separate
+  test surface.
+- Real issue bodies from this repository's open proposals make better
+  fixtures than invented prose, because the failure mode being guarded
+  against is specifically how these were written.
+
+## Out of scope
+
+- Sweeping, closing, relabelling or pruning any existing proposal. The
+  PRD's Out of Scope section names all of these.
+- Backfilling premise blocks onto old proposals.
+- Deciding whether an old proposal is still worth doing. The gate rules
+  on whether its premise holds, not on whether the idea has value.
+- Ranking or scoring the backlog.
+
+## Verification note
+
+A proposal with no checkable claim must proceed rather than stop.
+Treating "I found nothing to check" as a failure would block most of
+the backlog at once, which is the opposite of the intent.

--- a/docs/2026-08-13-proposal-premise-gate/prd.md
+++ b/docs/2026-08-13-proposal-premise-gate/prd.md
@@ -1,0 +1,292 @@
+# Proposal Premise Gate
+
+## Problem Statement
+
+The minion pipeline files feature proposals twice a day, and it writes
+them about code it has never read.
+
+**A proposal can assert something false about this repository and
+nothing will catch it.** Issue #30 said Partio's post-commit hook
+"performs a full tree walk to determine which files were changed in a
+commit… O(N) in the number of tracked files". The hook never did that.
+It ran a two-commit `git diff`, which is already a tree-to-tree
+comparison and never touches the working tree. The claim was imported
+from a sibling product's changelog, where the problem was real. Nobody
+checked whether it was real here.
+
+The issue was filed on 2026-03-26 and built on 2026-08-10. It took
+three builds to produce a pull request, and that pull request improves
+nothing. Measured directly, the replacement is level with the original
+on a thousand-file repository and roughly thirty to forty percent
+slower on a ten-thousand-file one; process startup dominates both. The
+one genuine defect it fixes — first commits recording zero attributed
+lines, because the fallback pointed at a git object that does not exist
+in any repository — was found by accident and is unrelated to the
+stated goal.
+
+**The proposer improvises, because its instructions are thrown away.**
+The program format keeps the title prose, the context section, the
+planner section and the agents section. Everything else is discarded
+without warning. The propose program carries its seven steps under a
+`## Steps` heading and defines no agents, so the executor synthesizes
+an implicit agent whose entire instruction set is the one-sentence
+description under the title. The steps that tell it to apply the ingest
+prompt, to check for an existing proposal, and to advance the source
+cursor never reach the model. It reads three files named as context
+hints and invents the rest of the workflow. Five programs are written
+this way; every program that behaves reliably uses an agents section.
+
+**The result is a queue nobody can read.** There are 534 open
+proposals. Fifty-six already carry the approved label and will build
+when touched. Ten have been closed. Nine minion pull requests have ever
+merged — under two percent of what the proposer has filed. A bad
+proposal does not stand out in a queue that long, and the operator is
+the only gate between a false premise and a build.
+
+## Solution
+
+Make a proposal state what it believes about this repository, and make
+every stage check that belief before spending anything on it.
+
+- **A proposal carries its premise.** Each one records the factual
+  claims it rests on, one per line, each paired with the path or
+  command that proves it. A premise written as prose cannot be
+  rechecked; a premise written as claims can.
+- **The proposer reads the code before it writes the claim.** The
+  source tree is already checked out when the proposer runs. It stops
+  guessing from a sibling product's changelog and grounds every claim
+  in what is actually here. Only ideas whose premise survives get
+  filed, so volume falls at the source rather than being pruned later.
+- **Every stage rechecks, because time passes.** Propose, research and
+  implement each verify the premise against the tree in front of them.
+  A claim that was true in March can be false by August, and issue #30
+  sat for four and a half months.
+- **A failed check stops the stage.** It adds the blocking label,
+  comments what it checked and what it found, and ends. It does not
+  close the issue and it does not build anyway. The operator decides
+  what happens next.
+- **Rejections are recorded.** Ideas the proposer drops are appended to
+  a log it commits, with the reason. Without that record a bar that is
+  set too high is indistinguishable from a source that has gone quiet.
+- **Instructions reach the model.** The propose program and the ingest
+  prompt move their instructions into the agents section, where the
+  format actually carries them. A test then fails any program that
+  hides instructions in a section the parser drops.
+
+## User Stories
+
+1. As the operator, I want a proposal to state the facts it assumes about my code, so that I can judge it without reading the codebase myself.
+2. As the operator, I want each assumed fact paired with a command that proves it, so that I can verify a claim in seconds rather than minutes.
+3. As the operator, I want the proposer to read my repository before it describes my repository, so that proposals stop describing a product I do not have.
+4. As the operator, I want a proposal whose premise is already false to never be filed, so that my queue holds only work that could still matter.
+5. As the operator, I want the premise rechecked when research runs, so that a proposal that aged badly is caught before it is planned.
+6. As the operator, I want the premise rechecked when the build starts, so that a proposal approved months ago cannot build against a tree that has moved on.
+7. As the operator, I want a failed check to stop the stage, so that no compute is spent on work that is already known to be pointless.
+8. As the operator, I want a failed check to add a blocking label, so that the issue cannot be picked up again by accident.
+9. As the operator, I want the failing stage to comment what it checked and what it found, so that I can confirm or overrule the machine from the issue alone.
+10. As the operator, I want the machine never to close an issue on its own, so that I stay the one who decides what is abandoned.
+11. As the operator, I want to overrule a failed check and build anyway, so that a verifier mistake does not permanently block real work.
+12. As the operator, I want rejected ideas written to a file in the repository, so that I can audit whether the bar is dropping things I wanted.
+13. As the operator, I want each rejection to record its reason, so that I can tell a false premise from an irrelevant source item.
+14. As the operator, I want the rejection log committed by the same run that advances the source cursor, so that a dropped idea is never silently unrecoverable.
+15. As the operator, I want proposal volume to fall because fewer bad ideas are filed, so that I do not have to bulk-close a backlog I never read.
+16. As the operator, I want my existing 534 proposals left alone, so that nothing I might still want disappears in a cleanup.
+17. As the operator, I want an older proposal that has no premise block checked against its prose claims instead, so that the backlog is not exempt from the gate.
+18. As the operator, I want the fifty-six already-approved proposals checked when a stage next touches them, so that no special sweep is needed.
+19. As the operator, I want the propose program's instructions to actually reach the model, so that it follows the workflow I wrote instead of inventing one.
+20. As the operator, I want a test that fails when a program hides instructions in a discarded section, so that this class of bug cannot return quietly.
+21. As the operator, I want that test to name the offending program, so that I can fix it without bisecting the format rules.
+22. As the operator, I want the ingest prompt to demand claims grounded in the checked-out tree, so that the model cannot satisfy it with a plausible guess.
+23. As the operator, I want the proposal format to keep working for sources that are genuinely relevant, so that raising the bar does not silence the pipeline.
+24. As the operator, I want the change to ship as program text in this repository, so that no engine release, tag and version pin is needed to adopt it.
+25. As the operator, I want the gate to reuse the blocking label the pipeline already understands, so that no new state is introduced.
+26. As the researcher stage, I want to read a machine-checkable premise, so that I can validate before planning rather than planning something void.
+27. As the researcher stage, I want to refresh the premise block when I run, so that later stages check against the newest evidence.
+28. As the build stage, I want to refuse a proposal whose premise has failed, so that I never open a pull request that solves nothing.
+29. As the operator, I want a stage to record what it verified even when the premise holds, so that a green build carries its evidence too.
+30. As the operator, I want the gate scoped to the CLI repository, so that the change lands where every source and every target already points.
+31. As a Partio user, I want first commits to record their attributed lines, so that my earliest work is not silently counted as zero.
+32. As a Partio user, I want hook changes justified by measurement, so that my post-commit path does not get slower in the name of speed.
+33. As the operator, I want a benchmark that compares against the old behaviour, so that "faster" is demonstrated rather than asserted.
+34. As the operator, I want the pipeline's hit rate to become legible, so that I can tell whether the proposer is worth running twice a day.
+
+## Implementation Decisions
+
+**The premise block is the contract between stages.** Every proposal
+carries a section listing the factual claims it depends on. Each claim
+is one line and names the evidence that settles it — a path, a symbol,
+or a command whose output decides the matter. The block is the only
+thing a later stage needs in order to recheck; it does not depend on
+the prose that surrounds it.
+
+**One verifier, three callers.** Verification is a single described
+behaviour: given a premise block and a checked-out tree, produce a
+verdict plus the evidence gathered. The propose, research and implement
+programs call it. They do not each carry their own idea of what
+verification means.
+
+**Verification runs at every stage, not once.** The operator's decision
+was explicit: code moves between filing, approval, research and build,
+so a single check at any one point is worthless by the time the next
+stage runs. Research additionally refreshes the block so that implement
+checks the newest evidence.
+
+**A failed verdict stops the stage and hands control back.** The stage
+adds the existing `do-not-build` label, comments the claims it checked
+and the evidence that contradicted them, and exits without further
+work. It does not close the issue. This follows the standing rule that
+the machine does not change state the operator has not seen. The label
+is reused rather than invented because the approval program already
+treats it as a skip condition.
+
+**Proposals predating the block are checked against their prose.** The
+534 existing proposals carry no block. A stage that meets one extracts
+the factual claims from the body and verifies those, with the same stop
+behaviour on failure. The backlog is not swept ahead of time and is not
+pruned; each proposal is checked when a stage next touches it.
+
+**Volume is reduced at the source.** The proposer files only what
+survives its own premise check. No cap on proposals per run and no bulk
+close of the existing queue — the operator chose to raise the bar
+rather than bound the output or discard the backlog.
+
+**Rejections are durable.** Ideas dropped by the proposer append to a
+log file that the run commits alongside the source cursor it already
+updates. Reason is recorded with each entry. This exists because the
+cursor advances past a rejected item, so without the log the idea is
+gone with no trace.
+
+**Instructions move into the agents section.** This is a prerequisite,
+not a nicety. The program format retains the title prose, the context
+section, the planner section and the agents section, and silently
+discards the rest; a program with no agents runs with only its
+one-sentence description as instruction. Premise instructions added to
+a steps section would vanish exactly as the current seven steps do. The
+propose program is converted. The ingest prompt is a template read as
+context rather than a parsed program, so it needs new content but no
+conversion. The approval, ingest, documentation-update and
+readme-update programs have the same defect and are named here as a
+known gap rather than fixed in this work; of those, only the
+documentation-update program is reachable from a workflow.
+
+**The ingest prompt gains premise fields and a grounding rule.** Its
+output schema carries the claims and their evidence, and its
+instructions require every claim to be grounded in the checked-out
+tree. Adaptation from a source product remains the goal; asserting the
+source product's problems as this product's problems does not.
+
+**Nothing changes in the engine.** All edits are program text in this
+repository, so adoption needs no engine release, tag, or version pin
+bump. The single exception is the shape test, which is ordinary Go.
+
+**Language.** The shape test is written in Go, because this repository
+is Go and the existing language policy makes the repository's language
+the default. Everything else in this work is Markdown program text and
+implies no service or script.
+
+**Scope is this repository.** It is the only entry in the proposer's
+target list, and all three configured sources point at the same sibling
+repository.
+
+## Testing Decisions
+
+**What a good test looks like here.** A test asserts behaviour an
+outside caller can observe, not the shape of the implementation behind
+it. For program text, the observable behaviour is what actually reaches
+the model; for the shape test, it is whether a given program's
+instructions survive parsing. Tests do not assert on prompt wording,
+because wording is expected to change and asserting on it produces a
+suite that fails on every edit without ever catching a defect.
+
+**Every module is tested, and the untestable parts are named.**
+
+- `program-shape-test` is the machine-testable core and carries real
+  coverage. It reads every program in this repository and fails any one
+  whose instructions sit in a section the format discards, naming the
+  offending program. It covers the positive case (a program with an
+  agents section passes), the negative case (a program with steps and
+  no agents fails), and the boundary (a program whose whole instruction
+  set lives in the title prose passes, since that text does reach the
+  model).
+- `premise-block` is tested through the shape of what stages produce
+  and consume: a block with claims and evidence is recognised, a block
+  whose claims carry no evidence is rejected, and a proposal with no
+  block at all is handled by the prose path rather than crashing.
+- `premise-verifier`, `stage-gate`, `rejection-log`, `propose-program`,
+  `ingest-prompt`, `research-program` and `implement-program` are
+  prompt-driven behaviours. Their instruction text is verified
+  mechanically only to the extent that the shape test proves it reaches
+  the model. **Their runtime behaviour is not unit-testable and is
+  covered by dry-run inspection instead** — a dry run renders the
+  prompt that would be sent, and the rendered prompt is read to confirm
+  the verification, gate and logging instructions are present. This is
+  a deliberate and visible gap: no automated test proves that a stage
+  actually stops on a false premise. Closing it would require an
+  end-to-end harness that runs a real model against a fixture
+  repository, which this work does not build.
+
+**Prior art.** The program parser in the engine repository has
+table-driven parser tests covering section handling, and they are the
+model for the shape test's structure. Within this repository, the house
+pattern is table-driven tests on the standard library only, using
+temporary directories for filesystem isolation, with no external test
+framework. The shape test follows both.
+
+**A regression fixture for the triggering case.** The premise of issue
+#30 is kept as a fixture for the shape and block tests, since it is a
+known-false claim with known evidence and makes a clean negative case.
+
+## Out of Scope
+
+- **Pruning or capping the existing queue.** The 534 open proposals
+  stay. No bulk close, and no limit on proposals per run.
+- **A sweep of the fifty-six approved proposals.** They are checked when
+  a stage next touches them, not ahead of time.
+- **The approval, ingest, documentation-update and readme-update
+  programs.** They have the same dropped-instruction defect. Only the
+  documentation-update program is reachable from a workflow; the other
+  three are unreferenced. They are named in this document so the gap is
+  visible, and left for separate work.
+- **The approval program's automation.** It describes auto-approval
+  after a review window, but no workflow runs it, so approval is
+  effectively manual today. Whether to wire it up is a separate
+  decision and is not settled here.
+- **Any change to the engine.** No release, tag, or version pin bump.
+- **Ranking or scoring proposals.** The gate decides whether a premise
+  holds, not whether an idea is worth doing.
+- **Other target repositories.** App, site, extension and docs are
+  untouched.
+- **Issue #30 and its pull request.** The operator's decision is to
+  salvage the first-commit attribution fix as its own change and close
+  both. That is separate work and is not part of this document.
+- **An end-to-end harness that runs a real model against a fixture
+  repository.** Named in Testing Decisions as the reason a gap remains.
+
+## Further Notes
+
+The measurements behind the problem statement were taken directly
+rather than inherited. On a thousand-file repository the original and
+the replacement are level; on a ten-thousand-file repository the
+replacement is consistently slower across interleaved runs. Git process
+startup is roughly two thirds of the total in both cases, which is the
+more useful finding: the diff strategy was never the bottleneck in this
+path.
+
+The first-commit defect is worth restating because it was found by
+accident and is the only real bug in the episode. The removed fallback
+compared against the well-known empty-tree object, and that object is
+not present in a fresh repository — nor in this one. Both paths
+therefore failed on a first commit, and attribution recorded zero
+lines. Any work that touches this area should keep that fix.
+
+Two facts about the pipeline are worth watching once the gate is in.
+The first is the hit rate: nine merged pull requests against 544 filed
+proposals. If the gate works, the ratio should move, and if it does not
+move the problem is upstream of the premise. The second is the
+rejection log: if it fills with ideas that look good, the bar is
+catching the wrong thing, and the log is the only place that would show
+it.
+
+The sibling product remains a legitimate source of inspiration. The
+failure was never that a changelog was read; it was that a changelog
+was believed.

--- a/docs/2026-08-16-first-commit-attribution/issues.md
+++ b/docs/2026-08-16-first-commit-attribution/issues.md
@@ -1,0 +1,44 @@
+# Issues — 2026-08-16-first-commit-attribution
+
+Source: [prd.md](./prd.md)
+
+| Done | # | Title | Blocked by |
+|------|---|-------|------------|
+| [x]  | 1 | [First commit records its lines](./issues/01-first-commit-records-lines.md) | None |
+| [x]  | 2 | [First checkpoint lists its files](./issues/02-first-checkpoint-lists-files.md) | [#1](./issues/01-first-commit-records-lines.md) |
+| [x]  | 3 | [First checkpoint stores its diff](./issues/03-first-checkpoint-stores-diff.md) | [#1](./issues/01-first-commit-records-lines.md) |
+| [x]  | 4 | [A failed measurement is visible](./issues/04-failed-measurement-is-visible.md) | [#1](./issues/01-first-commit-records-lines.md) |
+| [x]  | 5 | [The speed claim is measurable](./issues/05-speed-claim-is-measurable.md) | [#1](./issues/01-first-commit-records-lines.md) |
+
+Slice 5 — pull request #653: decision pending. The operator records the
+outcome here.
+
+## User story coverage
+
+| Slice | PRD stories |
+|---|---|
+| 1 | 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16, 17, 29, 30, 31, 32, 33, 34 |
+| 2 | 2, 4, 17, 29, 30, 32, 33, 34 |
+| 3 | 3, 4, 17, 29, 30, 32, 33, 34 |
+| 4 | 14, 15, 29, 30, 32 |
+| 5 | 18, 19, 20, 21, 22, 23, 24, 28, 30 |
+
+**Not covered by any slice: stories 25, 26 and 27.**
+
+- Stories 25 and 26 ask that the false premise of issue #30 and the
+  merge regression in pull request #653 are recorded. The PRD's Further
+  Notes section already records both, so no slice adds them.
+- Story 27 asks that the premise-gate document is corrected. The PRD
+  names that as a separate decision in Out of Scope. It is unbuilt, and
+  it is recorded here so the gap stays visible.
+
+## Notes
+
+- Slice 1 carries the shared constant and the shared helper. Slices 2,
+  3, 4 and 5 all depend only on slice 1, so once it lands they can
+  proceed in parallel or in any order.
+- Slice 5 has a `## Handoff`. It is the only slice that ends with an
+  action for the operator.
+- Pull request #653 stays open. No slice closes it, comments on it, or
+  pushes to its branch. That decision belongs to the operator.
+- Do not commit or push. That stays with the operator.

--- a/docs/2026-08-16-first-commit-attribution/issues/01-first-commit-records-lines.md
+++ b/docs/2026-08-16-first-commit-attribution/issues/01-first-commit-records-lines.md
@@ -1,0 +1,120 @@
+# 01 — First commit records its lines
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+Partio counts the added lines in the first commit of a repository. A
+user who installs Partio and commits gets a checkpoint that reports the
+real line total, not zero.
+
+Today the line-count function compares a commit against its parent. A
+first commit has no parent, so git answers `fatal: ambiguous argument
+'HEAD~1'`. The attribution code then falls back to a comparison against
+git's empty tree object, and the constant it uses is corrupted:
+
+- The code holds `4b825dc642cb6eb9a060e54bf899d69f82cf7ee2`.
+- The real empty tree object is
+  `4b825dc642cb6eb9a060e54bf8d69288fbee4904`.
+
+Git answers the fallback with `fatal: bad object`. The attribution code
+catches that error, returns an empty result, and reports no error, so
+the first commit records zero lines.
+
+This slice adds one named constant for the empty tree object and one
+unexported helper in the git package that decides how to identify a
+commit's content. The helper takes a commit hash and returns the two
+revision arguments to compare:
+
+- A commit with a parent returns the parent revision and the commit
+  revision. This is today's behaviour, unchanged.
+- A commit with no parent returns the empty tree constant and the commit
+  revision.
+
+The line-count function then builds its own flags and appends the two
+revisions from the helper. Its signature does not change, so no caller
+changes. The attribution function drops its private copy of the empty
+tree fallback, which the helper makes dead.
+
+**Merge behaviour must not change.** A merge commit has a parent, so it
+takes the unchanged path and is compared against its first parent. Do
+NOT add the `--root` flag to production code. Measured directly, `git
+diff-tree --no-commit-id -r --root --numstat` returns nothing at all for
+a merge commit, while today's comparison returns the lines the merge
+brings in. Pull request #653 made that mistake, and this slice exists in
+part to avoid repeating it.
+
+## User stories covered
+
+1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16, 17, 29, 30, 31, 32, 33, 34
+
+## Acceptance criteria
+
+- [x] The git package holds one exported constant for git's empty tree
+      object id, with a comment that states what it is.
+- [x] The corrupted literal `4b825dc642cb6eb9a060e54bf899d69f82cf7ee2`
+      appears nowhere in the repository.
+- [x] An unexported helper in the git package takes a commit hash and
+      returns the two revision arguments that identify that commit's
+      content.
+- [x] The helper detects the parent through git, not through a guess,
+      and an error that is not the absence of a parent propagates to the
+      caller.
+- [x] The line-count function keeps its current signature.
+- [x] Attribution on a first commit that adds text files reports the
+      real added-line total.
+- [x] Attribution on a first commit with an agent active reports one
+      hundred percent agent lines and the real total.
+- [x] Attribution on a first commit with no agent active reports zero
+      percent agent lines and the real total.
+- [x] Attribution on a first commit that adds a binary file skips that
+      file and still counts the text files.
+- [x] Attribution on a first empty commit reports zero lines and no
+      error, so a real zero differs from a failed measurement.
+- [x] Attribution on a regular commit reports the same total it reports
+      today.
+- [x] Attribution on a merge commit reports the lines the merge brings
+      in against its first parent, the same total it reports today.
+- [x] The attribution function no longer holds its own empty tree
+      fallback.
+- [x] `make test` passes.
+
+## Modules touched
+
+- The git package empty tree constant.
+- The git package commit-range helper.
+- The git package line-count function (`DiffNumstat`).
+- The attribution calculate function (`attribution.Calculate`).
+
+## Test prior art
+
+The git package already holds a test that builds a real repository in a
+temporary directory, runs git through a local `run` closure that calls
+`t.Fatalf` on failure, and drives table-driven subtests. Follow it.
+
+- `internal/git/*_test.go` — the repository-building pattern.
+- The house pattern is `t.TempDir()` for filesystem isolation, table-
+  driven subtests, and the standard library `testing` package alone.
+- The repository uses no external test framework. Do not add one.
+
+The three commit-diff functions read the process working directory, so a
+test must change directory into the temporary repository with `t.Chdir`.
+That is a known wart in the interface and this slice does not repair it.
+
+## Out of scope
+
+- The changed-file function. Slice
+  [02](./02-first-checkpoint-lists-files.md) covers it.
+- The unified-diff function. Slice
+  [03](./03-first-checkpoint-stores-diff.md) covers it.
+- Error propagation out of the attribution function when git genuinely
+  fails. Slice [04](./04-failed-measurement-is-visible.md) covers it.
+  In this slice the attribution function keeps its current behaviour on
+  a real failure.
+- The benchmark. Slice [05](./05-speed-claim-is-measurable.md) covers
+  it.
+- A repository path parameter on the commit-diff functions. The PRD
+  names the interface wart and leaves it alone.
+- Pull request #653 and issue #30. Do not close, comment on, or push to
+  either.

--- a/docs/2026-08-16-first-commit-attribution/issues/02-first-checkpoint-lists-files.md
+++ b/docs/2026-08-16-first-commit-attribution/issues/02-first-checkpoint-lists-files.md
@@ -1,0 +1,78 @@
+# 02 — First checkpoint lists its files
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [01 — First commit records its lines](./01-first-commit-records-lines.md)
+
+## What to build
+
+Partio lists the files that a first commit touched. Today the changed-
+file function compares a commit against its parent, so it fails on a
+first commit and returns an empty list.
+
+The function has the same root-commit defect that slice 01 repaired in
+the line-count function, and slice 01 already built the fix. This slice
+routes the changed-file function through the same commit-range helper.
+
+The function keeps its current signature, so no caller changes. It
+builds its own flags and appends the two revisions from the helper.
+
+**Merge behaviour must not change.** A merge commit has a parent, so it
+takes the unchanged path and is compared against its first parent. Do
+NOT add the `--root` flag to production code.
+
+The current caller of this function is the post-commit hook's debug
+logging, which compares the commit's file list against the agent session
+content paths. That caller is behind a debug-level check, so the visible
+outcome of this slice is a correct file list at debug level on a first
+commit, plus a function that later callers can trust.
+
+## User stories covered
+
+2, 4, 17, 29, 30, 32, 33, 34
+
+## Acceptance criteria
+
+- [x] The changed-file function uses the commit-range helper from slice
+      01 and holds no revision logic of its own.
+- [x] The changed-file function keeps its current signature.
+- [x] The changed-file function on a first commit returns every path
+      that commit added.
+- [x] The changed-file function on a regular commit returns the same
+      paths it returns today.
+- [x] The changed-file function on a merge commit returns the paths the
+      merge brings in against its first parent, the same paths it
+      returns today.
+- [x] The changed-file function on a first commit that adds a binary
+      file includes that file's path.
+- [x] The changed-file function on an empty commit returns an empty
+      result and no error.
+- [x] `make test` passes.
+
+## Modules touched
+
+- The git package changed-file function (`DiffNameOnly`).
+
+## Test prior art
+
+The git package already holds a test that builds a real repository in a
+temporary directory, runs git through a local `run` closure that calls
+`t.Fatalf` on failure, and drives table-driven subtests. Slice 01 added
+tests in the same package under the same pattern — mirror them.
+
+- `internal/git/*_test.go` — the repository-building pattern.
+- The house pattern is `t.TempDir()` for filesystem isolation, table-
+  driven subtests, and the standard library `testing` package alone.
+- The function reads the process working directory, so a test must
+  change directory into the temporary repository with `t.Chdir`.
+
+## Out of scope
+
+- The line-count function and the shared helper. Slice
+  [01](./01-first-commit-records-lines.md) covers them.
+- The unified-diff function. Slice
+  [03](./03-first-checkpoint-stores-diff.md) covers it.
+- Any change to the post-commit hook's debug logging. This slice repairs
+  the function the hook calls, not the hook.
+- A repository path parameter on the commit-diff functions.
+- Pull request #653 and issue #30. Do not close, comment on, or push to
+  either.

--- a/docs/2026-08-16-first-commit-attribution/issues/03-first-checkpoint-stores-diff.md
+++ b/docs/2026-08-16-first-commit-attribution/issues/03-first-checkpoint-stores-diff.md
@@ -1,0 +1,75 @@
+# 03 — First checkpoint stores its diff
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [01 — First commit records its lines](./01-first-commit-records-lines.md)
+
+## What to build
+
+A checkpoint for a first commit holds the unified diff of that commit.
+Today the unified-diff function compares a commit against its parent, so
+it fails on a first commit. The post-commit hook calls it inside an
+`err == nil` check, so the hook silently stores a checkpoint with no
+diff at all. The user's first checkpoint holds the agent session and
+none of the code.
+
+The function has the same root-commit defect that slice 01 repaired in
+the line-count function, and slice 01 already built the fix. This slice
+routes the unified-diff function through the same commit-range helper.
+
+The function keeps its current signature, so no caller changes. It
+builds its own flags and appends the two revisions from the helper.
+
+**Merge behaviour must not change.** A merge commit has a parent, so it
+takes the unchanged path and is compared against its first parent. Do
+NOT add the `--root` flag to production code.
+
+## User stories covered
+
+3, 4, 17, 29, 30, 32, 33, 34
+
+## Acceptance criteria
+
+- [x] The unified-diff function uses the commit-range helper from slice
+      01 and holds no revision logic of its own.
+- [x] The unified-diff function keeps its current signature.
+- [x] The unified-diff function on a first commit returns a diff that
+      contains the added content.
+- [x] The unified-diff function on a regular commit returns the same
+      diff it returns today.
+- [x] The unified-diff function on a merge commit returns the diff
+      against its first parent, the same diff it returns today.
+- [x] The unified-diff function on an empty commit returns an empty
+      result and no error.
+- [x] A checkpoint created for a first commit holds a non-empty diff.
+- [x] `make test` passes.
+
+## Modules touched
+
+- The git package unified-diff function (`git.Diff`).
+
+## Test prior art
+
+The git package already holds a test that builds a real repository in a
+temporary directory, runs git through a local `run` closure that calls
+`t.Fatalf` on failure, and drives table-driven subtests. Slice 01 added
+tests in the same package under the same pattern — mirror them.
+
+- `internal/git/*_test.go` — the repository-building pattern.
+- `internal/hooks/*_test.go` — prior art for a test that drives the
+  post-commit path, if the checkpoint criterion needs one.
+- The house pattern is `t.TempDir()` for filesystem isolation, table-
+  driven subtests, and the standard library `testing` package alone.
+- The function reads the process working directory, so a test must
+  change directory into the temporary repository with `t.Chdir`.
+
+## Out of scope
+
+- The line-count function and the shared helper. Slice
+  [01](./01-first-commit-records-lines.md) covers them.
+- The changed-file function. Slice
+  [02](./02-first-checkpoint-lists-files.md) covers it.
+- The checkpoint storage format. This slice changes what the hook can
+  fetch, not how a checkpoint is written.
+- A repository path parameter on the commit-diff functions.
+- Pull request #653 and issue #30. Do not close, comment on, or push to
+  either.

--- a/docs/2026-08-16-first-commit-attribution/issues/04-failed-measurement-is-visible.md
+++ b/docs/2026-08-16-first-commit-attribution/issues/04-failed-measurement-is-visible.md
@@ -1,0 +1,75 @@
+# 04 — A failed measurement is visible
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [01 — First commit records its lines](./01-first-commit-records-lines.md)
+
+## What to build
+
+When git cannot measure a commit, the user learns about it. Today the
+attribution function returns an empty result and a nil error, so a
+failed measurement and an empty commit look identical. The post-commit
+hook has a branch for an attribution error, and that branch never runs.
+
+This is the behaviour that hid the first-commit defect for four months.
+The defect was found by accident, and it was found by accident because
+nothing ever reported it.
+
+This slice makes the attribution function return the error when git
+cannot answer. The post-commit hook's existing error branch then runs,
+writes a warning, and continues.
+
+**Hooks must stay non-blocking.** The repository's convention is that a
+hook logs a warning and does not fail a git operation on a non-critical
+error. A commit must still succeed when attribution fails. Do not turn
+this error into a hook failure.
+
+The hook's existing error branch sets the result to one hundred percent
+agent lines. That behaviour is odd, and the PRD puts it out of scope.
+Leave it as it is.
+
+## User stories covered
+
+14, 15, 29, 30, 32
+
+## Acceptance criteria
+
+- [x] The attribution function returns the error from git when git
+      cannot measure the commit.
+- [x] The attribution function no longer returns an empty result with a
+      nil error on a git failure.
+- [x] The attribution function on an empty commit still returns zero
+      lines and a nil error, so a real zero and a failed measurement
+      stay distinguishable.
+- [x] A commit hash that git cannot resolve produces an error from the
+      attribution function.
+- [x] The post-commit hook writes a warning when attribution fails.
+- [x] The post-commit hook does not fail the git operation when
+      attribution fails.
+- [x] `make test` passes.
+
+## Modules touched
+
+- The attribution calculate function (`attribution.Calculate`).
+- The post-commit hook, for the warning path only.
+
+## Test prior art
+
+- `internal/hooks/*_test.go` — prior art for tests that drive a hook
+  against a real repository in a temporary directory.
+- `internal/git/*_test.go` — the repository-building pattern, and the
+  tests slice 01 added.
+- The house pattern is `t.TempDir()` for filesystem isolation,
+  `t.Setenv()` for environment variables, table-driven subtests, and the
+  standard library `testing` package alone.
+
+## Out of scope
+
+- The root-commit fix in any of the three commit-diff functions. Slices
+  [01](./01-first-commit-records-lines.md),
+  [02](./02-first-checkpoint-lists-files.md) and
+  [03](./03-first-checkpoint-stores-diff.md) cover them.
+- The hook's fallback to one hundred percent agent lines on an
+  attribution error. The PRD names it and leaves it alone.
+- Any change that makes a hook block a git operation.
+- Pull request #653 and issue #30. Do not close, comment on, or push to
+  either.

--- a/docs/2026-08-16-first-commit-attribution/issues/05-speed-claim-is-measurable.md
+++ b/docs/2026-08-16-first-commit-attribution/issues/05-speed-claim-is-measurable.md
@@ -1,0 +1,164 @@
+# 05 — The speed claim is measurable
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [01 — First commit records its lines](./01-first-commit-records-lines.md)
+
+## What to build
+
+A benchmark measures the post-commit comparison strategy, so the next
+speed claim about this path meets a number.
+
+Issue #30 said the post-commit hook performed a full tree walk that was
+O(N) in the number of tracked files, and that a `git diff-tree`
+replacement would cut hook latency. The hook never performed a tree
+walk. It always ran a two-commit `git diff`, which is a tree-to-tree
+comparison. The claim came from a sibling product's changelog. The
+repository holds no benchmark, so nobody could check the claim, and a
+pull request was built on it four months later.
+
+This slice adds a benchmark in the git package that runs two strategies
+over the same commit in the same generated repository:
+
+- The two-commit comparison the code uses today.
+- The `git diff-tree --no-commit-id -r --root` plumbing call that issue
+  #30 proposed.
+
+**The `git diff-tree` call lives only in the benchmark file.**
+Production code keeps exactly one strategy. Do not add a production
+helper for the rejected strategy, and do not export it.
+
+The benchmark builds a repository with a large file count. The file
+count appears in the benchmark name, so a reader knows what was
+measured. Continuous integration does not gate on the numbers. The
+benchmark is a measurement tool for a person.
+
+When the benchmark runs, record the numbers in this issue file under the
+Handoff block below.
+
+The expected result, from the premise-gate document's own measurements:
+the replacement is level on a repository with one thousand files, and
+roughly thirty to forty percent slower on a repository with ten thousand
+files. Git process startup is roughly two thirds of the total in both
+strategies. Report what you actually measure. If the numbers disagree
+with that expectation, say so and do not adjust them.
+
+## User stories covered
+
+18, 19, 20, 21, 22, 23, 24, 28, 30
+
+## Acceptance criteria
+
+- [x] The git package holds a benchmark that measures the current
+      comparison strategy over a generated repository.
+- [x] The same benchmark file measures the `git diff-tree` alternative
+      over the same commit in the same repository.
+- [x] The `git diff-tree` invocation appears only in the benchmark file
+      and in no production file.
+- [x] The generated repository's file count appears in the benchmark
+      name.
+- [x] The benchmark builds its repository under `t.TempDir()` or the
+      benchmark equivalent, so it leaves nothing behind.
+- [x] `go test -bench` runs both strategies and reports a number for
+      each.
+- [x] `make test` passes and does not run the benchmark by default.
+- [x] The measured numbers are recorded in the Handoff block in this
+      file.
+
+## Modules touched
+
+- The git package benchmark file (test-only).
+
+## Test prior art
+
+- `internal/git/*_test.go` — the pattern that builds a real repository
+  in a temporary directory and runs git through a local `run` closure.
+- The repository holds no benchmark today, so there is no prior art for
+  the benchmark shape itself. Follow the standard library `testing`
+  package's `Benchmark` convention and keep the repository-building
+  helper out of the timed loop.
+- The house pattern is the standard library `testing` package alone. Do
+  not add a benchmark framework.
+
+## Out of scope
+
+- Any production change to the comparison strategy. The alternative is
+  measured, not adopted.
+- A test that fails when the post-commit path gets slower. The PRD names
+  this gap: the benchmark measures, it does not assert.
+- The root-commit fix in the three commit-diff functions. Slices
+  [01](./01-first-commit-records-lines.md),
+  [02](./02-first-checkpoint-lists-files.md) and
+  [03](./03-first-checkpoint-stores-diff.md) cover them.
+- Closing pull request #653. See the Handoff below.
+
+## Handoff
+
+When this slice's acceptance criteria all pass, BEFORE flipping its row
+in `issues.md`, post the following block to the user verbatim:
+
+- **URL / artefact to visit**:
+  - The benchmark output from `go test -bench` in the git package, with
+    both strategies side by side.
+  - https://github.com/partio-io/cli/pull/653
+- **Action required**: Read the two benchmark numbers. Pull request #653
+  replaces the current strategy with the slower one, and it also drops
+  merge-commit attribution to zero. This work does not close it. Decide
+  whether to close pull request #653, and close it yourself.
+- **Where to record the decision**:
+  - In this file, under this Handoff block, paste the measured numbers
+    so the next proposal about this path meets a recorded figure, AND
+  - In `issues.md`, add a one-line note next to this slice's row stating
+    whether pull request #653 was closed.
+
+There is no next slice, so no slice is blocked on this. The handoff
+exists because the decision belongs to the operator and would otherwise
+go unrecorded.
+
+**Measured numbers**: Recorded 2026-08-17.
+
+Command: `go test -run '^$' -bench BenchmarkCommitDiffStrategies
+-benchtime 100x -count 5 ./internal/git/`
+
+Machine: AMD Ryzen AI MAX+ 395, linux/amd64, 32 threads. git 2.55.0, go
+1.26.6. Each figure is the median of 5 runs, in milliseconds for one
+call. The measured commit changes one file in a repository that holds
+the stated file count.
+
+| Measurement | 1000 files | 10000 files |
+|---|---|---|
+| Current strategy, `DiffNumstat` (parent lookup + `git diff`) | 1.34 | 1.74 |
+| The `git diff` command alone, revisions already known | 0.74 | 1.17 |
+| Proposed `git diff-tree --no-commit-id -r --root --numstat` | 0.74 | 1.47 |
+
+**Read the third row against the second row, not the first.** The first
+row starts two git processes, because the current code asks git for the
+parent commit first. The third row starts one. A git process costs about
+0.6 ms on this machine, and that fixed cost, not the tree size, is the
+whole gap between row one and row three.
+
+Command against command, rows two and three:
+
+- 1000 files: the proposal is level. It is 0.3 percent slower, which is
+  inside the noise.
+- 10000 files: the proposal is 26 percent slower.
+
+This agrees with the premise-gate document's direction. The document
+expected 30 to 40 percent slower at 10000 files; the measurement here is
+26 percent. The proposal is slower at scale, and it is never faster.
+
+Strategy against strategy, rows one and three, the proposal looks 45
+percent faster at 1000 files and 16 percent faster at 10000 files. That
+number is real but it does not measure the tree comparison. It measures
+one git process against two. Slice 01 added the parent lookup on
+purpose, to stop the code from guessing the parent. A future proposal
+that cites the faster number must say which of the two it means.
+
+Process startup share: about 80 percent of a single call at 1000 files
+and about 50 percent at 10000 files. The premise-gate document said
+roughly two thirds. The measured share is not constant; it falls as the
+repository grows.
+
+**Issue #30's premise is not supported.** The claim was a full tree walk
+that is O(N) in tracked files. A ten times larger repository raises the
+current call from 1.34 ms to 1.74 ms, which is 30 percent, not ten
+times. The cost is dominated by process startup.

--- a/docs/2026-08-16-first-commit-attribution/prd.md
+++ b/docs/2026-08-16-first-commit-attribution/prd.md
@@ -1,0 +1,239 @@
+# First-Commit Attribution
+
+## Problem Statement
+
+**Partio records zero attributed lines for the first commit in a
+repository.** A user who installs Partio and commits gets a checkpoint
+that claims the commit added nothing. The earliest work in a repository
+is the work most likely to be large, and it is the work Partio counts
+as empty.
+
+The cause is a corrupted constant. The attribution code asks git for the
+line counts of a commit. It compares the commit against its parent. A
+first commit has no parent, so that comparison fails. The code then
+falls back to a comparison against git's empty tree object, and the
+constant it uses for that object is
+`4b825dc642cb6eb9a060e54bf899d69f82cf7ee2`. The real empty tree object
+is `4b825dc642cb6eb9a060e54bf8d69288fbee4904`. Git answers the fallback
+with `fatal: bad object`. The attribution code catches that error,
+returns an empty result, and reports no error to its caller. The post-
+commit hook therefore has nothing to log and nothing to warn about.
+
+**The same defect makes a first checkpoint hold no diff.** Three
+functions in the git package identify a commit's content by a comparison
+against the parent commit. All three fail on a first commit. One
+produces the line counts, one produces the changed file list, and one
+produces the unified diff that the checkpoint stores. A user's first
+checkpoint therefore holds zero lines, no file list, and no diff.
+
+**A speed claim about this code path cannot be checked.** Issue #30 said
+the post-commit hook performed a full tree walk, and that a replacement
+would cut hook latency. The hook never performed a tree walk. The claim
+came from a sibling product. The repository holds no benchmark, so the
+claim went unmeasured for four months and a pull request was built on
+it.
+
+## Solution
+
+Partio counts the lines in a first commit, lists its files, and stores
+its diff, exactly as it does for every later commit.
+
+One place in the git package decides how to identify a commit's content.
+A commit with a parent keeps today's behaviour, without any change. A
+commit with no parent is compared against git's empty tree object, under
+a named constant that no caller can mistype.
+
+Attribution stops the report of a failed measurement as a zero
+measurement. When git cannot answer, the caller learns about it and
+writes a warning. Hooks stay non-blocking, as the repository requires.
+
+A benchmark compares the current comparison strategy against the
+alternative that issue #30 proposed. The next person who claims that a
+change to this path is faster must show a number. The benchmark also
+records the outcome for this specific alternative: it is not faster.
+
+## User Stories
+
+1. As a Partio user, I want my first commit to record its attributed lines, so that my earliest work is not silently counted as zero.
+2. As a Partio user, I want my first checkpoint to store the changed file list, so that the checkpoint describes what the commit touched.
+3. As a Partio user, I want my first checkpoint to store the unified diff, so that the checkpoint holds the code and not only the session.
+4. As a Partio user, I want a fresh repository to behave like an established one, so that I do not need a second commit before Partio works.
+5. As a Partio user, I want a repository with exactly one commit to report a correct total, so that a new project is not misreported from day one.
+6. As a Partio user, I want a first commit that adds many files to count all of them, so that a project import is measured.
+7. As a Partio user, I want a first commit that adds a binary file to skip that file and still count the text files, so that one binary does not zero the commit.
+8. As a Partio user, I want a first empty commit to record zero lines truthfully, so that a real zero and a failed measurement are different outcomes.
+9. As a Partio user, I want merge commits to keep the counts they have today, so that a fix for first commits does not change my history.
+10. As a Partio user, I want a merge commit to report the lines it brings in against its first parent, so that merge attribution stays comparable across releases.
+11. As a Partio user, I want a regular commit to keep the counts it has today, so that the common path carries no risk from this change.
+12. As a Partio user, I want an agent-authored first commit to record one hundred percent agent lines, so that agent attribution starts at the first commit.
+13. As a Partio user, I want a human-authored first commit to record zero percent agent lines, so that my own work is attributed to me.
+14. As a Partio user, I want a failed measurement to appear in the log, so that I can tell a broken measurement from an empty commit.
+15. As a Partio user, I want a failed measurement to leave my commit intact, so that a hook problem never blocks my work.
+16. As a Partio user, I want the empty tree object identified in one named place, so that a typed literal cannot break this path again.
+17. As a Partio user, I want the fix to cover every commit-diff function, so that one function is not left broken after the others are fixed.
+18. As a Partio user, I want my post-commit path to keep its current speed, so that a correctness fix does not cost me latency.
+19. As a Partio user, I want hook changes justified by measurement, so that my post-commit path does not get slower in the name of speed.
+20. As the operator, I want a benchmark that compares against the old behaviour, so that "faster" is demonstrated rather than asserted.
+21. As the operator, I want the benchmark to cover a repository with many files, so that a scale claim is tested at scale.
+22. As the operator, I want the benchmark to hold both strategies side by side, so that a comparison needs no second branch.
+23. As the operator, I want the rejected strategy kept out of production code, so that the shipped code carries exactly one strategy.
+24. As the operator, I want the benchmark result written down, so that the next proposal about this path meets a recorded number.
+25. As the operator, I want the false premise of issue #30 recorded here, so that the same claim does not return unchallenged.
+26. As the operator, I want the merge regression in pull request #653 recorded here, so that the reason to reject that pull request is written and not remembered.
+27. As the operator, I want the premise-gate document corrected, so that our own record of this defect states the real cause.
+28. As the operator, I want pull request #653 left open, so that the decision to close it stays mine.
+29. As the operator, I want every changed function covered by a test, so that a later refactor cannot reintroduce this defect quietly.
+30. As the operator, I want the tests to follow the house pattern, so that a reader of this package finds nothing unfamiliar.
+31. As a Partio contributor, I want the root-commit decision made in one function, so that a future diff helper inherits the fix.
+32. As a Partio contributor, I want the tests to build real repositories, so that the tests measure git and not a mock of git.
+33. As a Partio contributor, I want a first-commit case in the test table of each function, so that the defect has a permanent guard.
+34. As a Partio contributor, I want a merge-commit case in the test table of each function, so that the regression in pull request #653 cannot land later.
+
+## Implementation Decisions
+
+**Language.** Go. The repository is Go, and an existing repository's
+language wins. No new service and no new script is added.
+
+**One decision point for the commit range.** The git package gets an
+unexported helper. It takes a commit hash. It returns the two revision
+arguments that identify that commit's content:
+
+- For a commit with a parent, it returns the parent revision and the
+  commit revision. This is today's behaviour, unchanged.
+- For a commit with no parent, it returns the empty tree constant and
+  the commit revision.
+
+The helper detects the parent through git, not through a guess. It does
+not swallow an error from git. An error that is not the absence of a
+parent propagates to the caller.
+
+**A named empty tree constant.** The git package holds one exported
+constant for git's empty tree object id, with a comment that states what
+it is. The corrupted literal is deleted. No other package holds a copy.
+
+**Three public functions keep their signatures.** The function for line
+counts, the function for the changed file list, and the function for the
+unified diff each build their own flags and then append the two
+revisions from the helper. Their signatures do not change, so no caller
+changes.
+
+**Merge semantics do not change.** A merge commit has a parent, so it
+takes the unchanged path and is compared against its first parent. The
+`--root` flag is not added to production code, because it makes a merge
+commit produce no output at all.
+
+**Attribution stops the silent zero.** The attribution function drops
+its private copy of the empty tree fallback. When git cannot answer, the
+function returns the error. The post-commit hook already has a branch
+for that error, and that branch writes a warning and continues, so hooks
+stay non-blocking.
+
+**The benchmark holds both strategies.** The benchmark lives in the git
+package as a test-only file. It builds a repository with a large file
+count, then measures two strategies over the same commit:
+
+- The two-commit comparison that the code uses today.
+- The `git diff-tree` plumbing call that issue #30 proposed.
+
+The `git diff-tree` call appears only in that file. Production code
+never gains a second strategy. The benchmark is a measurement tool, and
+continuous integration does not gate on its numbers.
+
+**The file count is a benchmark parameter.** The benchmark runs at a
+size that matches the claim under test, and the size appears in the
+benchmark name so a reader knows what was measured.
+
+## Testing Decisions
+
+**What makes a good test here.** A test drives a public function of the
+package and asserts the value that function returns. It does not assert
+which git subcommand ran, which flags were passed, or which branch of
+the helper executed. A test that survives a rewrite of the internals is
+a good test. A test that fails when the internals move is not.
+
+**Every module is tested.** The three commit-diff functions and the
+attribution function each get tests. This is not negotiated.
+
+**Each function gets the same four cases.** Every commit-diff function
+is tested against a first commit, a regular commit, a merge commit, and
+a commit that adds a binary file. The first-commit case is the guard for
+this defect. The merge-commit case is the guard against the regression
+found in pull request #653.
+
+**Attribution is tested for both actors and for failure.** The tests
+cover an agent-active first commit, a human first commit, and a commit
+hash that git cannot resolve. The failure case asserts that the function
+returns an error, because the silent zero is the defect under repair.
+
+**Prior art.** The git package already holds a test that builds a real
+repository in a temporary directory, runs git through a local helper
+closure, and drives table-driven subtests on the standard library alone.
+The new tests follow it. The repository uses no external test framework,
+and none is added.
+
+**Named gap: the tests change the process working directory.** The three
+commit-diff functions read the process working directory, so a test must
+change directory to reach a temporary repository. This is a wart in the
+existing interface. This work does not repair it, because a repository
+path parameter would ripple to every caller. The gap is named here so it
+is visible rather than silent.
+
+**Named gap: no test asserts hook latency.** The benchmark measures, it
+does not assert. No test fails when the post-commit path gets slower.
+The benchmark exists so a future claim can be checked by a person, not
+so continuous integration can block a merge.
+
+## Out of Scope
+
+- **Pull request #653.** It stays open. The decision to close it belongs
+  to the operator. This work does not close it, does not comment on it,
+  and does not push to its branch.
+- **Issue #30.** It is already closed. This work does not reopen it.
+- **The blanket `git diff-tree` replacement.** It is measured as level
+  on a repository with one thousand files, and roughly thirty to forty
+  percent slower on a repository with ten thousand files. It also zeroes
+  merge attribution. It is not adopted.
+- **A repository path parameter on the commit-diff functions.** The
+  interface wart is named in Testing Decisions and left alone.
+- **The post-commit hook's fallback to one hundred percent on an
+  attribution error.** That behaviour is odd, and it is untouched here.
+- **Attribution by complexity.** Attribution stays binary, at zero or
+  one hundred percent, as it is today.
+- **Any release, tag, or version pin bump.**
+- **Other repositories.** Only the CLI repository changes.
+- **A correction to the premise-gate document.** The correction is
+  recorded in Further Notes below. Whether to edit that document is a
+  separate decision.
+
+## Further Notes
+
+**The premise-gate document states the wrong cause.** It says the
+well-known empty tree object "is not present in a fresh repository — nor
+in this one". That is false. A comparison against
+`4b825dc642cb6eb9a060e54bf8d69288fbee4904` succeeds in a repository
+created seconds earlier, because git special-cases that object. The
+cause is the corrupted constant alone.
+
+This matters more than a footnote. The premise-gate document exists
+because a proposal asserted something about this repository that nobody
+checked. Its own account of this defect is an assertion that nobody
+checked. The gate it describes would have caught it.
+
+**Pull request #653 regresses merge commits.** It routes the line counts
+and the changed file list through `git diff-tree --no-commit-id -r
+--root`. On a merge commit, the current code reports the lines that the
+merge brings in against its first parent. The proposed code reports
+nothing. Merge attribution drops to zero, silently. Issue #30's own
+acceptance criteria required "identical results to the previous
+implementation for regular commits, merges, and initial commits", so the
+pull request fails a criterion that it set for itself.
+
+**The first-commit defect was found by accident.** It is unrelated to
+the stated goal of issue #30, and it is the only real defect in that
+episode. The salvage keeps that fix and nothing else.
+
+**The benchmark is the durable part.** The line-count fix stops a
+present defect. The benchmark stops the next false speed claim, and this
+path has already attracted one. Process startup is roughly two thirds of
+the total in both strategies, which is the more useful finding: the
+comparison strategy was never the bottleneck here.

--- a/internal/attribution/calculate.go
+++ b/internal/attribution/calculate.go
@@ -1,6 +1,7 @@
 package attribution
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -9,14 +10,11 @@ import (
 
 // Calculate computes attribution for a commit based on whether an agent was active.
 func Calculate(commitHash string, agentActive bool) (*Result, error) {
-	// Get numstat for the commit
+	// Get numstat for the commit. A git failure is a failed measurement, not
+	// an empty commit. The error goes to the caller so the two stay apart.
 	numstat, err := git.DiffNumstat(commitHash)
 	if err != nil {
-		// If this is the first commit, try diff against empty tree
-		numstat, err = git.ExecGit("diff", "--numstat", "4b825dc642cb6eb9a060e54bf899d69f82cf7ee2", commitHash)
-		if err != nil {
-			return &Result{}, nil
-		}
+		return nil, fmt.Errorf("measuring commit %s: %w", commitHash, err)
 	}
 
 	totalAdded := 0

--- a/internal/attribution/calculate_test.go
+++ b/internal/attribution/calculate_test.go
@@ -1,0 +1,248 @@
+package attribution
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// initRepo creates a git repository in a temporary directory, changes the
+// process working directory into it, and returns the directory plus a git
+// runner. The commit-diff functions read the process working directory, so
+// the change of directory is required.
+func initRepo(t *testing.T) (string, func(args ...string) string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test")
+
+	return dir, run
+}
+
+// writeLines writes a text file of the given line count into dir.
+func writeLines(t *testing.T, dir, name string, lines int) {
+	t.Helper()
+
+	content := strings.Repeat("line\n", lines)
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestCalculateFirstCommitTextFiles(t *testing.T) {
+	dir, run := initRepo(t)
+
+	writeLines(t, dir, "a.txt", 3)
+	writeLines(t, dir, "b.txt", 2)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	sha := run("git", "rev-parse", "HEAD")
+
+	got, err := Calculate(sha, true)
+	if err != nil {
+		t.Fatalf("Calculate() unexpected error: %v", err)
+	}
+	if got.TotalLines != 5 {
+		t.Errorf("TotalLines = %d, want 5", got.TotalLines)
+	}
+	if got.AgentLines != 5 {
+		t.Errorf("AgentLines = %d, want 5", got.AgentLines)
+	}
+	if got.AgentPercent != 100 {
+		t.Errorf("AgentPercent = %d, want 100", got.AgentPercent)
+	}
+}
+
+func TestCalculateFirstCommitNoAgent(t *testing.T) {
+	dir, run := initRepo(t)
+
+	writeLines(t, dir, "a.txt", 3)
+	writeLines(t, dir, "b.txt", 2)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	sha := run("git", "rev-parse", "HEAD")
+
+	got, err := Calculate(sha, false)
+	if err != nil {
+		t.Fatalf("Calculate() unexpected error: %v", err)
+	}
+	if got.TotalLines != 5 {
+		t.Errorf("TotalLines = %d, want 5", got.TotalLines)
+	}
+	if got.HumanLines != 5 {
+		t.Errorf("HumanLines = %d, want 5", got.HumanLines)
+	}
+	if got.AgentLines != 0 {
+		t.Errorf("AgentLines = %d, want 0", got.AgentLines)
+	}
+	if got.AgentPercent != 0 {
+		t.Errorf("AgentPercent = %d, want 0", got.AgentPercent)
+	}
+}
+
+func TestCalculateFirstCommitBinaryFile(t *testing.T) {
+	dir, run := initRepo(t)
+
+	writeLines(t, dir, "a.txt", 4)
+	// A NUL byte makes git treat the file as binary. Numstat then reports a
+	// dash instead of a line count for it.
+	if err := os.WriteFile(filepath.Join(dir, "logo.bin"), []byte{0x00, 0x01, 0x02, 0x00}, 0o644); err != nil {
+		t.Fatalf("write logo.bin: %v", err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	sha := run("git", "rev-parse", "HEAD")
+
+	numstat := run("git", "show", "--numstat", "--format=", sha)
+	if !strings.Contains(numstat, "-\t-\tlogo.bin") {
+		t.Fatalf("git does not see logo.bin as binary, numstat:\n%s", numstat)
+	}
+
+	got, err := Calculate(sha, true)
+	if err != nil {
+		t.Fatalf("Calculate() unexpected error: %v", err)
+	}
+	if got.TotalLines != 4 {
+		t.Errorf("TotalLines = %d, want 4", got.TotalLines)
+	}
+}
+
+func TestCalculateFirstCommitEmpty(t *testing.T) {
+	_, run := initRepo(t)
+
+	run("git", "commit", "--allow-empty", "-m", "first")
+
+	sha := run("git", "rev-parse", "HEAD")
+
+	got, err := Calculate(sha, true)
+	if err != nil {
+		t.Fatalf("Calculate() unexpected error: %v", err)
+	}
+	if got.TotalLines != 0 {
+		t.Errorf("TotalLines = %d, want 0", got.TotalLines)
+	}
+}
+
+func TestCalculateUnresolvableCommit(t *testing.T) {
+	dir, run := initRepo(t)
+
+	writeLines(t, dir, "a.txt", 1)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	// A well-formed hash that names no object in this repository. Git cannot
+	// measure it, so the measurement failed. A failed measurement must not
+	// look like an empty commit.
+	got, err := Calculate("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", true)
+	if err == nil {
+		t.Fatalf("Calculate() error = nil, want an error; result = %+v", got)
+	}
+}
+
+// addedLines sums the added column of a numstat block. It gives the tests the
+// total that the comparison against the first parent produced before this
+// slice, so a regression against that total is visible.
+func addedLines(t *testing.T, numstat string) int {
+	t.Helper()
+
+	total := 0
+	for _, line := range strings.Split(numstat, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		added, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue // binary file
+		}
+		total += added
+	}
+
+	return total
+}
+
+func TestCalculateRegularCommit(t *testing.T) {
+	dir, run := initRepo(t)
+
+	writeLines(t, dir, "a.txt", 1)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	writeLines(t, dir, "b.txt", 6)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "second")
+
+	sha := run("git", "rev-parse", "HEAD")
+	want := addedLines(t, run("git", "diff", "--numstat", sha+"~1", sha))
+	if want != 6 {
+		t.Fatalf("the comparison against the parent gives %d added lines, want 6", want)
+	}
+
+	got, err := Calculate(sha, true)
+	if err != nil {
+		t.Fatalf("Calculate() unexpected error: %v", err)
+	}
+	if got.TotalLines != want {
+		t.Errorf("TotalLines = %d, want %d", got.TotalLines, want)
+	}
+}
+
+func TestCalculateMergeCommit(t *testing.T) {
+	dir, run := initRepo(t)
+
+	writeLines(t, dir, "a.txt", 1)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	base := run("git", "rev-parse", "--abbrev-ref", "HEAD")
+
+	run("git", "checkout", "-b", "feature")
+	writeLines(t, dir, "c.txt", 3)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "feature work")
+
+	run("git", "checkout", base)
+	writeLines(t, dir, "b.txt", 2)
+	run("git", "add", ".")
+	run("git", "commit", "-m", "base work")
+
+	run("git", "merge", "--no-ff", "-m", "merge feature", "feature")
+
+	sha := run("git", "rev-parse", "HEAD")
+	want := addedLines(t, run("git", "diff", "--numstat", sha+"~1", sha))
+	if want != 3 {
+		t.Fatalf("the comparison against the first parent gives %d added lines, want 3", want)
+	}
+
+	got, err := Calculate(sha, true)
+	if err != nil {
+		t.Fatalf("Calculate() unexpected error: %v", err)
+	}
+	// A merge commit must keep the lines it brings in against its first
+	// parent. The --root flag makes this total zero, which is the regression
+	// in pull request #653.
+	if got.TotalLines != want {
+		t.Errorf("TotalLines = %d, want %d", got.TotalLines, want)
+	}
+}

--- a/internal/git/commit_range.go
+++ b/internal/git/commit_range.go
@@ -1,0 +1,25 @@
+package git
+
+import "strings"
+
+// commitRange returns the two revision arguments that identify the content of
+// commitHash. A commit with a parent compares against its first parent. A
+// commit with no parent compares against git's empty tree.
+//
+// Git supplies the parent. An error from git propagates to the caller, so a
+// commit that does not exist is not mistaken for a commit with no parent.
+func commitRange(commitHash string) (string, string, error) {
+	out, err := execGit("rev-list", "--parents", "-n", "1", commitHash)
+	if err != nil {
+		return "", "", err
+	}
+
+	// The first field is the commit itself. The fields after it are the
+	// parents. No parent means this is the first commit of the repository.
+	fields := strings.Fields(out)
+	if len(fields) < 2 {
+		return EmptyTree, commitHash, nil
+	}
+
+	return fields[1], commitHash, nil
+}

--- a/internal/git/commit_range_test.go
+++ b/internal/git/commit_range_test.go
@@ -1,0 +1,93 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommitRange(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test")
+
+	write("a.txt", "one\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+	first := run("git", "rev-parse", "HEAD")
+
+	write("a.txt", "one\ntwo\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "second")
+	second := run("git", "rev-parse", "HEAD")
+
+	tests := []struct {
+		name     string
+		commit   string
+		wantFrom string
+		wantTo   string
+		wantErr  bool
+	}{
+		{
+			name:     "commit with no parent compares against the empty tree",
+			commit:   first,
+			wantFrom: EmptyTree,
+			wantTo:   first,
+		},
+		{
+			name:     "commit with a parent compares against that parent",
+			commit:   second,
+			wantFrom: first,
+			wantTo:   second,
+		},
+		{
+			name:    "an error that is not the absence of a parent propagates",
+			commit:  "0000000000000000000000000000000000000000",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, to, err := commitRange(tt.commit)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("commitRange(%s) = (%q, %q, nil), want an error", tt.commit, from, to)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("commitRange() unexpected error: %v", err)
+			}
+			if from != tt.wantFrom {
+				t.Errorf("from = %q, want %q", from, tt.wantFrom)
+			}
+			if to != tt.wantTo {
+				t.Errorf("to = %q, want %q", to, tt.wantTo)
+			}
+		})
+	}
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -2,5 +2,10 @@ package git
 
 // Diff returns the unified diff for a specific commit.
 func Diff(commitHash string) (string, error) {
-	return execGit("diff", commitHash+"~1", commitHash)
+	from, to, err := commitRange(commitHash)
+	if err != nil {
+		return "", err
+	}
+
+	return execGit("diff", from, to)
 }

--- a/internal/git/diff_name_only.go
+++ b/internal/git/diff_name_only.go
@@ -4,7 +4,12 @@ import "strings"
 
 // DiffNameOnly returns the list of file paths changed in a specific commit.
 func DiffNameOnly(commitHash string) ([]string, error) {
-	out, err := execGit("diff", "--name-only", commitHash+"~1", commitHash)
+	from, to, err := commitRange(commitHash)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := execGit("diff", "--name-only", from, to)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/diff_name_only_test.go
+++ b/internal/git/diff_name_only_test.go
@@ -1,0 +1,143 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newDiffNameOnlyRepo makes an empty git repository in a temporary directory,
+// changes into it, and returns a command runner and a file writer for it.
+func newDiffNameOnlyRepo(t *testing.T) (run func(args ...string) string, write func(name, content string)) {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	run = func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	write = func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test")
+
+	return run, write
+}
+
+func TestDiffNameOnly(t *testing.T) {
+	run, write := newDiffNameOnlyRepo(t)
+
+	write("a.txt", "one\n")
+	write("b.txt", "two\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+	first := run("git", "rev-parse", "HEAD")
+
+	write("a.txt", "one\nthree\n")
+	write("c.txt", "four\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "second")
+	second := run("git", "rev-parse", "HEAD")
+
+	// A merge commit brings in the branch file. It has a parent, so it takes
+	// the unchanged path and is compared against that first parent.
+	run("git", "checkout", "-b", "side", first)
+	write("d.txt", "five\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "side")
+	run("git", "checkout", "-")
+	run("git", "merge", "--no-ff", "-m", "merge", "side")
+	merge := run("git", "rev-parse", "HEAD")
+
+	run("git", "commit", "--allow-empty", "-m", "empty")
+	empty := run("git", "rev-parse", "HEAD")
+
+	tests := []struct {
+		name   string
+		commit string
+		want   []string
+	}{
+		{
+			name:   "a first commit returns every path it adds",
+			commit: first,
+			want:   []string{"a.txt", "b.txt"},
+		},
+		{
+			name:   "a regular commit returns the paths it changes",
+			commit: second,
+			want:   []string{"a.txt", "c.txt"},
+		},
+		{
+			name:   "a merge commit returns the paths it brings in against its first parent",
+			commit: merge,
+			want:   []string{"d.txt"},
+		},
+		{
+			name:   "an empty commit returns an empty result and no error",
+			commit: empty,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DiffNameOnly(tt.commit)
+			if err != nil {
+				t.Fatalf("DiffNameOnly() unexpected error: %v", err)
+			}
+			if !equalPaths(got, tt.want) {
+				t.Errorf("DiffNameOnly() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDiffNameOnlyBinaryFirstCommit needs its own repository, because the
+// binary file must land in the first commit.
+func TestDiffNameOnlyBinaryFirstCommit(t *testing.T) {
+	run, write := newDiffNameOnlyRepo(t)
+
+	write("a.txt", "one\n")
+	write("logo.png", string([]byte{0x00, 0x01, 0x02, 0x00, 0xff}))
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+	first := run("git", "rev-parse", "HEAD")
+
+	got, err := DiffNameOnly(first)
+	if err != nil {
+		t.Fatalf("DiffNameOnly() unexpected error: %v", err)
+	}
+	want := []string{"a.txt", "logo.png"}
+	if !equalPaths(got, want) {
+		t.Errorf("DiffNameOnly() = %v, want %v", got, want)
+	}
+}
+
+func equalPaths(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/git/diff_numstat.go
+++ b/internal/git/diff_numstat.go
@@ -2,5 +2,10 @@ package git
 
 // DiffNumstat returns numstat for a specific commit.
 func DiffNumstat(commitHash string) (string, error) {
-	return execGit("diff", "--numstat", commitHash+"~1", commitHash)
+	from, to, err := commitRange(commitHash)
+	if err != nil {
+		return "", err
+	}
+
+	return execGit("diff", "--numstat", from, to)
 }

--- a/internal/git/diff_numstat_bench_test.go
+++ b/internal/git/diff_numstat_bench_test.go
@@ -1,0 +1,132 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// BenchmarkCommitDiffStrategies measures the two ways to identify the content
+// of a commit that the post-commit path can use:
+//
+//   - The two-commit "git diff" that production code runs today, through
+//     DiffNumstat.
+//   - The "git diff-tree --no-commit-id -r --root" plumbing call that issue
+//     #30 proposed as the faster replacement.
+//
+// The diff-tree call is in this file only. Production code keeps one strategy.
+// This benchmark measures the alternative. It does not adopt it.
+//
+// Each repository holds the number of tracked files in the benchmark name. The
+// measured commit changes one file, which is what a post-commit hook sees in a
+// real repository. Continuous integration does not gate on these numbers. A
+// person reads them.
+func BenchmarkCommitDiffStrategies(b *testing.B) {
+	for _, fileCount := range []int{1000, 10000} {
+		dir, commit := buildBenchRepo(b, fileCount)
+
+		b.Run(fmt.Sprintf("current_git_diff/%d_files", fileCount), func(b *testing.B) {
+			b.Chdir(dir)
+			for b.Loop() {
+				if _, err := DiffNumstat(commit); err != nil {
+					b.Fatalf("DiffNumstat(%s): %v", commit, err)
+				}
+			}
+		})
+
+		// The two strategies differ in two ways at once: the git command, and
+		// the number of git processes. DiffNumstat asks git for the parent
+		// first, so it starts two processes. The diff-tree call starts one.
+		// This third measurement times the diff command alone, with the two
+		// revisions resolved before the loop. It isolates the git command, so
+		// a reader can tell the two causes apart.
+		b.Run(fmt.Sprintf("current_git_diff_command_only/%d_files", fileCount), func(b *testing.B) {
+			b.Chdir(dir)
+			from, to, err := commitRange(commit)
+			if err != nil {
+				b.Fatalf("commitRange(%s): %v", commit, err)
+			}
+			for b.Loop() {
+				if _, err := execGit("diff", "--numstat", from, to); err != nil {
+					b.Fatalf("git diff %s %s: %v", from, to, err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("proposed_git_diff_tree/%d_files", fileCount), func(b *testing.B) {
+			b.Chdir(dir)
+			for b.Loop() {
+				if _, err := benchDiffTree(commit); err != nil {
+					b.Fatalf("benchDiffTree(%s): %v", commit, err)
+				}
+			}
+		})
+	}
+}
+
+// benchDiffTree runs the plumbing call that issue #30 proposed in place of the
+// two-commit diff. It is the measured alternative. It is unexported, it is in
+// this benchmark file, and no production file calls it.
+//
+// It mirrors execGit: it reads the process working directory and it takes
+// stdout only, so the two strategies differ in the git command alone.
+func benchDiffTree(commitHash string) (string, error) {
+	cmd := exec.Command("git", "diff-tree", "--no-commit-id", "-r", "--root", "--numstat", commitHash)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// buildBenchRepo makes a repository with fileCount tracked files in the
+// benchmark's temporary directory. It returns that directory and the hash of a
+// second commit that changes one file. The setup is outside the timed loop.
+func buildBenchRepo(b *testing.B, fileCount int) (string, string) {
+	b.Helper()
+
+	dir := b.TempDir()
+
+	run := func(args ...string) string {
+		b.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			b.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	write := func(name, content string) {
+		b.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			b.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test")
+
+	for i := range fileCount {
+		write(fmt.Sprintf("file%05d.txt", i), "one\n")
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	write("file00000.txt", "one\ntwo\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "second")
+
+	// The benchmark name states the file count. Check the repository agrees,
+	// so the name cannot claim a size the repository does not have.
+	if tracked := len(strings.Fields(run("git", "ls-files"))); tracked != fileCount {
+		b.Fatalf("repository holds %d tracked files, want %d", tracked, fileCount)
+	}
+
+	return dir, run("git", "rev-parse", "HEAD")
+}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,0 +1,104 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiffFirstCommit is the tracer bullet for slice 03. A first commit has no
+// parent, so the old revision expression `HEAD~1` made git fail and the hook
+// stored a checkpoint with no diff at all.
+func TestDiffFirstCommit(t *testing.T) {
+	run, write := newDiffNameOnlyRepo(t)
+
+	write("a.txt", "one\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+	first := run("git", "rev-parse", "HEAD")
+
+	got, err := Diff(first)
+	if err != nil {
+		t.Fatalf("Diff() unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "a.txt") {
+		t.Errorf("Diff() = %q, want it to name a.txt", got)
+	}
+	if !strings.Contains(got, "+one") {
+		t.Errorf("Diff() = %q, want it to hold the added content", got)
+	}
+}
+
+// TestDiffUnchangedForCommitsWithAParent holds the behaviour of every commit
+// that has a parent. Such a commit still compares against its first parent, so
+// the result must equal the old `<commit>~1 <commit>` expression exactly.
+func TestDiffUnchangedForCommitsWithAParent(t *testing.T) {
+	run, write := newDiffNameOnlyRepo(t)
+
+	write("a.txt", "one\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+	first := run("git", "rev-parse", "HEAD")
+
+	write("a.txt", "one\nthree\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "second")
+	second := run("git", "rev-parse", "HEAD")
+
+	// A merge commit brings in the branch file. It has a parent, so it takes
+	// the unchanged path and is compared against that first parent.
+	run("git", "checkout", "-b", "side", first)
+	write("d.txt", "five\n")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "side")
+	run("git", "checkout", "-")
+	run("git", "merge", "--no-ff", "-m", "merge", "side")
+	merge := run("git", "rev-parse", "HEAD")
+
+	run("git", "commit", "--allow-empty", "-m", "empty")
+	empty := run("git", "rev-parse", "HEAD")
+
+	tests := []struct {
+		name         string
+		commit       string
+		wantContains string
+		wantEmpty    bool
+	}{
+		{
+			name:         "a regular commit returns the diff it returns today",
+			commit:       second,
+			wantContains: "+three",
+		},
+		{
+			// Pull request #653 added the --root flag, which makes git return
+			// nothing at all for a merge commit. This row fails if that
+			// mistake returns.
+			name:         "a merge commit returns the diff against its first parent",
+			commit:       merge,
+			wantContains: "d.txt",
+		},
+		{
+			name:      "an empty commit returns an empty result and no error",
+			commit:    empty,
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Diff(tt.commit)
+			if err != nil {
+				t.Fatalf("Diff() unexpected error: %v", err)
+			}
+			want := run("git", "diff", tt.commit+"~1", tt.commit)
+			if strings.TrimSpace(got) != want {
+				t.Errorf("Diff() = %q, want %q", got, want)
+			}
+			if tt.wantContains != "" && !strings.Contains(got, tt.wantContains) {
+				t.Errorf("Diff() = %q, want it to hold %q", got, tt.wantContains)
+			}
+			if tt.wantEmpty && strings.TrimSpace(got) != "" {
+				t.Errorf("Diff() = %q, want an empty result", got)
+			}
+		})
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,11 @@ import (
 
 const CheckpointBranch = "partio/checkpoints/v1"
 
+// EmptyTree is the object id of git's empty tree. Git always gives a tree
+// with no entries this hash, so a diff against it shows the full content of
+// a commit that has no parent.
+const EmptyTree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
 // execGit runs a git command and returns trimmed stdout.
 func execGit(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)

--- a/internal/hooks/postcommit_test.go
+++ b/internal/hooks/postcommit_test.go
@@ -1,0 +1,184 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/partio-io/cli/internal/checkpoint"
+	"github.com/partio-io/cli/internal/config"
+	"github.com/partio-io/cli/internal/git"
+)
+
+// newPostCommitRepo makes an empty git repository in a temporary directory,
+// changes into it, and returns the repository root and a command runner.
+func newPostCommitRepo(t *testing.T) (dir string, run func(args ...string) string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	t.Chdir(dir)
+
+	run = func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test")
+
+	return dir, run
+}
+
+// enableCheckpointBranch makes the orphan branch that the checkpoint store
+// writes to. In production `partio enable` does this.
+func enableCheckpointBranch(t *testing.T, run func(args ...string) string) {
+	t.Helper()
+
+	tree := run("git", "hash-object", "-t", "tree", "/dev/null")
+	commit := run("git", "commit-tree", tree, "-m", "partio: initialize checkpoint storage")
+	run("git", "update-ref", "refs/heads/"+git.CheckpointBranch, commit)
+}
+
+// TestPostCommitFirstCommitStoresDiff proves the end of the slice: the
+// checkpoint written for the first commit of a repository holds that commit's
+// diff. Before this slice git.Diff failed on a root commit, the hook swallowed
+// the error in an `err == nil` check, and the checkpoint held no code at all.
+func TestPostCommitFirstCommitStoresDiff(t *testing.T) {
+	dir, run := newPostCommitRepo(t)
+	enableCheckpointBranch(t, run)
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	writePreCommitState(t, dir, preCommitState{
+		AgentActive: true,
+		AgentName:   "claude-code",
+		Branch:      run("git", "rev-parse", "--abbrev-ref", "HEAD"),
+	})
+
+	if err := runPostCommit(dir, config.Config{Agent: "claude-code"}); err != nil {
+		t.Fatalf("runPostCommit() unexpected error: %v", err)
+	}
+
+	id := checkpointIDFromTrailers(t, run("git", "log", "-1", "--format=%B"))
+	data, err := checkpoint.Read(id)
+	if err != nil {
+		t.Fatalf("checkpoint.Read(%s): %v", id, err)
+	}
+
+	if strings.TrimSpace(data.Diff) == "" {
+		t.Fatal("checkpoint holds an empty diff, want the diff of the first commit")
+	}
+	if !strings.Contains(data.Diff, "a.txt") {
+		t.Errorf("checkpoint diff = %q, want it to name a.txt", data.Diff)
+	}
+	if !strings.Contains(data.Diff, "+one") {
+		t.Errorf("checkpoint diff = %q, want it to hold the added content", data.Diff)
+	}
+}
+
+// captureLogs sends the default logger to a buffer for the length of the test
+// and returns the buffer. The hook reports a failed measurement through the
+// default logger, so the buffer is where the warning becomes visible.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return buf
+}
+
+// breakCommitObject deletes the object file of the given commit. Git then reads
+// the reference but cannot read the commit, so it cannot measure it. This is
+// the failure the corrupted empty tree constant produced in the field: `fatal:
+// bad object`.
+func breakCommitObject(t *testing.T, repoRoot, sha string) {
+	t.Helper()
+
+	object := filepath.Join(repoRoot, ".git", "objects", sha[:2], sha[2:])
+	if err := os.Remove(object); err != nil {
+		t.Fatalf("remove commit object %s: %v", sha, err)
+	}
+}
+
+// TestPostCommitWarnsWhenAttributionFails proves the point of the slice: a
+// measurement that git cannot make is reported. Before this slice the
+// attribution function returned an empty result and a nil error, so this
+// warning branch of the hook never ran and the defect stayed silent.
+func TestPostCommitWarnsWhenAttributionFails(t *testing.T) {
+	dir, run := newPostCommitRepo(t)
+	enableCheckpointBranch(t, run)
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "first")
+
+	branch := run("git", "rev-parse", "--abbrev-ref", "HEAD")
+	breakCommitObject(t, dir, run("git", "rev-parse", "HEAD"))
+
+	writePreCommitState(t, dir, preCommitState{
+		AgentActive: true,
+		AgentName:   "claude-code",
+		Branch:      branch,
+	})
+
+	logs := captureLogs(t)
+
+	// The hook must not fail the git operation when a measurement fails.
+	if err := runPostCommit(dir, config.Config{Agent: "claude-code"}); err != nil {
+		t.Fatalf("runPostCommit() error = %v, want nil; a failed measurement must not fail the git operation", err)
+	}
+
+	if !strings.Contains(logs.String(), "could not calculate attribution") {
+		t.Errorf("the hook wrote no attribution warning, logs:\n%s", logs.String())
+	}
+}
+
+func writePreCommitState(t *testing.T, repoRoot string, state preCommitState) {
+	t.Helper()
+
+	stateDir := filepath.Join(repoRoot, config.PartioDir, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("make state dir: %v", err)
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal pre-commit state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "pre-commit.json"), data, 0o644); err != nil {
+		t.Fatalf("write pre-commit state: %v", err)
+	}
+}
+
+func checkpointIDFromTrailers(t *testing.T, message string) string {
+	t.Helper()
+
+	const prefix = "Partio-Checkpoint:"
+	for line := range strings.SplitSeq(message, "\n") {
+		if after, ok := strings.CutPrefix(strings.TrimSpace(line), prefix); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	t.Fatalf("commit message holds no %s trailer:\n%s", prefix, message)
+	return ""
+}

--- a/internal/premise/fixture_test.go
+++ b/internal/premise/fixture_test.go
@@ -1,0 +1,219 @@
+package premise
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoRoot is this repository's root, relative to the package directory that go
+// test runs in.
+const repoRoot = "../.."
+
+// claimEvidence records what the tree said about one claim, and the verdict
+// that evidence produced. Present and absent are the excerpts the verdict
+// rests on, re-read from the tree on every run: if the code they describe
+// changes, the recorded verdict stops being true and this test says so, rather
+// than the record quietly rotting into a comment nobody rechecks.
+//
+// Prose and evidence are set only for a fixture that carries no premise block.
+// They are the claim a stage extracts from the issue prose, and the path that
+// settles it. Prose is quoted from the body word for word, and the test fails
+// unless it is still there, so an extracted claim is grounded in what the
+// proposal says rather than in what this record wishes it said.
+type claimEvidence struct {
+	prose    string
+	evidence string
+	present  []string
+	absent   []string
+	verdict  Verdict
+	why      string
+}
+
+// TestPremiseFixturesAreVerifiedAgainstThisRepository runs the verifier's
+// procedure over both fixtures: gather the evidence each claim names, then
+// decide from what was gathered. It checks both directions on purpose. A gate
+// that drops everything and a gate that works are indistinguishable until
+// something is shown to pass it.
+func TestPremiseFixturesAreVerifiedAgainstThisRepository(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		source  Source
+		block   Verdict
+		claims  []claimEvidence
+	}{
+		{
+			name:    "the issue #30 premise fails against this repository",
+			fixture: "issue-30.md",
+			source:  SourceBlock,
+			block:   Fails,
+			claims: []claimEvidence{{
+				// The hook names the changed files with a git diff, which
+				// compares two trees and reads no directory.
+				present: []string{"git.DiffNameOnly(commitHash)"},
+				absent:  []string{"filepath.Walk", "filepath.WalkDir", "os.ReadDir", "ls-files"},
+				verdict: Fails,
+				why:     "the post-commit hook walks no tree; it asks git to diff two commits",
+			}, {
+				// The loop runs over the numstat output, which carries one
+				// line per changed file, not one per tracked file.
+				present: []string{"git.DiffNumstat(commitHash)", "strings.Split(numstat"},
+				absent:  []string{"filepath.Walk", "ls-files"},
+				verdict: Fails,
+				why:     "the cost follows the number of changed files, not the number tracked",
+			}},
+		},
+		{
+			// The proposal that started this work, as it was actually filed:
+			// prose, no premise block, and a claim already proven false. An
+			// older proposal is not exempt, so the same evidence settles it
+			// the same way whether it arrived in a block or in a paragraph.
+			name:    "the issue #30 body fails on claims extracted from its prose",
+			fixture: "issue-30-body.md",
+			source:  SourceProse,
+			block:   Fails,
+			claims: []claimEvidence{{
+				prose:    "performs a full tree walk to determine which files were changed in a commit",
+				evidence: "internal/hooks/postcommit.go",
+				present:  []string{"git.DiffNameOnly(commitHash)"},
+				absent:   []string{"filepath.Walk", "filepath.WalkDir", "os.ReadDir", "ls-files"},
+				verdict:  Fails,
+				why:      "the post-commit hook walks no tree; it asks git to diff two commits",
+			}, {
+				prose:    "This is O(N) in the number of tracked files",
+				evidence: "internal/attribution/calculate.go",
+				present:  []string{"git.DiffNumstat(commitHash)", "strings.Split(numstat"},
+				absent:   []string{"filepath.Walk", "ls-files"},
+				verdict:  Fails,
+				why:      "the cost follows the number of changed files, not the number tracked",
+			}},
+		},
+		{
+			name:    "a claim that is true of this repository holds",
+			fixture: "holds.md",
+			source:  SourceBlock,
+			block:   Holds,
+			claims: []claimEvidence{{
+				present: []string{"if agentActive", "result.AgentPercent = 100"},
+				verdict: Holds,
+				why:     "an agent-active commit is attributed wholly to the agent",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src, err := os.ReadFile(filepath.Join("testdata", tt.fixture))
+			if err != nil {
+				t.Fatalf("read the %s fixture: %v", tt.fixture, err)
+			}
+			body := string(src)
+			if got := ClaimSource(body); got != tt.source {
+				t.Fatalf("the %s fixture takes its claims from the %s, want the %s", tt.fixture, got, tt.source)
+			}
+
+			var claims []Claim
+			switch tt.source {
+			case SourceBlock:
+				block, err := Parse(body)
+				if err != nil {
+					t.Fatalf("the %s fixture does not parse: %v", tt.fixture, err)
+				}
+				claims = block.Claims
+			case SourceProse:
+				// Extraction is the agent's work at check time, so what this
+				// test pins is that the claims it verifies are the ones the
+				// prose actually makes.
+				for _, record := range tt.claims {
+					if !strings.Contains(body, record.prose) {
+						t.Fatalf("the %s fixture no longer says %q, so the extracted claim is invented", tt.fixture, record.prose)
+					}
+					claims = append(claims, Claim{Statement: record.prose, Evidence: record.evidence})
+				}
+			}
+
+			if len(claims) != len(tt.claims) {
+				t.Fatalf("the %s fixture states %d claims, the record covers %d", tt.fixture, len(claims), len(tt.claims))
+			}
+
+			// One loop from here down, whichever way the claims arrived. An
+			// extracted claim is verified by the same behaviour as one the
+			// proposal carried, or "the same behaviour" is only a promise.
+			worst := Holds
+			for i, c := range claims {
+				record := tt.claims[i]
+
+				// Gather. A claim whose evidence cannot be read settles
+				// nothing, and an unread claim is never a pass.
+				raw, err := os.ReadFile(filepath.Join(repoRoot, c.Evidence))
+				if err != nil {
+					t.Errorf("claim %q: evidence %q could not be gathered: %v", c.Statement, c.Evidence, err)
+					worst = Unresolved
+					continue
+				}
+				got := string(raw)
+
+				// Decide, from what was gathered and nothing else.
+				for _, wanted := range record.present {
+					if !strings.Contains(got, wanted) {
+						t.Errorf("claim %q: %s no longer contains %q, so the recorded verdict %q is stale",
+							c.Statement, c.Evidence, wanted, record.verdict)
+					}
+				}
+				for _, unwanted := range record.absent {
+					if strings.Contains(got, unwanted) {
+						t.Errorf("claim %q: %s now contains %q, so the recorded verdict %q is stale",
+							c.Statement, c.Evidence, unwanted, record.verdict)
+					}
+				}
+
+				if record.verdict == Fails {
+					worst = Fails
+				}
+				t.Logf("claim %q -> %s (%s)", c.Statement, record.verdict, record.why)
+			}
+
+			if worst != tt.block {
+				t.Errorf("the %s fixture verifies as %q, want %q", tt.fixture, worst, tt.block)
+			}
+		})
+	}
+}
+
+// TestIssueThirtyPremiseFixtureParses pins the premise of issue #30, the
+// proposal that started this work. Its claims are false for this repository and
+// the evidence that settles them is known, which makes it the case a later
+// stage has to catch. Slice 4 verifies the claims; this only captures them.
+func TestIssueThirtyPremiseFixtureParses(t *testing.T) {
+	path := filepath.Join("testdata", "issue-30.md")
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the issue #30 fixture: %v", err)
+	}
+
+	block, err := Parse(string(src))
+	if err != nil {
+		t.Fatalf("the issue #30 fixture does not parse: %v", err)
+	}
+	if len(block.Claims) == 0 {
+		t.Fatal("the issue #30 fixture captures no claims")
+	}
+
+	for _, c := range block.Claims {
+		if c.Evidence == "" {
+			t.Errorf("claim %q captures no evidence", c.Statement)
+			continue
+		}
+		// The fixture names paths, not commands, so the evidence has to be
+		// something a later stage can actually open.
+		if strings.ContainsAny(c.Evidence, " ") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(repoRoot, c.Evidence)); err != nil {
+			t.Errorf("claim %q names evidence that is not in this repository: %v", c.Statement, err)
+		}
+	}
+}

--- a/internal/premise/gate.go
+++ b/internal/premise/gate.go
@@ -1,0 +1,29 @@
+package premise
+
+// A stage gate is what a stage does with a verdict. Verification decides
+// whether a claim holds; the gate decides what happens next, and it is one
+// described behaviour rather than a rule each stage invents. A stage that
+// gates its own way stops differently from the stage beside it, and an
+// operator reading a blocked issue cannot tell which of them stopped it.
+const (
+	// GatePath is where the gate is described, relative to the repository
+	// root.
+	GatePath = ".minions/stage-gate.md"
+
+	// GateMarker names the description and its format version. Exactly one
+	// file carries it, which is what makes "described once" checkable.
+	GateMarker = "<!-- partio:stage-gate:v1 -->"
+)
+
+const (
+	// BlockingLabel is the label a stage adds when a premise fails. The
+	// approval program already treats it as a skip condition, so blocking
+	// needs no new label and no new pipeline wiring. Removing it is how the
+	// operator overrules a verdict.
+	BlockingLabel = "do-not-build"
+
+	// GateCommentMarker opens the comment a blocked stage posts. The comment
+	// is the operator's whole account of why the stage stopped, so it is
+	// findable by marker rather than by matching the prose around it.
+	GateCommentMarker = "<!-- partio:premise-gate:v1 -->"
+)

--- a/internal/premise/premise.go
+++ b/internal/premise/premise.go
@@ -1,0 +1,149 @@
+// Package premise defines the premise block that a filed proposal carries: the
+// factual claims the proposal depends on, each paired with the evidence that
+// settles it. The block is machine-checkable, so a later stage rechecks a
+// proposal from this block alone and never has to parse the surrounding prose.
+package premise
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// Heading starts the premise section of an issue body.
+	Heading = "## Premise"
+
+	// Marker names the block and its format version, so a later stage finds
+	// the section without guessing at the prose around it.
+	Marker = "<!-- partio:premise:v1 -->"
+)
+
+var (
+	// ErrNotFound reports a body that carries no premise section.
+	ErrNotFound = errors.New("premise: no premise section")
+
+	// ErrNoClaims reports a premise section that states nothing.
+	ErrNoClaims = errors.New("premise: section carries no claims")
+
+	// ErrNoEvidence reports a claim with no evidence to settle it.
+	ErrNoEvidence = errors.New("premise: claim has no evidence")
+)
+
+// Claim is one factual statement about the repository, with the evidence that
+// settles it: a path, a symbol, or a command whose output decides the matter.
+type Claim struct {
+	Statement string
+	Evidence  string
+}
+
+// Block is the set of claims a proposal depends on.
+type Block struct {
+	Claims []Claim
+}
+
+// claimLine matches one claim. The whole claim is on one line, and the evidence
+// closes it, so a claim that names nothing cannot pass as prose.
+var claimLine = regexp.MustCompile("^-\\s+(.*\\S)\\s+\\[evidence:\\s*`([^`]*)`\\]$")
+
+// Render writes a block as the premise section a proposal carries. It refuses a
+// claim with no evidence rather than emit an empty field for a later stage to
+// puzzle over.
+func Render(b Block) (string, error) {
+	if len(b.Claims) == 0 {
+		return "", ErrNoClaims
+	}
+
+	var out strings.Builder
+	out.WriteString(Heading + "\n\n" + Marker + "\n\n")
+
+	for _, c := range b.Claims {
+		statement := strings.TrimSpace(c.Statement)
+		evidence := strings.TrimSpace(c.Evidence)
+
+		if statement == "" {
+			return "", fmt.Errorf("premise: claim states nothing (evidence %q)", evidence)
+		}
+		if evidence == "" {
+			return "", fmt.Errorf("%w: %s", ErrNoEvidence, statement)
+		}
+		if strings.ContainsAny(statement, "\n\r") || strings.ContainsAny(evidence, "\n\r`") {
+			return "", fmt.Errorf("premise: claim does not fit one line: %s", statement)
+		}
+
+		fmt.Fprintf(&out, "- %s [evidence: `%s`]\n", statement, evidence)
+	}
+
+	return out.String(), nil
+}
+
+// Find returns the premise section of an issue body, from the heading to the
+// next heading of the same level or to the end of the body. It reports false
+// unless the section also carries Marker.
+func Find(body string) (string, bool) {
+	lines := strings.Split(body, "\n")
+
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == Heading {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+
+	end := len(lines)
+	for i := start; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "## ") {
+			end = i
+			break
+		}
+	}
+
+	section := strings.Join(lines[start:end], "\n")
+	if !strings.Contains(section, Marker) {
+		return "", false
+	}
+	return section, true
+}
+
+// Parse reads the premise block out of an issue body. It rejects a claim that
+// attaches no evidence rather than return it with an empty field.
+func Parse(body string) (Block, error) {
+	section, ok := Find(body)
+	if !ok {
+		return Block{}, ErrNotFound
+	}
+
+	var b Block
+	for _, line := range strings.Split(section, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == Marker {
+			continue
+		}
+
+		m := claimLine.FindStringSubmatch(line)
+		if m == nil {
+			if !strings.Contains(line, "[evidence:") {
+				return Block{}, fmt.Errorf("%w: %s", ErrNoEvidence, line)
+			}
+			return Block{}, fmt.Errorf("premise: line is not one claim: %s", line)
+		}
+		if strings.TrimSpace(m[2]) == "" {
+			return Block{}, fmt.Errorf("%w: %s", ErrNoEvidence, m[1])
+		}
+
+		b.Claims = append(b.Claims, Claim{
+			Statement: m[1],
+			Evidence:  strings.TrimSpace(m[2]),
+		})
+	}
+
+	if len(b.Claims) == 0 {
+		return Block{}, ErrNoClaims
+	}
+	return b, nil
+}

--- a/internal/premise/premise_test.go
+++ b/internal/premise/premise_test.go
@@ -1,0 +1,214 @@
+package premise
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFindLocatesTheSectionWithoutGuessing(t *testing.T) {
+	const claim = "- A claim. [evidence: `a.go`]"
+
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "the section ends the body",
+			body: "Description.\n\n" + Heading + "\n\n" + Marker + "\n\n" + claim + "\n",
+			want: true,
+		},
+		{
+			name: "the section sits between two other sections",
+			body: "## Why\n\nreasons\n\n" + Heading + "\n\n" + Marker + "\n\n" + claim +
+				"\n\n## Acceptance criteria\n\n- something else\n",
+			want: true,
+		},
+		{
+			name: "the body carries no premise section",
+			body: "## Why\n\nreasons\n",
+			want: false,
+		},
+		{
+			name: "a hand-written heading with no marker is not the block",
+			body: "## Premise\n\nWe assume the hook walks the whole tree.\n",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Find(tt.body)
+			if ok != tt.want {
+				t.Fatalf("Find found = %v, want %v; section %q", ok, tt.want, got)
+			}
+			if !ok {
+				return
+			}
+			if !strings.Contains(got, claim) {
+				t.Errorf("section is missing its claim: %q", got)
+			}
+			if strings.Contains(got, "Acceptance criteria") {
+				t.Errorf("section runs past the heading that ends it: %q", got)
+			}
+		})
+	}
+}
+
+// issueBody wraps a premise section in the prose an issue carries around it, so
+// the tests exercise the section boundaries and not just the claim lines.
+func issueBody(claims string) string {
+	return "Some description of the proposal.\n\n" +
+		Heading + "\n\n" + Marker + "\n\n" + claims + "\n\n" +
+		"## Next steps\n\nprose that is not a claim\n"
+}
+
+func TestParseReadsOneClaimPerLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		claims  string
+		want    []Claim
+		wantErr bool
+	}{
+		{
+			name:   "a claim names the path that proves it",
+			claims: "- The post-commit hook reads the commit diff. [evidence: `internal/hooks/post_commit.go`]",
+			want: []Claim{{
+				Statement: "The post-commit hook reads the commit diff.",
+				Evidence:  "internal/hooks/post_commit.go",
+			}},
+		},
+		{
+			name:   "a claim may name a command instead of a path",
+			claims: "- Attribution is binary. [evidence: `go doc ./internal/attribution`]",
+			want: []Claim{{
+				Statement: "Attribution is binary.",
+				Evidence:  "go doc ./internal/attribution",
+			}},
+		},
+		{
+			name: "claims keep the order they were written in",
+			claims: "- First claim. [evidence: `a.go`]\n" +
+				"- Second claim. [evidence: `b.go`]",
+			want: []Claim{
+				{Statement: "First claim.", Evidence: "a.go"},
+				{Statement: "Second claim.", Evidence: "b.go"},
+			},
+		},
+		{
+			name:    "a claim continued on a second line is not one claim",
+			claims:  "- The hook walks the whole tree\n  on every commit. [evidence: `internal/hooks/post_commit.go`]",
+			wantErr: true,
+		},
+		{
+			name:    "prose in the section is not a claim",
+			claims:  "This proposal assumes the hook is slow. [evidence: `internal/hooks/post_commit.go`]",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(issueBody(tt.claims))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse succeeded, want an error; got %+v", got.Claims)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if !reflect.DeepEqual(got.Claims, tt.want) {
+				t.Errorf("Parse claims =\n%+v\nwant\n%+v", got.Claims, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRejectsAClaimWithNoEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims string
+	}{
+		{
+			name:   "no evidence field at all",
+			claims: "- The post-commit hook walks the whole tree.",
+		},
+		{
+			name:   "an empty evidence field",
+			claims: "- The post-commit hook walks the whole tree. [evidence: ``]",
+		},
+		{
+			name:   "an evidence field of only spaces",
+			claims: "- The post-commit hook walks the whole tree. [evidence: `   `]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(issueBody(tt.claims))
+			if !errors.Is(err, ErrNoEvidence) {
+				t.Fatalf("Parse error = %v, want ErrNoEvidence; got claims %+v", err, got.Claims)
+			}
+		})
+	}
+}
+
+func TestRenderRejectsAClaimWithNoEvidence(t *testing.T) {
+	tests := []struct {
+		name  string
+		block Block
+		want  error
+	}{
+		{
+			name:  "no claims",
+			block: Block{},
+			want:  ErrNoClaims,
+		},
+		{
+			name:  "a claim with no evidence",
+			block: Block{Claims: []Claim{{Statement: "The hook walks the whole tree."}}},
+			want:  ErrNoEvidence,
+		},
+		{
+			name:  "a claim with blank evidence",
+			block: Block{Claims: []Claim{{Statement: "The hook walks the whole tree.", Evidence: "  "}}},
+			want:  ErrNoEvidence,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Render(tt.block)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Render error = %v, want %v; rendered %q", err, tt.want, got)
+			}
+			if got != "" {
+				t.Errorf("Render returned %q with an error, want the empty string", got)
+			}
+		})
+	}
+}
+
+func TestRenderRoundTripsThroughParse(t *testing.T) {
+	want := Block{Claims: []Claim{
+		{Statement: "The post-commit hook reads the commit diff.", Evidence: "internal/hooks/post_commit.go"},
+		{Statement: "Attribution is binary.", Evidence: "go doc ./internal/attribution"},
+	}}
+
+	section, err := Render(want)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	got, err := Parse("Some description.\n\n" + section)
+	if err != nil {
+		t.Fatalf("Parse of a rendered section: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round trip =\n%+v\nwant\n%+v", got, want)
+	}
+}

--- a/internal/premise/repo_build_test.go
+++ b/internal/premise/repo_build_test.go
@@ -1,0 +1,301 @@
+package premise
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	implementProgram = "../../.minions/programs/implement.md"
+	gateProgram      = "../../.minions/programs/premise-gate.md"
+	buildWorkflow    = "../../.github/workflows/minion.yml"
+)
+
+// workflowStep starts a step in the build workflow's step list. The runtime
+// order of the steps is what the gate depends on, so the tests below compare
+// step positions rather than positions in the raw file: the program path
+// appears in an earlier "Determine program" step than the step that runs it.
+var workflowStep = regexp.MustCompile(`(?m)^      - `)
+
+// buildSteps splits the build workflow into its steps, in order. Element 0 is
+// everything above the first step and is kept so the returned indices line up
+// with nothing in particular — only their order matters.
+func buildSteps(t *testing.T) []string {
+	t.Helper()
+
+	return workflowStep.Split(readRepoFile(t, buildWorkflow), -1)
+}
+
+// stepContaining reports the index of the first build step carrying want.
+func stepContaining(steps []string, want string) int {
+	for i, step := range steps {
+		if strings.Contains(step, want) {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestBuildStageVerifiesBeforeItWritesCode is the tracer bullet: the premise is
+// checked by its own program, that program runs before the one that writes
+// code, and the verification it applies is the shared description rather than a
+// second idea of what verification means.
+func TestBuildStageVerifiesBeforeItWritesCode(t *testing.T) {
+	gate := readRepoFile(t, gateProgram)
+
+	context, ok := section(gate, "## Context")
+	if !ok {
+		t.Fatalf("%s has no ## Context section, so the shared descriptions are never read", gateProgram)
+	}
+	for _, want := range []string{VerifierPath, GatePath} {
+		if !strings.Contains(context, want) {
+			t.Errorf("%s ## Context does not carry %s", gateProgram, want)
+		}
+	}
+
+	steps := buildSteps(t)
+
+	gateAt := stepContaining(steps, "premise-gate.md")
+	if gateAt < 0 {
+		t.Fatalf("%s never runs the premise gate", buildWorkflow)
+	}
+
+	buildAt := stepContaining(steps, "minions $ARGS")
+	if buildAt < 0 {
+		t.Fatalf("%s never runs the implement program", buildWorkflow)
+	}
+
+	if gateAt > buildAt {
+		t.Errorf("the premise gate runs after the build: gate is step %d, build is step %d", gateAt, buildAt)
+	}
+}
+
+// gateGuard is the condition that keeps a step from running once the premise
+// has been found not to hold.
+const gateGuard = "steps.gate.outputs.blocked != 'true'"
+
+// TestBuildRestatesNeitherVerificationNorGating pins that the build stage
+// applies the two shared descriptions rather than carrying its own copies. A
+// pasted copy is what a stray marker looks like.
+func TestBuildRestatesNeitherVerificationNorGating(t *testing.T) {
+	src := readRepoFile(t, gateProgram)
+
+	for _, marker := range []string{VerifierMarker, GateMarker} {
+		if strings.Contains(src, marker) {
+			t.Errorf("%s carries %s, so it is a copy rather than a reference", gateProgram, marker)
+		}
+	}
+
+	checker, ok := section(src, "### premise-checker")
+	if !ok {
+		t.Fatalf("%s has no ### premise-checker agent", gateProgram)
+	}
+	for _, want := range []string{VerifierPath, GatePath, "as written"} {
+		if !containsPhrase(checker, want) {
+			t.Errorf("### premise-checker does not name %q, so it does not reuse the shared behaviour", want)
+		}
+	}
+}
+
+// TestBuildStopBehaviourIsTheSameAsResearch pins criterion 3: the build stops
+// the way research stops. Both stages point at the one description of stopping,
+// and neither holds its own idea of the label or the comment shape.
+func TestBuildStopBehaviourIsTheSameAsResearch(t *testing.T) {
+	restated := []struct {
+		what  string
+		token string
+	}{
+		{"the gate description", GateMarker},
+		{"the blocking label", BlockingLabel},
+		{"the gate comment shape", GateCommentMarker},
+	}
+
+	for _, path := range []string{gateProgram, researchProgram} {
+		src := readRepoFile(t, path)
+
+		if !strings.Contains(src, GatePath) {
+			t.Errorf("%s does not apply %s", path, GatePath)
+		}
+		for _, r := range restated {
+			if strings.Contains(src, r.token) {
+				t.Errorf("%s carries %s (%s); stopping is described once, in %s",
+					path, r.token, r.what, GatePath)
+			}
+		}
+	}
+}
+
+// TestBlockedBuildOpensNoPullRequestAndCreatesNoBranch pins the criterion the
+// runtime cannot enforce from inside a program. The runtime creates the branch
+// before the agent session starts and pushes unconditionally, so the only place
+// a build can be stopped without leaving artefacts behind is before it starts.
+func TestBlockedBuildOpensNoPullRequestAndCreatesNoBranch(t *testing.T) {
+	steps := buildSteps(t)
+
+	buildAt := stepContaining(steps, "minions $ARGS")
+	if buildAt < 0 {
+		t.Fatalf("%s never runs the implement program", buildWorkflow)
+	}
+	if !strings.Contains(steps[buildAt], gateGuard) {
+		t.Errorf("the step that runs the build is not guarded by %q, so a blocked premise still opens a pull request", gateGuard)
+	}
+
+	gate := readRepoFile(t, gateProgram)
+
+	// The gate must not be a slice-aware program: the slice path commits an
+	// empty marker and pushes whatever the agent did or did not do, so a
+	// checking program declared that way opens a pull request of its own.
+	if strings.Contains(gate, "slices: true") {
+		t.Errorf("%s declares slices: true, so the runtime pushes and opens a PR even when it writes nothing", gateProgram)
+	}
+
+	// On the path the gate does take, the runtime opens a pull request for any
+	// worktree that is not clean, and it reads that with `git status
+	// --porcelain`, which counts a file nobody tracked yet. So the instruction
+	// to keep the working directory alone is what makes the check free of
+	// artefacts, not a detail of style.
+	for _, want := range []string{
+		"Do not create or modify any file in the working directory",
+		"/tmp",
+	} {
+		if !containsPhrase(gate, want) {
+			t.Errorf("%s does not say %q, so a file left behind turns the check into a pull request", gateProgram, want)
+		}
+	}
+}
+
+// TestBlockedBuildNeverClosesTheIssue pins criterion 6 across both halves of
+// the stage: the program does not close the issue, and neither does the
+// workflow once the gate has blocked the run.
+func TestBlockedBuildNeverClosesTheIssue(t *testing.T) {
+	src := readRepoFile(t, gateProgram)
+	for _, token := range []string{"gh issue close", "minion-done"} {
+		if strings.Contains(src, token) {
+			t.Errorf("%s carries %q; the stage reports, the operator decides", gateProgram, token)
+		}
+	}
+
+	// The workflow does close the issue on a normal run. Every step that ends
+	// the issue's life must stand down when the premise did not hold.
+	steps := buildSteps(t)
+	for _, token := range []string{"gh issue close", "minion-done", "minion-failed"} {
+		at := stepContaining(steps, token)
+		if at < 0 {
+			continue
+		}
+		if !strings.Contains(steps[at], gateGuard) {
+			t.Errorf("the step carrying %q is not guarded by %q, so a blocked run still changes the issue's state",
+				token, gateGuard)
+		}
+	}
+}
+
+// TestOperatorOverrulesTheBuildByRemovingTheLabel pins that the verdict acted
+// on is this run's, not a label left over from an earlier one. The gate runs
+// first and the label is read afterwards, so an operator who removes the label
+// gets a fresh verdict rather than a remembered one.
+func TestOperatorOverrulesTheBuildByRemovingTheLabel(t *testing.T) {
+	if src := readRepoFile(t, gateProgram); strings.Contains(src, BlockingLabel) {
+		t.Errorf("%s names %s; a program that reads the label can skip on it instead of verifying again",
+			gateProgram, BlockingLabel)
+	}
+
+	steps := buildSteps(t)
+	at := stepContaining(steps, "premise-gate.md")
+	if at < 0 {
+		t.Fatalf("%s never runs the premise gate", buildWorkflow)
+	}
+
+	runAt := strings.Index(steps[at], "minions run .minions/programs/premise-gate.md")
+	readAt := strings.Index(steps[at], "--json labels")
+	switch {
+	case readAt < 0:
+		t.Fatal("the gate step never reads the issue's labels, so it has no verdict to act on")
+	case runAt > readAt:
+		t.Error("the gate step reads the labels before it verifies, so a stale label decides the build")
+	}
+}
+
+// TestHoldingPremiseLetsTheBuildProceedUnchanged pins criterion 8: a premise
+// that holds records its evidence, and changes nothing about the build.
+func TestHoldingPremiseLetsTheBuildProceedUnchanged(t *testing.T) {
+	checker, ok := section(readRepoFile(t, gateProgram), "### premise-checker")
+	if !ok {
+		t.Fatalf("%s has no ### premise-checker agent", gateProgram)
+	}
+	for _, want := range []string{
+		"record every claim",
+		"the excerpt that produced it",
+		"for a block that holds",
+	} {
+		if !containsPhrase(checker, want) {
+			t.Errorf("### premise-checker does not record %q, so a build that proceeds carries no evidence", want)
+		}
+	}
+
+	// Only a blocked verdict stops the build. Any other condition on that step
+	// would make a holding premise change how the build runs.
+	steps := buildSteps(t)
+	at := stepContaining(steps, "minions $ARGS")
+	if at < 0 {
+		t.Fatalf("%s never runs the implement program", buildWorkflow)
+	}
+	for _, line := range strings.Split(steps[at], "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "if:") {
+			continue
+		}
+		if strings.TrimSpace(line) != "if: "+gateGuard {
+			t.Errorf("the build step is conditioned on %q, not only on a blocked premise", strings.TrimSpace(line))
+		}
+	}
+}
+
+// topHeading matches a second-level heading in a program file.
+var topHeading = regexp.MustCompile(`(?m)^## (.+)$`)
+
+// deepHeading matches a heading below the level the program parser reads. The
+// parser splits on every heading, whatever its depth, and keeps only the
+// second-level sections it knows and the third-level agents inside ## Agents.
+// A fourth-level heading therefore ends the agent's prose and its body is
+// discarded without a word.
+var deepHeading = regexp.MustCompile(`(?m)^#{4,} `)
+
+// keptHeadings are the second-level sections the program parser carries into
+// the prompt. Everything else is dropped, silently.
+var keptHeadings = map[string]bool{"Context": true, "Planner": true, "Agents": true}
+
+// TestImplementProgramInstructionsReachTheModel pins criterion 9. The parser
+// keeps the H1 prose, ## Context, ## Planner and ## Agents, and drops every
+// other second-level section without saying so. programshape.Check cannot catch
+// this for the implement program: it returns nil for any program that defines
+// an ## Agents section, so the instructions have to be pinned here.
+func TestImplementProgramInstructionsReachTheModel(t *testing.T) {
+	src := readRepoFile(t, implementProgram)
+
+	for _, m := range topHeading.FindAllStringSubmatch(src, -1) {
+		if heading := strings.TrimSpace(m[1]); !keptHeadings[heading] {
+			t.Errorf("## %s is dropped by the parser, so nothing under it reaches the model", heading)
+		}
+	}
+
+	if m := deepHeading.FindString(src); m != "" {
+		t.Errorf("a %q heading ends the agent's prose, so everything below it is dropped", strings.TrimSpace(m))
+	}
+
+	agents, ok := section(src, "## Agents")
+	if !ok {
+		t.Fatalf("%s has no ## Agents section", implementProgram)
+	}
+	for _, want := range []string{
+		"build only that slice",
+		"Leave the tree green at your boundary",
+		"never open a PR yourself",
+		"conventional commit format",
+		"Resolves #",
+	} {
+		if !containsPhrase(agents, want) {
+			t.Errorf("the instruction %q does not live under ## Agents, so the parser drops it", want)
+		}
+	}
+}

--- a/internal/premise/repo_ingest_prompt_test.go
+++ b/internal/premise/repo_ingest_prompt_test.go
@@ -1,0 +1,72 @@
+package premise
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// ingestPrompt is this repository's ingest prompt, relative to the package
+// directory that go test runs in.
+const ingestPrompt = "../../.minions/ingest-prompt.md"
+
+// TestIngestPromptGroundsClaimsInTheTree checks that the prompt asks for claims
+// about this repository rather than claims about the product the idea came
+// from. The schema alone does not get that: a well-formed claim inferred from a
+// sibling product's changelog fills every field and is still wrong here, which
+// is exactly how issue #30 was filed. Adaptation stays the goal; importing the
+// source product's premises does not.
+func TestIngestPromptGroundsClaimsInTheTree(t *testing.T) {
+	raw, err := os.ReadFile(ingestPrompt)
+	if err != nil {
+		t.Fatalf("read ingest prompt: %v", err)
+	}
+
+	instructions, ok := section(string(raw), "## Instructions")
+	if !ok {
+		t.Fatal("ingest prompt has no instructions section")
+	}
+	for _, want := range []string{"checked-out tree", "source material"} {
+		if !strings.Contains(instructions, want) {
+			t.Errorf("the ingest prompt never mentions the %q a claim must be grounded in or against", want)
+		}
+	}
+}
+
+// TestIngestPromptSchemaCarriesPremise checks that the model producing feature
+// ideas produces claims and evidence with them, rather than having a premise
+// bolted on after the idea already exists.
+func TestIngestPromptSchemaCarriesPremise(t *testing.T) {
+	src, err := os.ReadFile(ingestPrompt)
+	if err != nil {
+		t.Fatalf("read ingest prompt: %v", err)
+	}
+
+	raw, ok := fencedBlockContaining(string(src), `"acceptance_criteria"`)
+	if !ok {
+		t.Fatal("ingest prompt shows no feature-idea output schema")
+	}
+
+	var idea struct {
+		Premise []struct {
+			Claim    string `json:"claim"`
+			Evidence string `json:"evidence"`
+		} `json:"premise"`
+	}
+	if err := json.Unmarshal([]byte(raw), &idea); err != nil {
+		t.Fatalf("feature-idea output schema is not valid JSON: %v", err)
+	}
+
+	if len(idea.Premise) == 0 {
+		t.Fatal("feature-idea output schema declares no premise field")
+	}
+	for i, c := range idea.Premise {
+		if c.Claim == "" {
+			t.Errorf("premise entry %d declares no claim field", i)
+		}
+		if c.Evidence == "" {
+			t.Errorf("premise entry %d declares no evidence field", i)
+		}
+	}
+}

--- a/internal/premise/repo_premise_verifier_test.go
+++ b/internal/premise/repo_premise_verifier_test.go
@@ -1,0 +1,341 @@
+package premise
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// verifierDoc is this repository's premise verifier, relative to the package
+// directory that go test runs in.
+const verifierDoc = "../../" + VerifierPath
+
+// TestPremiseVerifierReachesTheProposer is the end-to-end path this slice
+// builds: a verifier that describes verification once, and a proposer that
+// reaches it before it files anything. A verifier nothing calls changes no
+// behaviour, and a proposer that verifies after filing has already filed.
+func TestPremiseVerifierReachesTheProposer(t *testing.T) {
+	raw, err := os.ReadFile(verifierDoc)
+	if err != nil {
+		t.Fatalf("read the premise verifier: %v", err)
+	}
+	doc := string(raw)
+
+	if !strings.Contains(doc, VerifierMarker) {
+		t.Errorf("the premise verifier does not carry %q", VerifierMarker)
+	}
+
+	// The inputs and the outputs are the contract a caller keys off. The
+	// verifier consumes the premise block, so it names that block's marker,
+	// and it returns one of a fixed set of verdicts.
+	if !strings.Contains(doc, Marker) {
+		t.Errorf("the premise verifier does not name the premise block it consumes (%q)", Marker)
+	}
+	for _, v := range Verdicts {
+		if !strings.Contains(doc, string(v)) {
+			t.Errorf("the premise verifier does not define the %q verdict", v)
+		}
+	}
+
+	src, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+
+	context, ok := section(string(src), "## Context")
+	if !ok {
+		t.Fatal("propose program has no context section")
+	}
+	if !strings.Contains(context, VerifierPath) {
+		t.Errorf("the propose program does not put %s in front of its agent", VerifierPath)
+	}
+
+	agents, ok := section(string(src), "## Agents")
+	if !ok {
+		t.Fatal("propose program has no agents section")
+	}
+	verify := strings.Index(agents, VerifierPath)
+	file := strings.Index(agents, "gh issue create")
+	switch {
+	case verify < 0:
+		t.Fatalf("the proposer is never told to apply %s", VerifierPath)
+	case file < 0:
+		t.Fatal("propose program gives no gh issue create instruction")
+	case verify > file:
+		t.Error("the proposer is told to verify the premise only after it has filed the issue")
+	}
+}
+
+// TestEveryEvidenceKindIsGatheredBeforeTheVerdict checks that the proposer can
+// actually gather whatever a claim names. The claim grammar admits a path, a
+// symbol or a command; a procedure that only describes reading files leaves the
+// other two ungathered, and a claim nobody gathered evidence for gets decided
+// from the source material instead — which is the defect this slice exists to
+// stop. The gathering is also ordered ahead of the verdict, so the description
+// cannot be read as "decide, then look".
+func TestEveryEvidenceKindIsGatheredBeforeTheVerdict(t *testing.T) {
+	raw, err := os.ReadFile(verifierDoc)
+	if err != nil {
+		t.Fatalf("read the premise verifier: %v", err)
+	}
+	doc := string(raw)
+
+	procedure, ok := section(doc, "## Procedure")
+	if !ok {
+		t.Fatal("the premise verifier describes no procedure")
+	}
+	for _, kind := range []string{"path", "symbol", "command"} {
+		if !strings.Contains(procedure, kind) {
+			t.Errorf("the procedure never says how to gather evidence named as a %s", kind)
+		}
+	}
+
+	gather := strings.Index(doc, "## Procedure")
+	decide := strings.Index(doc, "## Verdicts")
+	if gather < 0 || decide < 0 {
+		t.Fatal("the premise verifier does not separate the procedure from the verdicts")
+	}
+	if gather > decide {
+		t.Error("the premise verifier puts the verdicts ahead of the gathering that settles them")
+	}
+
+	// The proposer applies the verifier against a tree, so it has to be told
+	// there is a tree to read rather than left to answer from the source item.
+	src, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+	agents, ok := section(string(src), "## Agents")
+	if !ok {
+		t.Fatal("propose program has no agents section")
+	}
+	if !strings.Contains(agents, "checked out") {
+		t.Error("the proposer is never told the tree it must verify against is checked out")
+	}
+}
+
+// TestVerificationIsDescribedOnce checks that the description has one home.
+// Slices 6, 7 and 8 add callers, and a caller that pastes the procedure into
+// its own program is free to drift from it. The marker is the anchor: exactly
+// one file carries it, so a second copy of the description is a test failure
+// rather than something noticed months later.
+func TestVerificationIsDescribedOnce(t *testing.T) {
+	carriers := markerCarriers(t, VerifierMarker)
+
+	if len(carriers) != 1 {
+		t.Fatalf("verification is described in %d files, want exactly one: %v", len(carriers), carriers)
+	}
+	if want := filepath.ToSlash(filepath.Join(repoRoot, VerifierPath)); carriers[0] != want {
+		t.Errorf("verification is described in %s, want %s", carriers[0], want)
+	}
+}
+
+// noBlockHeading opens the part of the verifier that covers a proposal filed
+// before the premise block existed.
+const noBlockHeading = "## When there is no block"
+
+// TestAProposalWithNoBlockIsCheckedFromItsProse covers the backlog this gate
+// would otherwise exempt: 534 open proposals, 56 already approved, none
+// carrying a block. If the verifier only knows how to read a block, every one
+// of them builds unchecked, and the gate protects new work only.
+func TestAProposalWithNoBlockIsCheckedFromItsProse(t *testing.T) {
+	raw, err := os.ReadFile(verifierDoc)
+	if err != nil {
+		t.Fatalf("read the premise verifier: %v", err)
+	}
+
+	body, ok := section(string(raw), noBlockHeading)
+	if !ok {
+		t.Fatalf("the premise verifier has no %q section, so a proposal without a block is exempt", noBlockHeading)
+	}
+	for _, wanted := range []string{"extract", "prose"} {
+		if !strings.Contains(flat(body), wanted) {
+			t.Errorf("the %q section never says to %s the claims from the issue prose", noBlockHeading, wanted)
+		}
+	}
+}
+
+// TestExtractedClaimsAreVerifiedLikeBlockClaims checks that extraction feeds
+// the procedure that already exists rather than growing one beside it. A second
+// procedure is free to drift from the first, and then an old proposal is held
+// to a different bar than a new one — which is the exemption this slice
+// removes, reintroduced in a subtler form.
+func TestExtractedClaimsAreVerifiedLikeBlockClaims(t *testing.T) {
+	raw, err := os.ReadFile(verifierDoc)
+	if err != nil {
+		t.Fatalf("read the premise verifier: %v", err)
+	}
+	doc := string(raw)
+
+	body, ok := section(doc, noBlockHeading)
+	if !ok {
+		t.Fatalf("the premise verifier has no %q section", noBlockHeading)
+	}
+	if !strings.Contains(flat(body), "same") {
+		t.Errorf("the %q section never says extracted claims are verified the same way", noBlockHeading)
+	}
+
+	procedure, ok := section(doc, "## Procedure")
+	if !ok {
+		t.Fatal("the premise verifier describes no procedure")
+	}
+	if strings.Contains(procedure, "in the block") {
+		t.Error("the procedure scopes itself to claims in the block, so an extracted claim falls outside it")
+	}
+
+	// One gathering, described once. A copy inside the extraction section
+	// would be the second procedure this test exists to prevent.
+	if n := strings.Count(doc, "Gather the evidence"); n != 1 {
+		t.Errorf("the premise verifier describes the gathering %d times, want exactly once", n)
+	}
+}
+
+// TestAFailedExtractedClaimStopsTheStageTheSameWay checks that a false claim
+// costs an old proposal what it costs a new one. The extraction section says
+// nothing below it changes; that sentence is only true while the caller's stop
+// is in fact below it and is not written for a block alone. One stop, one
+// label, one comment — an old proposal is not stopped by a quieter mechanism
+// the operator has to learn separately.
+func TestAFailedExtractedClaimStopsTheStageTheSameWay(t *testing.T) {
+	doc := readRepoFile(t, verifierDoc)
+
+	const callerHeading = "## What the caller does"
+	extract, caller := strings.Index(doc, noBlockHeading), strings.Index(doc, callerHeading)
+	switch {
+	case extract < 0:
+		t.Fatalf("the premise verifier has no %q section", noBlockHeading)
+	case caller < 0:
+		t.Fatalf("the premise verifier has no %q section", callerHeading)
+	case extract > caller:
+		t.Errorf("%q sits after %q, so what the caller does is not covered by it", noBlockHeading, callerHeading)
+	}
+
+	callerBody, ok := section(doc, callerHeading)
+	if !ok {
+		t.Fatalf("the premise verifier has no %q section", callerHeading)
+	}
+	if strings.Contains(callerBody, "A block that") {
+		t.Error("the caller's stop is written for a block, so an extracted premise falls outside it")
+	}
+
+	gate := readRepoFile(t, gateDoc)
+	stop, ok := section(gate, "## When the premise does not hold")
+	if !ok {
+		t.Fatal("the stage gate does not say what happens when the premise does not hold")
+	}
+	if strings.Contains(stop, "in the block") {
+		t.Error("the blocked-stage comment reports only claims in the block, so an extracted claim goes unreported")
+	}
+	for _, want := range []string{BlockingLabel, GateCommentMarker} {
+		if !strings.Contains(gate, want) {
+			t.Errorf("the stage gate does not name %q, so the stop it describes is not the one the caller performs", want)
+		}
+	}
+}
+
+// TestAnOldProposalIsNotRewritten checks the promise that makes this gate cheap
+// enough to apply at all: extraction happens at check time and leaves nothing
+// behind. Backfilling a block would rewrite the operator's words in hundreds of
+// issues, one stage run at a time, and the gate would start editing the backlog
+// it was only meant to check. The gate's passing path is where the risk sits —
+// it refreshes the block it just verified, and on an old proposal there is no
+// block to refresh.
+func TestAnOldProposalIsNotRewritten(t *testing.T) {
+	body, ok := section(readRepoFile(t, verifierDoc), noBlockHeading)
+	if !ok {
+		t.Fatalf("the premise verifier has no %q section", noBlockHeading)
+	}
+	for _, want := range []string{"rewrite", "backfill"} {
+		if !strings.Contains(flat(body), want) {
+			t.Errorf("the %q section never rules out a %s of the issue body", noBlockHeading, want)
+		}
+	}
+
+	holds, ok := section(readRepoFile(t, gateDoc), "## When the premise holds")
+	if !ok {
+		t.Fatal("the stage gate does not say what happens when the premise holds")
+	}
+	if !strings.Contains(flat(holds), "no block") {
+		t.Error("the stage gate refreshes the premise block unconditionally, so a proposal that carries none gets one written into it")
+	}
+}
+
+// TestTheBacklogIsNotSwept checks that applying the gate to old proposals stays
+// a per-run cost and never becomes a pass over the 534 open ones. The operator
+// chose that explicitly: not swept ahead of time, not pruned. A sweep would
+// relabel or close issues nobody asked about, in bulk, from a stage that was
+// only meant to check the one in front of it — so the checking is lazy, and the
+// only issue a run may edit is the one it was handed.
+func TestTheBacklogIsNotSwept(t *testing.T) {
+	body, ok := section(readRepoFile(t, verifierDoc), noBlockHeading)
+	if !ok {
+		t.Fatalf("the premise verifier has no %q section", noBlockHeading)
+	}
+	lower := flat(body)
+	for _, want := range []string{"check time", "touches"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("the %q section never says %q, so it does not say when an old proposal is checked", noBlockHeading, want)
+		}
+	}
+
+	// Neither description may reach for the backlog. A stage is handed one
+	// issue; listing the others is the sweep this slice must not introduce.
+	for _, doc := range []string{verifierDoc, gateDoc} {
+		src := readRepoFile(t, doc)
+		for _, banned := range []string{"gh issue list", "gh issue close"} {
+			if strings.Contains(src, banned) {
+				t.Errorf("%s runs %q, which reaches past the issue the stage was handed", doc, banned)
+			}
+		}
+	}
+
+	// Labelling is per-issue for the same reason: the issue number comes from
+	// the run, never from a list the stage assembled itself.
+	for _, line := range strings.Split(readRepoFile(t, gateDoc), "\n") {
+		if strings.Contains(line, "gh issue edit") && !strings.Contains(line, "$MINION_ISSUE_NUMBER") {
+			t.Errorf("the stage gate edits an issue it was not handed: %s", strings.TrimSpace(line))
+		}
+	}
+}
+
+// flat lowercases src and collapses each run of whitespace to one space. A
+// phrase these tests look for then reads the same whether or not the paragraph
+// carrying it was rewrapped: prose gets rewrapped, and the rule it states does
+// not change when it does.
+func flat(src string) string {
+	return strings.ToLower(strings.Join(strings.Fields(src), " "))
+}
+
+// section returns the body of the section src opens with heading, up to the
+// next heading of the same level or the end of src. It ignores fenced code
+// blocks, because the propose program shows a `## Premise` template inside one
+// and that template does not end the section it sits in.
+func section(src, heading string) (string, bool) {
+	lines := strings.Split(src, "\n")
+	closes := strings.Repeat("#", strings.Count(heading, "#")) + " "
+
+	start, fenced := -1, false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "```") {
+			fenced = !fenced
+			continue
+		}
+		if fenced {
+			continue
+		}
+
+		switch {
+		case start < 0 && trimmed == heading:
+			start = i + 1
+		case start >= 0 && strings.HasPrefix(trimmed, closes):
+			return strings.Join(lines[start:i], "\n"), true
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+	return strings.Join(lines[start:], "\n"), true
+}

--- a/internal/premise/repo_propose_test.go
+++ b/internal/premise/repo_propose_test.go
@@ -1,0 +1,264 @@
+package premise
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// proposeProgram is this repository's propose program, relative to the package
+// directory that go test runs in.
+const proposeProgram = "../../.minions/programs/propose.md"
+
+// TestProposeProgramTemplateParses checks that the premise template the propose
+// program shows its agent is the same format this package parses. If the
+// program and the parser drift apart, every later stage is back to reading
+// prose, which is the failure this whole feature exists to stop.
+func TestProposeProgramTemplateParses(t *testing.T) {
+	src, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+
+	tmpl, ok := fencedBlockContaining(string(src), Marker)
+	if !ok {
+		t.Fatalf("propose program shows no fenced premise template containing %q", Marker)
+	}
+
+	block, err := Parse(tmpl)
+	if err != nil {
+		t.Fatalf("premise template in the propose program does not parse: %v", err)
+	}
+	if len(block.Claims) == 0 {
+		t.Fatal("premise template in the propose program carries no claims")
+	}
+	for i, c := range block.Claims {
+		if c.Evidence == "" {
+			t.Errorf("claim %d in the propose program template has no evidence", i)
+		}
+	}
+}
+
+// TestProposeProgramFilesPremiseWithEveryProposal checks that the issue the
+// program creates carries the premise section. Showing the format somewhere in
+// the program's prose is not enough: the section has to reach the issue body.
+func TestProposeProgramFilesPremiseWithEveryProposal(t *testing.T) {
+	src, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+
+	create, ok := lineContaining(string(src), "gh issue create")
+	if !ok {
+		t.Fatal("propose program gives no gh issue create instruction")
+	}
+	if !strings.Contains(create, "premise section") {
+		t.Errorf("the gh issue create instruction leaves the premise section out of the issue body:\n%s", create)
+	}
+}
+
+// TestProposeProgramKeepsItsExistingProposalBehaviour guards the parts of the
+// proposal this slice must not disturb. The premise section is an addition to
+// the issue body; the title, the labels and the duplicate check stay as they
+// were.
+func TestProposeProgramKeepsItsExistingProposalBehaviour(t *testing.T) {
+	raw, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+	src := string(raw)
+
+	create, ok := lineContaining(src, "gh issue create")
+	if !ok {
+		t.Fatal("propose program gives no gh issue create instruction")
+	}
+	for _, want := range []string{
+		"--repo <this-repo>",
+		"--label minion-proposal",
+		`--title "<title>"`,
+		"<description",
+		"link to program file",
+		"<!-- program: .minions/programs/<id>.md --> marker",
+	} {
+		if !strings.Contains(create, want) {
+			t.Errorf("the gh issue create instruction lost %q:\n%s", want, create)
+		}
+	}
+
+	for _, want := range []string{
+		`gh issue list --repo <this-repo> --label minion-proposal --search "<feature-id>" --limit 1`,
+		"write a program file to `.minions/programs/<id>.md`",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("propose program lost %q", want)
+		}
+	}
+}
+
+// TestProposeProgramDropsAnIdeaWhosePremiseFails checks the order the proposer
+// works in. Verifying after the issue exists changes nothing: the proposal is
+// already filed and the operator is already reading it. The check has to come
+// first, and a failed check has to leave no program file and no issue behind.
+func TestProposeProgramDropsAnIdeaWhosePremiseFails(t *testing.T) {
+	raw, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+	agents, ok := section(string(raw), "## Agents")
+	if !ok {
+		t.Fatal("propose program has no agents section")
+	}
+
+	steps := []struct {
+		what  string
+		token string
+	}{
+		{"apply the verifier", VerifierPath},
+		// Not merely "drop the idea": the premise-format bullet already
+		// tells the agent to drop an idea it can find no evidence for, and
+		// that is a different event from a premise that was checked and
+		// failed.
+		{"drop an idea whose premise does not hold", "does not hold, drop the idea"},
+		{"write the program file", "write a program file"},
+		{"create the issue", "gh issue create"},
+	}
+	at := make([]int, len(steps))
+	for i, s := range steps {
+		at[i] = strings.Index(agents, s.token)
+		if at[i] < 0 {
+			t.Fatalf("the proposer is never told to %s", s.what)
+		}
+		if i > 0 && at[i-1] > at[i] {
+			t.Errorf("the proposer is told to %s before it is told to %s", steps[i].what, steps[i-1].what)
+		}
+	}
+
+	drop, _, _ := strings.Cut(agents[at[1]:], "\n   - ")
+	for _, want := range []string{"no program file", "no issue"} {
+		if !strings.Contains(drop, want) {
+			t.Errorf("dropping an idea leaves %q unsaid, so a failed check still files something:\n%s", want, drop)
+		}
+	}
+}
+
+// TestProposeProgramGrantsTheToolsVerificationNeeds pins the proposer's tool
+// grant. Verification is reading the tree and running commands against it, so
+// an agent without those tools cannot verify and will answer from the source
+// item instead — the same wrong answer as before, now with a verdict attached
+// to it. The grant already covered this before the slice; the test is here so
+// a later edit cannot narrow it without saying so.
+func TestProposeProgramGrantsTheToolsVerificationNeeds(t *testing.T) {
+	raw, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+
+	grant, ok := fencedBlockContaining(string(raw), "tools:")
+	if !ok {
+		t.Fatal("the proposer declares no tools")
+	}
+	for tool, why := range map[string]string{
+		"Read": "read a file the evidence names",
+		"Glob": "locate a path the evidence names",
+		"Grep": "find a symbol the evidence names",
+		"Bash": "run a command the evidence names",
+	} {
+		if !strings.Contains(grant, "- "+tool+"\n") {
+			t.Errorf("the proposer cannot %s: %s is not granted", why, tool)
+		}
+	}
+}
+
+// TestProposeProgramSeparatesSkippedFromDropped checks that a run reports the
+// two ways an idea can fail to become an issue as different events. An
+// irrelevant source item was never an idea; a dropped idea was one, and the
+// tree contradicted it. Folded into one count they are unreadable, and the
+// cursor has already advanced past both — so the run output is the only place
+// the difference survives.
+func TestProposeProgramSeparatesSkippedFromDropped(t *testing.T) {
+	raw, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+	agents, ok := section(string(raw), "## Agents")
+	if !ok {
+		t.Fatal("propose program has no agents section")
+	}
+
+	at := strings.Index(agents, "Print summary")
+	if at < 0 {
+		t.Fatal("the proposer prints no summary of what a run did")
+	}
+	summary := agents[at:]
+
+	for outcome, meaning := range map[string]string{
+		"filed":   "an idea whose premise held",
+		"dropped": "an idea whose premise did not hold",
+		"skipped": "a source item that was never relevant",
+	} {
+		if !strings.Contains(summary, outcome) {
+			t.Errorf("the run summary does not report %q — %s", outcome, meaning)
+		}
+	}
+
+	// Skipping is the ingest prompt's job and predates this slice. Raising the
+	// bar on premises must not quietly turn "not relevant" into "rejected".
+	prompt, err := os.ReadFile(ingestPrompt)
+	if err != nil {
+		t.Fatalf("read ingest prompt: %v", err)
+	}
+	if !strings.Contains(string(prompt), "Skip features that don't apply") {
+		t.Error("the ingest prompt no longer skips irrelevant source items")
+	}
+}
+
+// TestProposeProgramFilesTheEvidenceItGathered checks that a proposal which
+// passed the check carries the evidence that passed it. A green verdict with
+// nothing behind it is the same prose assertion the premise block replaced.
+func TestProposeProgramFilesTheEvidenceItGathered(t *testing.T) {
+	raw, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read propose program: %v", err)
+	}
+
+	create, ok := lineContaining(string(raw), "gh issue create")
+	if !ok {
+		t.Fatal("propose program gives no gh issue create instruction")
+	}
+	if !strings.Contains(create, "gathered evidence") {
+		t.Errorf("the issue body carries the premise but not the evidence gathered for it:\n%s", create)
+	}
+}
+
+// lineContaining returns the first line of src that contains want.
+func lineContaining(src, want string) (string, bool) {
+	for _, line := range strings.Split(src, "\n") {
+		if strings.Contains(line, want) {
+			return line, true
+		}
+	}
+	return "", false
+}
+
+// fencedBlockContaining returns the body of the first fenced code block in src
+// that contains want.
+func fencedBlockContaining(src, want string) (string, bool) {
+	lines := strings.Split(src, "\n")
+	for i := 0; i < len(lines); i++ {
+		if !strings.HasPrefix(strings.TrimSpace(lines[i]), "```") {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			if !strings.HasPrefix(strings.TrimSpace(lines[j]), "```") {
+				continue
+			}
+			body := strings.Join(lines[i+1:j], "\n")
+			if strings.Contains(body, want) {
+				return body, true
+			}
+			i = j
+			break
+		}
+	}
+	return "", false
+}

--- a/internal/premise/repo_research_test.go
+++ b/internal/premise/repo_research_test.go
@@ -1,0 +1,451 @@
+package premise
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// researchProgram is this repository's research program, relative to the package
+// directory that go test runs in.
+const researchProgram = "../../.minions/programs/research.md"
+
+// gateDoc is this repository's stage gate, relative to the package directory
+// that go test runs in.
+const gateDoc = "../../" + GatePath
+
+// The premise verdict passes between the research program's agents through a
+// file, because each agent is a separate session in a worktree that is
+// discarded when it finishes. These two are that channel: the path every agent
+// reads, and the only first line that lets a run continue.
+const (
+	premiseStatePath = `PREMISE="/tmp/minion-research-premise-${MINION_ISSUE_NUMBER:-0}.md"`
+	premiseOK        = "PREMISE_OK"
+)
+
+// TestResearchStageVerifiesBeforeItPlans is the end-to-end path this slice
+// builds. A premise checked at filing time says nothing about the tree a
+// research run reads months later: issue #30 was filed on 2026-03-26 and built
+// on 2026-08-10. So research rechecks, and it rechecks first — a verdict that
+// arrives after the PRD is written has not stopped anything.
+func TestResearchStageVerifiesBeforeItPlans(t *testing.T) {
+	gate := readRepoFile(t, gateDoc)
+	if !strings.Contains(gate, GateMarker) {
+		t.Errorf("the stage gate does not carry %q", GateMarker)
+	}
+
+	src := readRepoFile(t, researchProgram)
+
+	context, ok := section(src, "## Context")
+	if !ok {
+		t.Fatal("research program has no context section")
+	}
+	for _, path := range []string{VerifierPath, GatePath} {
+		if !strings.Contains(context, path) {
+			t.Errorf("the research program does not put %s in front of its agents", path)
+		}
+	}
+
+	agents, ok := section(src, "## Agents")
+	if !ok {
+		t.Fatal("research program has no agents section")
+	}
+
+	verify := strings.Index(agents, VerifierPath)
+	if verify < 0 {
+		t.Fatalf("the research stage is never told to apply %s", VerifierPath)
+	}
+	// Every artifact a research run produces. The check is worthless unless it
+	// precedes all of them.
+	for what, token := range map[string]string{
+		"asks its first question": "### researcher",
+		"writes the PRD":          "### prd-writer",
+		"slices the plan":         "### slicer",
+		"publishes anything":      "### publisher",
+	} {
+		at := strings.Index(agents, token)
+		if at < 0 {
+			t.Fatalf("research program has no %s agent", token)
+		}
+		if verify > at {
+			t.Errorf("the research stage verifies the premise only after it %s", what)
+		}
+	}
+}
+
+// TestResearchRestatesNeitherVerificationNorGating checks that the research
+// stage reaches the two descriptions rather than carrying its own copy. A
+// pasted copy is free to drift: the stage keeps working, keeps producing
+// verdicts, and stops meaning the same thing as the stage beside it. The
+// markers are the anchor — a program that carries one has taken a copy.
+func TestResearchRestatesNeitherVerificationNorGating(t *testing.T) {
+	src := readRepoFile(t, researchProgram)
+
+	for marker, doc := range map[string]string{
+		VerifierMarker: VerifierPath,
+		GateMarker:     GatePath,
+	} {
+		if strings.Contains(src, marker) {
+			t.Errorf("the research program carries %s rather than referencing %s", marker, doc)
+		}
+	}
+
+	checker, ok := section(src, "### premise-checker")
+	if !ok {
+		t.Fatal("research program has no premise-checker agent")
+	}
+	for path, what := range map[string]string{
+		VerifierPath: "how to verify a claim",
+		GatePath:     "what to do with the verdict",
+	} {
+		if !containsPhrase(checker, path) {
+			t.Errorf("the premise-checker decides %s for itself: it never reaches %s", what, path)
+		}
+	}
+	if !containsPhrase(checker, "as written") {
+		t.Error("the premise-checker is not told to follow the descriptions as written, " +
+			"so it is free to paraphrase them into a different behaviour")
+	}
+}
+
+// TestGatingIsDescribedOnce mirrors TestVerificationIsDescribedOnce for the
+// gate. Slices 7 and 8 add callers, and a caller that pastes the procedure into
+// its own program stops its own way — which leaves the operator unable to tell,
+// from a blocked issue, which stage blocked it or why.
+func TestGatingIsDescribedOnce(t *testing.T) {
+	carriers := markerCarriers(t, GateMarker)
+
+	if len(carriers) != 1 {
+		t.Fatalf("gating is described in %d files, want exactly one: %v", len(carriers), carriers)
+	}
+	if want := filepath.ToSlash(filepath.Join(repoRoot, GatePath)); carriers[0] != want {
+		t.Errorf("gating is described in %s, want %s", carriers[0], want)
+	}
+}
+
+// addLabel matches a gh call that puts a label on the issue.
+var addLabel = regexp.MustCompile(`--add-label\s+(\S+)`)
+
+// TestBlockedResearchRunLabelsTheIssue checks the blocking label. The approval
+// program already skips on do-not-build, so this label needs no new pipeline
+// wiring — and a second, invented label would need all of it while looking, on
+// the issue, exactly like a working block.
+func TestBlockedResearchRunLabelsTheIssue(t *testing.T) {
+	blocked := blockedSection(t)
+
+	labels := addLabel.FindAllStringSubmatch(blocked, -1)
+	if len(labels) == 0 {
+		t.Fatal("a blocked stage adds no label, so nothing downstream knows the premise failed")
+	}
+	for _, m := range labels {
+		if m[1] != BlockingLabel {
+			t.Errorf("a blocked stage adds %q; the pipeline only understands %q", m[1], BlockingLabel)
+		}
+	}
+}
+
+// TestBlockedResearchRunSaysWhatItCheckedAndFound checks the comment. A label
+// alone tells the operator a stage stopped and nothing about why; the operator
+// then has to redo the verification by hand to decide whether to overrule it.
+// The comment is the account, so it carries the claims and the evidence behind
+// each verdict — including for claims that held.
+func TestBlockedResearchRunSaysWhatItCheckedAndFound(t *testing.T) {
+	blocked := blockedSection(t)
+
+	if !containsPhrase(blocked, GateCommentMarker) {
+		t.Errorf("the blocked-run comment carries no %s, so nothing can find it later", GateCommentMarker)
+	}
+	for what, token := range map[string]string{
+		"the claim it checked":                "the claim, word for word",
+		"the evidence that claim named":       "the evidence the claim named",
+		"the verdict it reached":              "the verdict",
+		"the excerpt behind that verdict":     "the excerpt that produced it",
+		"the claims that failed, by name":     "the claims that failed",
+		"the evidence that contradicted them": "the evidence that contradicted them",
+	} {
+		if !containsPhrase(blocked, token) {
+			t.Errorf("the blocked-run comment leaves out %s", what)
+		}
+	}
+}
+
+// agentHeading matches the heading that opens one agent in a program.
+var agentHeading = regexp.MustCompile(`(?m)^### (\S+)\s*$`)
+
+// TestBlockedResearchRunProducesNoPlan checks that a failed premise stops every
+// agent that could produce something, not merely the next one. Each agent is
+// its own one-shot session in a discarded worktree, so there is no early return
+// to take: a stopped stage is every later agent reading the verdict and
+// declining to work. An agent added later without that read resumes the run
+// halfway through, and publishes a PRD for a premise the tree contradicts.
+func TestBlockedResearchRunProducesNoPlan(t *testing.T) {
+	src := readRepoFile(t, researchProgram)
+
+	agents, ok := section(src, "## Agents")
+	if !ok {
+		t.Fatal("research program has no agents section")
+	}
+
+	names := agentHeading.FindAllStringSubmatch(agents, -1)
+	if len(names) < 2 {
+		t.Fatalf("research program declares %d agents, want the checker plus the pipeline", len(names))
+	}
+
+	for _, m := range names {
+		name := m[1]
+		if name == "premise-checker" {
+			continue
+		}
+
+		body, ok := section(agents, "### "+name)
+		if !ok {
+			t.Fatalf("cannot read the %s agent", name)
+		}
+		for what, token := range map[string]string{
+			"read the premise verdict":           premiseStatePath,
+			"stop unless the verdict passed":     premiseOK,
+			"do it before it does anything else": "Before anything else",
+		} {
+			if !containsPhrase(body, token) {
+				t.Errorf("the %s agent does not %s, so a blocked run still produces its artifact", name, what)
+			}
+		}
+	}
+
+	// The gate says the same thing once, for every stage that applies it.
+	blocked := blockedSection(t)
+	for _, want := range []string{"Stop before you produce anything", "No PRD, no slice plan"} {
+		if !containsPhrase(blocked, want) {
+			t.Errorf("the stage gate does not say %q, so what \"stop\" means is left to each caller", want)
+		}
+	}
+}
+
+// TestBlockedResearchRunNeverClosesTheIssue checks that blocking is reversible.
+// A wrong verdict on a closed issue costs the operator the issue; a wrong
+// verdict on a labelled one costs a label removal. The stage reports what it
+// found and hands the decision back — it does not make it.
+func TestBlockedResearchRunNeverClosesTheIssue(t *testing.T) {
+	src := readRepoFile(t, researchProgram)
+
+	for what, token := range map[string]string{
+		"closes the issue":            "gh issue close",
+		"marks the issue as finished": "--add-label minion-done",
+	} {
+		if strings.Contains(src, token+"\n") || strings.Contains(src, token+" ") {
+			t.Errorf("the research stage %s, which the operator cannot undo with a label removal", what)
+		}
+	}
+
+	blocked := blockedSection(t)
+	for _, want := range []string{"Do not close the issue", "minion-done"} {
+		if !containsPhrase(blocked, want) {
+			t.Errorf("the stage gate does not forbid %q on a blocked issue", want)
+		}
+	}
+}
+
+// TestOperatorOverrulesByRemovingTheLabel checks the escape hatch. Verification
+// is a judgement made by a model against a tree, so it will be wrong sometimes,
+// and a gate with no override turns each wrong verdict into a dead issue. The
+// override works because no stage treats the label as a stored decision: every
+// run re-gathers the evidence, so removing the label is enough to get a fresh
+// verdict rather than the old one replayed.
+func TestOperatorOverrulesByRemovingTheLabel(t *testing.T) {
+	override, ok := section(readRepoFile(t, gateDoc), "## How the operator overrules")
+	if !ok {
+		t.Fatal("the stage gate gives the operator no way to overrule a verdict")
+	}
+	for what, token := range map[string]string{
+		"name the label the operator removes":     BlockingLabel,
+		"say the removal is the whole mechanism":  "removes",
+		"say a later run reaches its own verdict": "re-verifies",
+	} {
+		if !containsPhrase(override, token) {
+			t.Errorf("the override section does not %s", what)
+		}
+	}
+
+	// A stage that skipped on the label would read the previous run's verdict
+	// instead of reaching its own, and the operator's removal would be the only
+	// thing that ever decided anything.
+	src := readRepoFile(t, researchProgram)
+	if strings.Contains(src, BlockingLabel) {
+		t.Errorf("the research program names %q itself; the label belongs to %s, "+
+			"and a program that reads it can skip on it instead of re-verifying",
+			BlockingLabel, GatePath)
+	}
+
+	// Re-adding a label that is already present fires no trigger, so a repeat
+	// block would be silent. The gate removes it first, every time.
+	blocked := blockedSection(t)
+	remove := strings.Index(blocked, "--remove-label "+BlockingLabel)
+	add := strings.Index(blocked, "--add-label "+BlockingLabel)
+	switch {
+	case remove < 0:
+		t.Errorf("a repeat block re-adds %q without removing it first, so the trigger never fires", BlockingLabel)
+	case add < 0:
+		t.Fatalf("a blocked stage never adds %q", BlockingLabel)
+	case remove > add:
+		t.Errorf("the gate removes %q after adding it, which leaves the issue unblocked", BlockingLabel)
+	}
+}
+
+var (
+	// shellUse matches a shell variable the program tells an agent to expand.
+	shellUse = regexp.MustCompile(`\$\{?([A-Z_][A-Z0-9_]*)`)
+
+	// shellAssign matches a shell variable the program tells an agent to set.
+	shellAssign = regexp.MustCompile(`(?m)^\s*([A-Z_][A-Z0-9_]*)=`)
+)
+
+// environmentVars are supplied to every agent by the runner, so a program may
+// expand them without assigning them.
+var environmentVars = map[string]bool{
+	"MINION_ISSUE_NUMBER": true,
+	"GITHUB_RUN_ID":       true,
+}
+
+// TestHoldingPremiseIsRefreshedInTheIssue checks the passing path. Verifying and
+// then discarding what you found leaves the build stage rechecking against the
+// proposer's months-old excerpts, so each stage repeats the last stage's work
+// and the issue never gets any fresher. The refresh is also a real command with
+// a real path: an agent told to write `--body-file "$SOMETHING"` that nothing
+// ever sets writes the empty string, and `gh` overwrites the issue body with
+// nothing.
+func TestHoldingPremiseIsRefreshedInTheIssue(t *testing.T) {
+	src := readRepoFile(t, researchProgram)
+
+	checker, ok := section(src, "### premise-checker")
+	if !ok {
+		t.Fatal("research program has no premise-checker agent")
+	}
+	for what, token := range map[string]string{
+		"write the refreshed body back to the issue": "gh issue edit",
+		"keep the premise section it refreshes":      Marker,
+		"leave the rest of the body alone":           "the rest of the body untouched",
+	} {
+		if !containsPhrase(checker, token) {
+			t.Errorf("the premise-checker does not %s", what)
+		}
+	}
+
+	assigned := map[string]bool{}
+	for _, m := range shellAssign.FindAllStringSubmatch(src, -1) {
+		assigned[m[1]] = true
+	}
+	for _, m := range shellUse.FindAllStringSubmatch(checker, -1) {
+		if name := m[1]; !assigned[name] && !environmentVars[name] {
+			t.Errorf("the premise-checker expands $%s, which nothing in the program sets — "+
+				"it expands to the empty string at run time", name)
+		}
+	}
+
+	// The gate says what refreshing means, once, for every stage that holds.
+	holds := holdsSection(t)
+	if !containsPhrase(holds, "replace the evidence excerpts") {
+		t.Error("the stage gate does not say the refresh replaces the evidence with what this run read")
+	}
+}
+
+// TestHoldingPremiseRecordsWhatWasVerified checks that a green run carries its
+// evidence too. A verdict with nothing behind it is the prose assertion the
+// premise block replaced — and a run that only records failures leaves the
+// operator unable to tell a checked premise from an unchecked one.
+func TestHoldingPremiseRecordsWhatWasVerified(t *testing.T) {
+	checker, ok := section(readRepoFile(t, researchProgram), "### premise-checker")
+	if !ok {
+		t.Fatal("research program has no premise-checker agent")
+	}
+	for what, token := range map[string]string{
+		"record every claim it checked":      "record every claim",
+		"record the excerpt behind each one": "the excerpt that produced it",
+		"do so for a block that holds":       "for a block that holds",
+	} {
+		if !containsPhrase(checker, token) {
+			t.Errorf("a passing run does not %s", what)
+		}
+	}
+
+	if !containsPhrase(holdsSection(t), "Record the verdict") {
+		t.Error("the stage gate does not tell a passing stage to record its verdict")
+	}
+}
+
+// blockedSection returns the part of the stage gate that describes what a stage
+// does when the premise does not hold.
+func blockedSection(t *testing.T) string {
+	t.Helper()
+	return gateSection(t, "## When the premise does not hold")
+}
+
+// holdsSection returns the part of the stage gate that describes what a stage
+// does when the premise holds.
+func holdsSection(t *testing.T) string {
+	t.Helper()
+	return gateSection(t, "## When the premise holds")
+}
+
+// gateSection returns one section of the stage gate.
+func gateSection(t *testing.T, heading string) string {
+	t.Helper()
+
+	body, ok := section(readRepoFile(t, gateDoc), heading)
+	if !ok {
+		t.Fatalf("the stage gate has no %q section", heading)
+	}
+	return body
+}
+
+// markerCarriers lists every markdown file under .minions that contains marker.
+// Exactly one carrier is what makes "described once" checkable, so both the
+// verifier and the gate check their own marker through this walk.
+func markerCarriers(t *testing.T, marker string) []string {
+	t.Helper()
+
+	var carriers []string
+	err := filepath.WalkDir(filepath.Join(repoRoot, ".minions"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(path) != ".md" {
+			return err
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(src), marker) {
+			carriers = append(carriers, filepath.ToSlash(path))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk the minions tree: %v", err)
+	}
+	return carriers
+}
+
+// whitespace matches any run of spaces, tabs and newlines.
+var whitespace = regexp.MustCompile(`\s+`)
+
+// containsPhrase reports whether src states want, ignoring where the prose
+// happens to wrap. These programs are hand-wrapped markdown, so a phrase moves
+// across a line break whenever a sentence above it is edited. Matching the
+// bytes would fail on a reflow that changed nothing, and a test that cries wolf
+// on rewrapping gets deleted rather than fixed.
+func containsPhrase(src, want string) bool {
+	return strings.Contains(whitespace.ReplaceAllString(src, " "), whitespace.ReplaceAllString(want, " "))
+}
+
+// readRepoFile reads a file this repository ships, failing the test rather than
+// returning an error a caller has to re-report at every call site.
+func readRepoFile(t *testing.T, path string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}

--- a/internal/premise/source.go
+++ b/internal/premise/source.go
@@ -1,0 +1,30 @@
+package premise
+
+// A proposal filed before the premise block existed states its facts in prose.
+// There are hundreds of them, and 56 already carry the approved label, so a
+// gate that only reads blocks leaves every one of them exempt. Where the claims
+// come from is decided here, once, so no stage invents its own answer.
+
+// Source names where a stage takes the claims it verifies.
+type Source string
+
+const (
+	// SourceBlock reports a proposal that carries a premise block. The block
+	// is the claims, and the prose around it is not read.
+	SourceBlock Source = "block"
+
+	// SourceProse reports a proposal with no premise block. The claims are
+	// extracted from the issue prose at check time. Nothing is written back:
+	// the body keeps its own words and gains no block.
+	SourceProse Source = "prose"
+)
+
+// ClaimSource reports where the claims for an issue body come from. A body that
+// carries a block uses the block, so a proposal that states its premise is
+// never re-read from its prose.
+func ClaimSource(body string) Source {
+	if _, ok := Find(body); ok {
+		return SourceBlock
+	}
+	return SourceProse
+}

--- a/internal/premise/source_test.go
+++ b/internal/premise/source_test.go
@@ -1,0 +1,125 @@
+package premise
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClaimSourcePrefersTheBlock checks which claims a stage verifies when a
+// proposal offers both. A proposal that states its premise has already done the
+// work of naming what it depends on and what settles it; re-deriving that from
+// the surrounding paragraphs would let a stage check something the proposal
+// never claimed, and would make the block optional in practice.
+func TestClaimSourcePrefersTheBlock(t *testing.T) {
+	prose, err := os.ReadFile(filepath.Join("testdata", "issue-30-body.md"))
+	if err != nil {
+		t.Fatalf("read the issue #30 body fixture: %v", err)
+	}
+
+	block, err := Render(Block{Claims: []Claim{{
+		Statement: "The post-commit hook names changed files with a git diff.",
+		Evidence:  "internal/hooks/postcommit.go",
+	}}})
+	if err != nil {
+		t.Fatalf("render a premise block: %v", err)
+	}
+
+	body := string(prose) + "\n" + block
+	if got := ClaimSource(body); got != SourceBlock {
+		t.Fatalf("a proposal that carries a block takes its claims from the %s, want the %s", got, SourceBlock)
+	}
+
+	parsed, err := Parse(body)
+	if err != nil {
+		t.Fatalf("the block does not parse out of the body: %v", err)
+	}
+	if len(parsed.Claims) != 1 {
+		t.Fatalf("the block states 1 claim, %d were taken", len(parsed.Claims))
+	}
+	if strings.Contains(parsed.Claims[0].Statement, "full tree walk") {
+		t.Error("a claim from the prose reached the verifier even though the proposal carries a block")
+	}
+
+	// The agent applies the same preference, so extraction has to be gated on
+	// the marker being absent rather than offered as an alternative reading.
+	noBlock, ok := section(readRepoFile(t, verifierDoc), noBlockHeading)
+	if !ok {
+		t.Fatalf("the premise verifier has no %q section", noBlockHeading)
+	}
+	if !strings.Contains(noBlock, Marker) {
+		t.Errorf("the %q section does not name %s as what makes it apply, so it reads as a second way to check any proposal", noBlockHeading, Marker)
+	}
+}
+
+// TestProseWithNoCheckableClaimProceeds guards the direction that would do the
+// most damage quietly. Most of the backlog describes what to build rather than
+// what is true, so reading "I found nothing to check" as a failure would block
+// hundreds of proposals at once — the opposite of the intent, and indis-
+// tinguishable from the gate working. An empty block stays an error, because a
+// proposal that opens a premise section and states nothing in it has made a
+// mistake; a proposal that never claimed anything has not.
+func TestProseWithNoCheckableClaimProceeds(t *testing.T) {
+	const wishes = "## Description\n\nAdd a --json flag to partio status.\n\n" +
+		"## Acceptance Criteria\n\n- [ ] The flag prints machine-readable output\n"
+
+	if got := ClaimSource(wishes); got != SourceProse {
+		t.Fatalf("a proposal with no block takes its claims from the %s, want the %s", got, SourceProse)
+	}
+	if _, err := Parse("## Premise\n\n" + Marker + "\n"); err == nil {
+		t.Error("a premise section that states nothing parses, so an empty block is indistinguishable from prose with no claim")
+	}
+
+	body, ok := section(readRepoFile(t, verifierDoc), noBlockHeading)
+	if !ok {
+		t.Fatalf("the premise verifier has no %q section", noBlockHeading)
+	}
+	lower := flat(body)
+	for _, want := range []string{"no checkable claim", "continue", "unresolved", "say so"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("the %q section never says %q, so a proposal that claims nothing has no stated outcome", noBlockHeading, want)
+		}
+	}
+}
+
+// TestClaimSourceReadsTheMarkerNotTheProse covers what counts as a block. The
+// marker is the whole test: a heading a proposal happened to write, or a
+// paragraph that talks about premises, is prose, and prose is extracted from
+// rather than parsed.
+func TestClaimSourceReadsTheMarkerNotTheProse(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want Source
+	}{
+		{
+			name: "a section carrying the marker is a block",
+			body: "## Premise\n\n" + Marker + "\n\n- Attribution is binary. [evidence: `internal/attribution/calculate.go`]\n",
+			want: SourceBlock,
+		},
+		{
+			name: "a premise heading without the marker is not a block",
+			body: "## Premise\n\n- Attribution is binary. [evidence: `internal/attribution/calculate.go`]\n",
+			want: SourceProse,
+		},
+		{
+			name: "prose that mentions a premise block is not one",
+			body: "This proposal has no premise block yet.\n\nThe hook walks the tree.\n",
+			want: SourceProse,
+		},
+		{
+			name: "an empty body has no block",
+			body: "",
+			want: SourceProse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClaimSource(tt.body); got != tt.want {
+				t.Errorf("ClaimSource() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/premise/testdata/holds.md
+++ b/internal/premise/testdata/holds.md
@@ -1,0 +1,14 @@
+A premise that is true of this repository, kept beside the issue #30 fixture.
+
+A bar that rejects everything looks exactly like a working bar until someone
+checks the other direction. This fixture is that check. Its claim survives
+verification, so an idea resting on it is filed rather than dropped.
+
+The claim names the file that settles it, and the evidence is read from this
+repository rather than asserted from a sibling product.
+
+## Premise
+
+<!-- partio:premise:v1 -->
+
+- Attribution is binary: a commit made while an agent was active is recorded as 100 percent agent. [evidence: `internal/attribution/calculate.go`]

--- a/internal/premise/testdata/issue-30-body.md
+++ b/internal/premise/testdata/issue-30-body.md
@@ -1,0 +1,49 @@
+## Description
+
+Partio's post-commit hook currently performs a full tree walk to determine which files were changed in a commit. This is O(N) in the number of tracked files and becomes a bottleneck on large repos. Replace the tree walk with a `git diff-tree --no-commit-id -r HEAD` invocation, which is a standard plumbing command that returns only the changed files for a given commit. This should noticeably reduce hook latency on repos with many files.
+
+## Source
+
+- **Origin:** entireio/cli#594 (changelog 0.5.0)
+- **Detected from:** `entireio-cli`
+
+## Target Repos
+
+- `cli`
+
+## Acceptance Criteria
+
+- [ ] Post-commit hook uses `git diff-tree` instead of a full tree walk to determine changed files
+- [ ] Hook produces identical results to the previous implementation for regular commits, merges, and initial commits
+- [ ] A benchmark test demonstrates measurably lower latency on a repo with 1000+ files
+- [ ] No regression in existing post-commit hook tests
+
+## Context Hints
+
+- `cli/internal/hooks/`
+- `cli/internal/git/`
+
+---
+
+Comment `/minion build` or add the `minion-approved` label to begin implementation.
+
+<!-- minion-task
+id: post-commit-hook-perf-diff-tree
+title: Replace O(N) tree walk with git diff-tree in post-commit hook
+source: entireio/cli#594 (changelog 0.5.0)
+source_type: changelog
+description: Partio's post-commit hook currently performs a full tree walk to determine which files were changed in a commit. This is O(N) in the number of tracked files and becomes a bottleneck on large repos. Replace the tree walk with a `git diff-tree --no-commit-id -r HEAD` invocation, which is a standard plumbing command that returns only the changed files for a given commit. This should noticeably reduce hook latency on repos with many files.
+target_repos:
+    - cli
+context_hints:
+    - cli/internal/hooks/
+    - cli/internal/git/
+acceptance_criteria:
+    - Post-commit hook uses `git diff-tree` instead of a full tree walk to determine changed files
+    - Hook produces identical results to the previous implementation for regular commits, merges, and initial commits
+    - A benchmark test demonstrates measurably lower latency on a repo with 1000+ files
+    - No regression in existing post-commit hook tests
+pr_labels:
+    - minion
+    - feature
+ minion-task -->

--- a/internal/premise/testdata/issue-30.md
+++ b/internal/premise/testdata/issue-30.md
@@ -1,0 +1,16 @@
+The premise of issue #30, filed 2026-03-26 and built on 2026-08-10.
+
+Both claims are false for this repository. They came from a sibling
+product's changelog, where the problem was real, and nobody checked
+whether it was real here. The hook runs a two-commit `git diff`, which
+is a tree-to-tree comparison and never touches the working tree.
+
+Each line names the evidence that settles it. This file only captures
+the premise; verifying it is slice 4.
+
+## Premise
+
+<!-- partio:premise:v1 -->
+
+- Partio's post-commit hook performs a full tree walk to determine which files were changed in a commit. [evidence: `internal/hooks/postcommit.go`]
+- The cost of determining changed files is O(N) in the number of tracked files. [evidence: `internal/attribution/calculate.go`]

--- a/internal/premise/verifier.go
+++ b/internal/premise/verifier.go
@@ -1,0 +1,36 @@
+package premise
+
+// Verification is a single described behaviour, not a copy per caller: given a
+// premise block and a checked-out tree, gather the evidence each claim names
+// and return a verdict plus what was found. The description lives in one file,
+// and the propose, research and implement programs reference it. The constants
+// below are the contract that file and its callers share.
+const (
+	// VerifierPath is where verification is described, relative to the
+	// repository root.
+	VerifierPath = ".minions/premise-verifier.md"
+
+	// VerifierMarker names the description and its format version. Exactly
+	// one file carries it, which is what makes "described once" checkable.
+	VerifierMarker = "<!-- partio:premise-verifier:v1 -->"
+)
+
+// Verdict is the outcome of checking one claim against the tree.
+type Verdict string
+
+const (
+	// Holds reports a claim the gathered evidence confirms.
+	Holds Verdict = "holds"
+
+	// Fails reports a claim the gathered evidence contradicts. One failed
+	// claim fails the block, and the calling stage stops.
+	Fails Verdict = "fails"
+
+	// Unresolved reports a claim the named evidence does not settle, because
+	// the path is missing or the command produced nothing to read. It is not
+	// a pass: a claim nothing settles has not been checked.
+	Unresolved Verdict = "unresolved"
+)
+
+// Verdicts is the closed set a caller may act on.
+var Verdicts = []Verdict{Holds, Fails, Unresolved}

--- a/internal/programshape/repo_programs_test.go
+++ b/internal/programshape/repo_programs_test.go
@@ -1,0 +1,58 @@
+package programshape
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// programsDir is this repository's minions programs directory, relative to the
+// package directory that go test runs in.
+const programsDir = "../../.minions/programs"
+
+// knownUnreachable records the programs whose instructions do not reach the
+// model today. Every entry is a defect that is accepted, not approved: the
+// suite stays green on arrival and the list is the checklist to work down.
+// Delete an entry when its program is fixed — the test fails if a listed
+// program turns out to be healthy, so the list cannot drift from reality.
+var knownUnreachable = map[string]string{
+	"approve.md":       "The whole procedure sits in ## Steps; the program is unreferenced by any workflow and is out of scope for this work.",
+	"ingest.md":        "The whole procedure sits in ## Steps; the program is unreferenced by any workflow and is out of scope for this work.",
+	"doc-update.md":    "The whole procedure sits in ## Steps; the program is reachable from a workflow, so it misbehaves in production, and it is out of scope for this work.",
+	"readme-update.md": "The whole procedure sits in ## Steps; the program is unreferenced by any workflow and is out of scope for this work.",
+
+	// The three programs below are one-shot feature specifications, not
+	// pipeline programs. The PRD for this work did not count them. Each has a
+	// bare H1 with no prose under it, so the model receives a title and
+	// nothing else — a worse state than the five programs above.
+	"e2e-model-name-checkpoint-flow.md":    "The specification sits in ## Background and ## What to build; the H1 carries no prose, so the model receives only the title.",
+	"e2e-squash-merge-branch-name-flow.md": "The specification sits in ## What to build; the H1 carries no prose, so the model receives only the title and ## Context.",
+	"e2e-two-rapid-commit-trailer-flow.md": "The specification sits in ## Background and ## What to build; the H1 carries no prose, so the model receives only the title.",
+}
+
+func TestRepoProgramsKeepInstructionsReachable(t *testing.T) {
+	scan, err := ScanDir(programsDir)
+	if err != nil {
+		t.Fatalf("scan the repository programs: %v", err)
+	}
+	if len(scan.Programs) == 0 {
+		t.Fatalf("no .md programs found in %s", programsDir)
+	}
+
+	for name, findings := range scan.Unreachable {
+		if _, accepted := knownUnreachable[name]; !accepted {
+			t.Errorf("%s", Report(filepath.Join(programsDir, name), findings))
+		}
+	}
+
+	for name := range knownUnreachable {
+		switch {
+		case !slices.Contains(scan.Programs, name):
+			t.Errorf("knownUnreachable lists %s, but no such program exists in %s — "+
+				"delete the stale entry.", name, programsDir)
+		case len(scan.Unreachable[name]) == 0:
+			t.Errorf("%s is listed in knownUnreachable, but its instructions now reach "+
+				"the model — delete its entry from knownUnreachable.", name)
+		}
+	}
+}

--- a/internal/programshape/scan.go
+++ b/internal/programshape/scan.go
@@ -1,0 +1,64 @@
+package programshape
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Scan is the result of reading a minions programs directory.
+type Scan struct {
+	// Programs are the program file names read, sorted.
+	Programs []string
+	// Unreachable maps a program file name to the sections whose instructions
+	// never reach the model. A program in good shape is absent from the map.
+	Unreachable map[string][]Finding
+}
+
+// ScanDir runs Check over every .md program in dir.
+func ScanDir(dir string) (Scan, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return Scan{}, fmt.Errorf("read programs directory %s: %w", dir, err)
+	}
+
+	scan := Scan{Unreachable: make(map[string][]Finding)}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return Scan{}, fmt.Errorf("read program %s: %w", name, err)
+		}
+
+		scan.Programs = append(scan.Programs, name)
+		if findings := Check(string(src)); len(findings) > 0 {
+			scan.Unreachable[name] = findings
+		}
+	}
+	slices.Sort(scan.Programs)
+
+	return scan, nil
+}
+
+// Report renders one program's findings as a failure message. It names the
+// program file and every dropped heading, so the repair needs no bisecting of
+// the program format rules.
+func Report(path string, findings []Finding) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s: instructions do not reach the model\n", path)
+	for _, f := range findings {
+		fmt.Fprintf(&b, "\tthe dropped section %q carries %s\n", f.Heading, f.Reason)
+	}
+	b.WriteString("\tThe program parser keeps only the H1 prose, ## Context, ## Planner and\n" +
+		"\t## Agents. Move these instructions into an ## Agents sub-section, or record\n" +
+		"\tthe program in knownUnreachable with a reason.")
+
+	return b.String()
+}

--- a/internal/programshape/scan_test.go
+++ b/internal/programshape/scan_test.go
@@ -1,0 +1,127 @@
+package programshape
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// writePrograms fills an isolated programs directory and returns its path.
+func writePrograms(t *testing.T, programs map[string]string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for name, src := range programs {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(src), 0o600); err != nil {
+			t.Fatalf("write program %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+const healthyProgram = `# Repair the failing check
+
+## Agents
+
+### checks-fix
+
+1. Read the failing check output.
+2. Repair the failure and push the fix.
+`
+
+const stepsProgram = `# Release the new version
+
+Cut a release.
+
+## Steps
+
+1. Tag the commit.
+2. Push the tag.
+`
+
+// A new program that hides its procedure in ## Steps must turn the suite red,
+// which is the whole point of the check.
+func TestScanDirFlagsANewStepsProgram(t *testing.T) {
+	dir := writePrograms(t, map[string]string{
+		"checks-fix.md": healthyProgram,
+		"release.md":    stepsProgram,
+	})
+
+	scan, err := ScanDir(dir)
+	if err != nil {
+		t.Fatalf("ScanDir: %v", err)
+	}
+
+	if _, ok := scan.Unreachable["checks-fix.md"]; ok {
+		t.Errorf("checks-fix.md was flagged, but its instructions reach the model")
+	}
+
+	findings, ok := scan.Unreachable["release.md"]
+	if !ok {
+		t.Fatalf("release.md was not flagged, but its procedure sits in a dropped ## Steps section")
+	}
+	if len(findings) != 1 || findings[0].Heading != "## Steps" {
+		t.Errorf("release.md findings = %v, want one finding for %q", findings, "## Steps")
+	}
+}
+
+func TestScanDirReadsEveryMarkdownProgramAndNothingElse(t *testing.T) {
+	dir := writePrograms(t, map[string]string{
+		"release.md":    stepsProgram,
+		"checks-fix.md": healthyProgram,
+		"notes.txt":     stepsProgram,
+		"sources.yaml":  "id: release\n",
+	})
+
+	scan, err := ScanDir(dir)
+	if err != nil {
+		t.Fatalf("ScanDir: %v", err)
+	}
+
+	want := []string{"checks-fix.md", "release.md"}
+	if !slices.Equal(scan.Programs, want) {
+		t.Errorf("ScanDir read %v, want %v", scan.Programs, want)
+	}
+}
+
+func TestScanDirReportsAMissingDirectory(t *testing.T) {
+	if _, err := ScanDir(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Fatal("ScanDir returned no error for a missing directory")
+	}
+}
+
+// A failure must name the program file and the dropped heading, so the fix
+// needs no bisecting of the program format rules.
+func TestReportNamesTheProgramAndTheDroppedHeading(t *testing.T) {
+	path := filepath.Join(".minions", "programs", "release.md")
+	message := Report(path, Check(stepsProgram))
+
+	if !strings.Contains(message, path) {
+		t.Errorf("message does not name the program file %q:\n%s", path, message)
+	}
+	if !strings.Contains(message, "## Steps") {
+		t.Errorf("message does not name the dropped heading %q:\n%s", "## Steps", message)
+	}
+}
+
+func TestReportNamesEveryDroppedHeading(t *testing.T) {
+	src := `# Build an end-to-end test
+
+## Background
+
+1. The trailer is written by the post-commit hook.
+
+## What to build
+
+1. Create a repository fixture.
+`
+	message := Report("e2e.md", Check(src))
+
+	for _, heading := range []string{"## Background", "## What to build"} {
+		if !strings.Contains(message, heading) {
+			t.Errorf("message does not name the dropped heading %q:\n%s", heading, message)
+		}
+	}
+}

--- a/internal/programshape/shape.go
+++ b/internal/programshape/shape.go
@@ -1,0 +1,157 @@
+// Package programshape checks that a minions program keeps its instructions
+// where the program parser can reach them.
+//
+// The parser keeps four things from a program body: the H1 heading with the
+// prose directly under it, a ## Context section, a ## Planner section, and a
+// ## Agents section with its H3 sub-sections. It discards every other heading
+// and its body, silently. When a program defines no agents, the executor
+// synthesizes one whose entire instruction set is the prose under the H1.
+//
+// A program that puts its procedure in a discarded section therefore runs on
+// one or two sentences and improvises the rest.
+package programshape
+
+import (
+	"regexp"
+	"strings"
+)
+
+// keptSections are the H2 headings the parser reads. The comparison is on the
+// lower-case heading text, without the leading "## ".
+var keptSections = map[string]bool{
+	"context": true,
+	"planner": true,
+	"agents":  true,
+}
+
+// Finding is one discarded section whose body tells the agent what to do.
+type Finding struct {
+	// Heading is the section heading as written, for example "## Steps".
+	Heading string
+	// Reason names the instruction content found, for the failure message.
+	Reason string
+}
+
+// Check reports the sections whose instructions never reach the model.
+//
+// Check returns nil for a program that defines an ## Agents section, because
+// the parser reads an agent's prose in full. It also returns nil for a program
+// whose entire instruction set is the prose under the H1, because that text
+// does reach the model.
+func Check(src string) []Finding {
+	sections := topLevelSections(stripFrontmatter(src))
+
+	for _, s := range sections {
+		if headingText(s.heading) == "agents" {
+			return nil
+		}
+	}
+
+	var findings []Finding
+	for _, s := range sections {
+		if keptSections[headingText(s.heading)] {
+			continue
+		}
+		if reason := instructionContent(s.body); reason != "" {
+			findings = append(findings, Finding{Heading: s.heading, Reason: reason})
+		}
+	}
+	return findings
+}
+
+// section is one H2 heading and the body under it.
+type section struct {
+	heading string
+	body    string
+}
+
+// stripFrontmatter removes a leading YAML frontmatter block, which the parser
+// reads separately from the Markdown body.
+func stripFrontmatter(src string) string {
+	lines := strings.Split(src, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return src
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return strings.Join(lines[i+1:], "\n")
+		}
+	}
+	return src
+}
+
+// topLevelSections splits a program body on its H2 headings. Text before the
+// first H2, which is the H1 and the prose under it, belongs to no section and
+// is dropped here because it always reaches the model.
+func topLevelSections(body string) []section {
+	var (
+		sections  []section
+		current   *section
+		bodyLines []string
+		inFence   bool
+	)
+
+	flush := func() {
+		if current == nil {
+			return
+		}
+		current.body = strings.Join(bodyLines, "\n")
+		sections = append(sections, *current)
+	}
+
+	for line := range strings.SplitSeq(body, "\n") {
+		if isFence(line) {
+			inFence = !inFence
+		} else if !inFence && strings.HasPrefix(line, "## ") {
+			flush()
+			current = &section{heading: strings.TrimSpace(line)}
+			bodyLines = nil
+			continue
+		}
+		if current != nil {
+			bodyLines = append(bodyLines, line)
+		}
+	}
+	flush()
+
+	return sections
+}
+
+// headingText returns the lower-case heading text, without its "##" marker.
+func headingText(heading string) string {
+	return strings.ToLower(strings.TrimSpace(strings.TrimPrefix(heading, "##")))
+}
+
+// numberedItem matches a numbered list item, which reads as one step of a
+// procedure.
+var numberedItem = regexp.MustCompile(`(?m)^\s*\d+\.\s+\S`)
+
+// instructionContent names the instruction content in a section body, or
+// returns an empty string when the body only explains, attributes, or asserts.
+// A numbered step list and a fenced block are the two markers that separate a
+// procedure the agent must follow from prose about why the work matters.
+func instructionContent(body string) string {
+	if hasFence(body) {
+		return "a command or code block"
+	}
+	if numberedItem.MatchString(body) {
+		return "a numbered step list"
+	}
+	return ""
+}
+
+// hasFence reports whether the body opens a fenced code block.
+func hasFence(body string) bool {
+	for line := range strings.SplitSeq(body, "\n") {
+		if isFence(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFence reports whether a line opens or closes a fenced code block.
+func isFence(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+}

--- a/internal/programshape/shape_test.go
+++ b/internal/programshape/shape_test.go
@@ -1,0 +1,137 @@
+package programshape
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string // headings expected in the findings, in order
+	}{
+		{
+			name: "steps section with no agents section is unreachable",
+			src: `---
+id: propose
+---
+
+# Propose features from monitored sources
+
+Scan monitored sources and create feature proposals.
+
+## Steps
+
+1. **Read sources config** from ` + "`.minions/sources.yaml`" + `.
+2. **For each source**, fetch new content since the cursor.
+`,
+			want: []string{"## Steps"},
+		},
+		{
+			name: "instructions in an agents section reach the model",
+			src: `# Repair the lint and test failures a check found
+
+A check failed. Repair it.
+
+## Steps
+
+1. This section is dropped, but the agent below carries the procedure.
+
+## Agents
+
+### checks-fix
+
+1. Read the failing check output.
+2. Repair the failure and push the fix.
+`,
+			want: nil,
+		},
+		{
+			name: "an entire instruction set under the H1 reaches the model",
+			src: `# Warn when importing agent history while not authenticated
+
+When ` + "`partio enable`" + ` runs and finds existing history to import, it
+must check whether the user is authenticated. If not, import as normal and
+warn that the checkpoints are local-only until the user authenticates.
+
+## Why
+
+Silent local-only imports create a deceptive success state.
+
+## Source
+
+entireio/cli issue #1773.
+`,
+			want: nil,
+		},
+		{
+			name: "a dropped section holding only a command block is unreachable",
+			src: `# Publish the release
+
+## Release
+
+` + "```bash\ngit push --tags\n```" + `
+`,
+			want: []string{"## Release"},
+		},
+		{
+			name: "a kept section is never reported",
+			src: `# Research minion
+
+Do the research.
+
+## Context
+
+1. ` + "`.minions/sources.yaml`" + `
+2. ` + "`.minions/project.yaml`" + `
+`,
+			want: nil,
+		},
+		{
+			name: "a heading inside a fenced block is not a section",
+			src: `# Show the program format
+
+The format is described below, and nothing here is dropped.
+
+## Example
+
+` + "```markdown\n## Steps\n\n1. A step inside a fence.\n```" + `
+`,
+			want: []string{"## Example"},
+		},
+		{
+			name: "every dropped section carrying instructions is reported",
+			src: `# Build an end-to-end test
+
+## Background
+
+1. The trailer is written by the post-commit hook.
+
+## What to build
+
+1. Create a repository fixture.
+2. Commit twice in rapid succession.
+`,
+			want: []string{"## Background", "## What to build"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := Check(tt.src)
+
+			if len(findings) != len(tt.want) {
+				t.Fatalf("Check() returned %d findings, want %d: %v", len(findings), len(tt.want), findings)
+			}
+			for i, heading := range tt.want {
+				if findings[i].Heading != heading {
+					t.Errorf("finding %d heading = %q, want %q", i, findings[i].Heading, heading)
+				}
+				if strings.TrimSpace(findings[i].Reason) == "" {
+					t.Errorf("finding %d for %q has an empty reason", i, heading)
+				}
+			}
+		})
+	}
+}

--- a/internal/rejection/rejection.go
+++ b/internal/rejection/rejection.go
@@ -1,0 +1,307 @@
+// Package rejection records what the proposer threw away, and why. The run that
+// drops an idea also advances the cursor that tracks how far it has read each
+// source, so the source item is never offered again. Without a record the idea
+// is gone with no trace, and a bar set too high looks exactly like a source that
+// has gone quiet. This log is the only surface that tells those two apart.
+package rejection
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/partio-io/cli/internal/premise"
+)
+
+const (
+	// LogPath is where rejections accumulate, relative to the repository root.
+	LogPath = ".minions/rejections.md"
+
+	// Marker names an entry and its format version, so a reader finds the
+	// entries without guessing at the prose around them.
+	Marker = "<!-- partio:rejection:v1 -->"
+
+	// header opens a log file that does not exist yet. It is written once, and
+	// every later run appends below it.
+	header = "# Rejections\n\n" +
+		"Ideas the proposer did not file, and why. Each run appends; nothing here\n" +
+		"is ever rewritten. The cursor has already moved past every item below, so\n" +
+		"this file is the only record that the idea was seen at all.\n"
+)
+
+// Reason is why an idea did not become a proposal.
+type Reason string
+
+const (
+	// PremiseFailed reports an idea this repository contradicted. It was
+	// checked, and a claim it depends on did not survive the check.
+	PremiseFailed Reason = "premise-failed"
+
+	// Irrelevant reports a source item that was never about this project. It
+	// was never an idea, so no claim was ever checked.
+	Irrelevant Reason = "irrelevant"
+)
+
+// Reasons is the closed set an entry may carry.
+var Reasons = []Reason{PremiseFailed, Irrelevant}
+
+var (
+	// ErrNoIdea reports an entry that does not say what was rejected.
+	ErrNoIdea = errors.New("rejection: entry names no idea")
+
+	// ErrNoSource reports an entry that does not say where the idea came from.
+	ErrNoSource = errors.New("rejection: entry names no source")
+
+	// ErrNoReason reports an entry with no reason, or one outside Reasons.
+	ErrNoReason = errors.New("rejection: entry gives no known reason")
+
+	// ErrNoClaim reports a premise-failed entry that does not name the claim
+	// that failed, or names one with no evidence behind it.
+	ErrNoClaim = errors.New("rejection: entry names no failed claim")
+
+	// ErrNoVerdict reports a premise-failed entry whose verdict is missing,
+	// outside premise.Verdicts, or Holds — a claim the tree confirmed did not
+	// cause a rejection.
+	ErrNoVerdict = errors.New("rejection: entry gives no verdict that rejects")
+
+	// ErrNoFinding reports a premise-failed entry that does not say what the
+	// gathered evidence actually showed. Without it the entry asserts the
+	// failure instead of recording it.
+	ErrNoFinding = errors.New("rejection: entry does not say what the evidence showed")
+
+	// ErrNoNote reports an irrelevant entry that does not say why the item was
+	// not about this project.
+	ErrNoNote = errors.New("rejection: entry does not say why the item was irrelevant")
+
+	// ErrNotChecked reports an irrelevant entry carrying a claim, a verdict or
+	// a finding. An item that was never about this project was never checked,
+	// so it has none of those, and an entry that shows them reads as a dropped
+	// idea — the one distinction this log exists to keep.
+	ErrNotChecked = errors.New("rejection: irrelevant entry carries a check that never ran")
+)
+
+// Entry is one rejected idea. A premise-failed entry carries the claim, the
+// evidence it named, the verdict and what was found; an irrelevant entry
+// carries none of those, because nothing was ever checked. That difference is
+// structural, so the two kinds cannot be confused by a reader or by a parser.
+type Entry struct {
+	// Idea is what was rejected, in one line.
+	Idea string
+
+	// Source is where the idea came from — the monitored source and the item
+	// within it.
+	Source string
+
+	// Reason is why it was rejected.
+	Reason Reason
+
+	// Claim is the claim that failed. PremiseFailed only.
+	Claim premise.Claim
+
+	// Verdict is what the check returned for that claim. PremiseFailed only.
+	Verdict premise.Verdict
+
+	// Found is what the gathered evidence actually showed — the excerpt that
+	// contradicted the claim. PremiseFailed only.
+	Found string
+
+	// Note is why the item was not about this project. Irrelevant only.
+	Note string
+}
+
+// claimLine matches the claim of a premise-failed entry. The evidence closes the
+// line, matching the grammar of the premise block the claim came from.
+var claimLine = regexp.MustCompile("^-\\s+claim:\\s+(.*\\S)\\s+\\[evidence:\\s*`([^`]*)`\\]$")
+
+// fieldLine matches a plain `- name: value` field.
+var fieldLine = regexp.MustCompile(`^-\s+([a-z]+):\s+(.*\S)\s*$`)
+
+// Render writes one entry as it appears in the log.
+func Render(e Entry) (string, error) {
+	idea := oneLine(e.Idea)
+	source := oneLine(e.Source)
+
+	if idea == "" {
+		return "", ErrNoIdea
+	}
+	if source == "" {
+		return "", fmt.Errorf("%w: %s", ErrNoSource, idea)
+	}
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "## %s\n\n%s\n\n", idea, Marker)
+	fmt.Fprintf(&out, "- source: `%s`\n", source)
+	fmt.Fprintf(&out, "- reason: `%s`\n", e.Reason)
+
+	switch e.Reason {
+	case PremiseFailed:
+		statement := oneLine(e.Claim.Statement)
+		evidence := oneLine(e.Claim.Evidence)
+		found := oneLine(e.Found)
+
+		if statement == "" || evidence == "" {
+			return "", fmt.Errorf("%w: %s", ErrNoClaim, idea)
+		}
+		if !rejects(e.Verdict) {
+			return "", fmt.Errorf("%w: %q on %s", ErrNoVerdict, e.Verdict, idea)
+		}
+		if found == "" {
+			return "", fmt.Errorf("%w: %s", ErrNoFinding, idea)
+		}
+
+		fmt.Fprintf(&out, "- claim: %s [evidence: `%s`]\n", statement, evidence)
+		fmt.Fprintf(&out, "- verdict: `%s`\n", e.Verdict)
+		fmt.Fprintf(&out, "- found: %s\n", found)
+	case Irrelevant:
+		note := oneLine(e.Note)
+
+		if e.Claim.Statement != "" || e.Claim.Evidence != "" || e.Verdict != "" || e.Found != "" {
+			return "", fmt.Errorf("%w: %s", ErrNotChecked, idea)
+		}
+		if note == "" {
+			return "", fmt.Errorf("%w: %s", ErrNoNote, idea)
+		}
+
+		fmt.Fprintf(&out, "- note: %s\n", note)
+	default:
+		return "", fmt.Errorf("%w: %q", ErrNoReason, e.Reason)
+	}
+
+	return out.String(), nil
+}
+
+// Append adds one entry to the log under root, creating the log if this is the
+// first rejection ever recorded. It never rewrites what is already there.
+func Append(root string, e Entry) (err error) {
+	entry, err := Render(e)
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(root, LogPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("rejection: make log directory: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("rejection: open log: %w", err)
+	}
+	// A close that fails on a write handle can lose the entry that was just
+	// written, which is the silent loss this log exists to stop. Report it.
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("rejection: close log: %w", cerr)
+		}
+	}()
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("rejection: stat log: %w", err)
+	}
+
+	out := "\n" + entry
+	if info.Size() == 0 {
+		out = header + out
+	}
+	if _, err := f.WriteString(out); err != nil {
+		return fmt.Errorf("rejection: append to log: %w", err)
+	}
+	return nil
+}
+
+// Parse reads every entry out of a log, oldest first.
+func Parse(log string) ([]Entry, error) {
+	var (
+		out     []Entry
+		current *Entry
+		marked  bool
+	)
+
+	flush := func() error {
+		if current == nil {
+			return nil
+		}
+		if !marked {
+			return fmt.Errorf("rejection: entry %q does not carry %s", current.Idea, Marker)
+		}
+		if current.Source == "" {
+			return fmt.Errorf("%w: %s", ErrNoSource, current.Idea)
+		}
+		if !known(current.Reason) {
+			return fmt.Errorf("%w: %s", ErrNoReason, current.Idea)
+		}
+		out = append(out, *current)
+		current = nil
+		return nil
+	}
+
+	for _, line := range strings.Split(log, "\n") {
+		line = strings.TrimSpace(line)
+
+		if heading, ok := strings.CutPrefix(line, "## "); ok {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			idea := strings.TrimSpace(heading)
+			if idea == "" {
+				return nil, ErrNoIdea
+			}
+			current = &Entry{Idea: idea}
+			marked = false
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		if line == Marker {
+			marked = true
+			continue
+		}
+		if m := claimLine.FindStringSubmatch(line); m != nil {
+			current.Claim = premise.Claim{Statement: m[1], Evidence: strings.TrimSpace(m[2])}
+			continue
+		}
+		if m := fieldLine.FindStringSubmatch(line); m != nil {
+			value := strings.Trim(m[2], "`")
+			switch m[1] {
+			case "source":
+				current.Source = value
+			case "reason":
+				current.Reason = Reason(value)
+			case "verdict":
+				current.Verdict = premise.Verdict(value)
+			case "found":
+				current.Found = value
+			case "note":
+				current.Note = value
+			}
+		}
+	}
+
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// rejects reports whether v is a verdict that drops an idea. Holds does not:
+// a claim the tree confirmed is not why a proposal was rejected.
+func rejects(v premise.Verdict) bool {
+	return v == premise.Fails || v == premise.Unresolved
+}
+
+// known reports whether r is one of Reasons.
+func known(r Reason) bool {
+	return slices.Contains(Reasons, r)
+}
+
+// oneLine trims a field and collapses any line break, so one entry stays one
+// readable block and a stray newline cannot forge a second entry.
+func oneLine(s string) string {
+	return strings.TrimSpace(strings.NewReplacer("\r", " ", "\n", " ").Replace(s))
+}

--- a/internal/rejection/rejection_test.go
+++ b/internal/rejection/rejection_test.go
@@ -1,0 +1,567 @@
+package rejection
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/partio-io/cli/internal/premise"
+)
+
+// proposeProgram is this repository's propose program, relative to the package
+// directory that go test runs in. It is the run that drops ideas, so it is the
+// run that has to write and commit the log.
+const proposeProgram = "../../.minions/programs/propose.md"
+
+// TestRejectionLogReachesTheProposer is the end-to-end path this slice builds.
+// A log nothing writes records nothing, and a log the run never commits is gone
+// the moment the workspace is thrown away — while the cursor has already moved
+// past the idea. So the test walks both halves: entries survive a write and a
+// read back, and the propose program stages the log in the same commit that
+// advances the cursor.
+func TestRejectionLogReachesTheProposer(t *testing.T) {
+	root := t.TempDir()
+
+	dropped := Entry{
+		Idea:   "walk the tree to attribute a commit",
+		Source: "entireio-cli-issues#1877",
+		Reason: PremiseFailed,
+		Claim: premise.Claim{
+			Statement: "the post-commit hook walks the whole tree",
+			Evidence:  "internal/hooks/post_commit.go",
+		},
+		Verdict: premise.Fails,
+		Found:   "the hook names changed files with git.DiffNameOnly(commitHash)",
+	}
+	skipped := Entry{
+		Idea:   "add a billing dashboard",
+		Source: "entireio-cli-changelog#0.9.1",
+		Reason: Irrelevant,
+		Note:   "this project has no billing surface",
+	}
+
+	for _, e := range []Entry{dropped, skipped} {
+		if err := Append(root, e); err != nil {
+			t.Fatalf("append %q: %v", e.Idea, err)
+		}
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, LogPath))
+	if err != nil {
+		t.Fatalf("read the log: %v", err)
+	}
+
+	got, err := Parse(string(raw))
+	if err != nil {
+		t.Fatalf("parse the log: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("wrote 2 rejections, read back %d", len(got))
+	}
+	if got[0].Reason != PremiseFailed || got[1].Reason != Irrelevant {
+		t.Errorf("the two kinds of rejection did not survive the round trip: %q then %q",
+			got[0].Reason, got[1].Reason)
+	}
+	if got[0].Claim.Statement != dropped.Claim.Statement || got[0].Found != dropped.Found {
+		t.Errorf("the failed claim lost what killed it: %+v", got[0])
+	}
+
+	// The other half: the run has to commit what it wrote. The cursor moves
+	// past a dropped idea whether or not the log survives, so a log left out
+	// of the commit is the silent loss this slice exists to stop.
+	src, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read the propose program: %v", err)
+	}
+	add, ok := lineContaining(string(src), "git add")
+	if !ok {
+		t.Fatal("the propose program stages nothing")
+	}
+	if !strings.Contains(add, LogPath) {
+		t.Errorf("the run does not stage %s, so a rejection dies with the workspace:\n%s", LogPath, add)
+	}
+	if !strings.Contains(add, ".minions/sources.yaml") {
+		t.Errorf("the log is not staged alongside the cursor it must travel with:\n%s", add)
+	}
+}
+
+// TestEntryRecordsIdeaSourceAndReason checks the three fields every entry
+// carries whatever the reason. An entry that names no idea, or no source, or no
+// known reason cannot be judged later, and a log of unjudgeable entries is the
+// silence this slice replaced. So a short entry is refused at the write rather
+// than appended half-empty for a reader to puzzle over.
+func TestEntryRecordsIdeaSourceAndReason(t *testing.T) {
+	complete := Entry{
+		Idea:    "walk the tree to attribute a commit",
+		Source:  "entireio-cli-issues#1877",
+		Reason:  PremiseFailed,
+		Claim:   premise.Claim{Statement: "the hook walks the tree", Evidence: "internal/hooks/post_commit.go"},
+		Verdict: premise.Fails,
+		Found:   "the hook calls git.DiffNameOnly(commitHash)",
+	}
+	without := func(f func(*Entry)) Entry {
+		e := complete
+		f(&e)
+		return e
+	}
+
+	tests := []struct {
+		name    string
+		entry   Entry
+		wantErr error
+	}{
+		{"complete", complete, nil},
+		{"no idea", without(func(e *Entry) { e.Idea = "" }), ErrNoIdea},
+		{"blank idea", without(func(e *Entry) { e.Idea = "   " }), ErrNoIdea},
+		{"no source", without(func(e *Entry) { e.Source = "" }), ErrNoSource},
+		{"no reason", without(func(e *Entry) { e.Reason = "" }), ErrNoReason},
+		{"reason outside the closed set", without(func(e *Entry) { e.Reason = "meh" }), ErrNoReason},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			err := Append(root, tt.entry)
+
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("append a complete entry: %v", err)
+				}
+				got := readOne(t, root)
+				if got.Idea != tt.entry.Idea {
+					t.Errorf("idea: got %q, want %q", got.Idea, tt.entry.Idea)
+				}
+				if got.Source != tt.entry.Source {
+					t.Errorf("source: got %q, want %q", got.Source, tt.entry.Source)
+				}
+				if got.Reason != tt.entry.Reason {
+					t.Errorf("reason: got %q, want %q", got.Reason, tt.entry.Reason)
+				}
+				return
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("append %s: got %v, want %v", tt.name, err, tt.wantErr)
+			}
+			if _, err := os.Stat(filepath.Join(root, LogPath)); !os.IsNotExist(err) {
+				t.Error("a refused entry still touched the log")
+			}
+		})
+	}
+}
+
+// TestPremiseFailedRecordsTheClaimAndWhatKilledIt checks the entry that has to
+// carry the most. "The premise failed" is the assertion the premise block
+// replaced: it is a verdict with nothing behind it. An entry that names the
+// claim, the evidence it named, the verdict and what the evidence actually
+// showed can be re-judged later; one that names fewer cannot, so it is refused.
+func TestPremiseFailedRecordsTheClaimAndWhatKilledIt(t *testing.T) {
+	complete := Entry{
+		Idea:    "walk the tree to attribute a commit",
+		Source:  "entireio-cli-issues#1877",
+		Reason:  PremiseFailed,
+		Claim:   premise.Claim{Statement: "the hook walks the tree", Evidence: "internal/hooks/post_commit.go"},
+		Verdict: premise.Fails,
+		Found:   "the hook calls git.DiffNameOnly(commitHash) and never walks",
+	}
+	without := func(f func(*Entry)) Entry {
+		e := complete
+		f(&e)
+		return e
+	}
+
+	tests := []struct {
+		name    string
+		entry   Entry
+		wantErr error
+	}{
+		{"no claim", without(func(e *Entry) { e.Claim.Statement = "" }), ErrNoClaim},
+		{"claim with no evidence", without(func(e *Entry) { e.Claim.Evidence = "" }), ErrNoClaim},
+		{"no verdict", without(func(e *Entry) { e.Verdict = "" }), ErrNoVerdict},
+		{"verdict outside the closed set", without(func(e *Entry) { e.Verdict = "maybe" }), ErrNoVerdict},
+		// A claim the tree confirmed did not cause this rejection. Recording
+		// one says the gate fired on evidence that supports the idea, which is
+		// either a mis-recorded entry or a real bug in the gate — either way
+		// the log must not be the place it goes quiet.
+		{"a verdict that holds", without(func(e *Entry) { e.Verdict = premise.Holds }), ErrNoVerdict},
+		{"no finding", without(func(e *Entry) { e.Found = "" }), ErrNoFinding},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := Append(root, tt.entry); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("append %s: got %v, want %v", tt.name, err, tt.wantErr)
+			}
+			if _, err := os.Stat(filepath.Join(root, LogPath)); !os.IsNotExist(err) {
+				t.Error("an entry that records nothing about the failure still reached the log")
+			}
+		})
+	}
+
+	t.Run("complete", func(t *testing.T) {
+		root := t.TempDir()
+		if err := Append(root, complete); err != nil {
+			t.Fatalf("append a complete entry: %v", err)
+		}
+
+		got := readOne(t, root)
+		if got.Claim != complete.Claim {
+			t.Errorf("claim: got %+v, want %+v", got.Claim, complete.Claim)
+		}
+		if got.Verdict != complete.Verdict {
+			t.Errorf("verdict: got %q, want %q", got.Verdict, complete.Verdict)
+		}
+		if got.Found != complete.Found {
+			t.Errorf("found: got %q, want %q", got.Found, complete.Found)
+		}
+	})
+}
+
+// TestIrrelevantIsDistinguishableFromPremiseFailed checks the difference the
+// log exists to preserve. An irrelevant item was never about this project and
+// no claim was ever checked; a dropped idea was checked and the tree
+// contradicted it. Folded together they are unreadable, and the reader cannot
+// tell a bar set too high from a source that has gone quiet. The difference is
+// structural, not just a label: an entry that was never checked cannot carry a
+// verdict, and one that was checked cannot omit it.
+func TestIrrelevantIsDistinguishableFromPremiseFailed(t *testing.T) {
+	irrelevant := Entry{
+		Idea:   "add a billing dashboard",
+		Source: "entireio-cli-changelog#0.9.1",
+		Reason: Irrelevant,
+		Note:   "this project has no billing surface",
+	}
+	with := func(f func(*Entry)) Entry {
+		e := irrelevant
+		f(&e)
+		return e
+	}
+
+	tests := []struct {
+		name    string
+		entry   Entry
+		wantErr error
+	}{
+		{"no note", with(func(e *Entry) { e.Note = "" }), ErrNoNote},
+		{
+			"carries a claim it never checked",
+			with(func(e *Entry) { e.Claim = premise.Claim{Statement: "x", Evidence: "y"} }),
+			ErrNotChecked,
+		},
+		{"carries a verdict it never reached", with(func(e *Entry) { e.Verdict = premise.Fails }), ErrNotChecked},
+		{"carries a finding it never gathered", with(func(e *Entry) { e.Found = "something" }), ErrNotChecked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := Append(root, tt.entry); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("append %s: got %v, want %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+
+	t.Run("the two kinds stay apart in one log", func(t *testing.T) {
+		root := t.TempDir()
+		failed := Entry{
+			Idea:    "walk the tree to attribute a commit",
+			Source:  "entireio-cli-issues#1877",
+			Reason:  PremiseFailed,
+			Claim:   premise.Claim{Statement: "the hook walks the tree", Evidence: "internal/hooks/post_commit.go"},
+			Verdict: premise.Fails,
+			Found:   "the hook calls git.DiffNameOnly(commitHash)",
+		}
+		for _, e := range []Entry{failed, irrelevant} {
+			if err := Append(root, e); err != nil {
+				t.Fatalf("append %q: %v", e.Idea, err)
+			}
+		}
+
+		raw, err := os.ReadFile(filepath.Join(root, LogPath))
+		if err != nil {
+			t.Fatalf("read the log: %v", err)
+		}
+		got, err := Parse(string(raw))
+		if err != nil {
+			t.Fatalf("parse the log: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("wrote 2 entries, read back %d", len(got))
+		}
+		if got[0].Reason == got[1].Reason {
+			t.Fatalf("both entries read back as %q", got[0].Reason)
+		}
+		if got[1].Verdict != "" || got[1].Claim.Statement != "" || got[1].Found != "" {
+			t.Errorf("the irrelevant entry came back carrying a check that never ran: %+v", got[1])
+		}
+		if got[1].Note != irrelevant.Note {
+			t.Errorf("note: got %q, want %q", got[1].Note, irrelevant.Note)
+		}
+	})
+
+	// The program half. The proposer is the only writer of this log, so a
+	// distinction the package enforces and the program never uses is a
+	// distinction the log never actually carries.
+	t.Run("the proposer records both kinds", func(t *testing.T) {
+		raw, err := os.ReadFile(proposeProgram)
+		if err != nil {
+			t.Fatalf("read the propose program: %v", err)
+		}
+		agents, ok := section(string(raw), "## Agents")
+		if !ok {
+			t.Fatal("the propose program has no agents section")
+		}
+
+		// The field form, not the bare word: "irrelevant" already appears in
+		// the run summary as prose, and a test that matches that passes on a
+		// program which records nothing.
+		for _, r := range Reasons {
+			field := "- reason: `" + string(r) + "`"
+			if !strings.Contains(agents, field) {
+				t.Errorf("the proposer is never shown %q, so it records no rejection of that kind", field)
+			}
+		}
+	})
+}
+
+// TestDryRunWritesAndCommitsNothing checks where the side effects live. A dry
+// run renders the program and starts no agent, so anything the agent is told to
+// do costs nothing. A write or a commit stated outside the agent's steps is a
+// side effect of the program itself, and a dry run would perform it — which
+// would put a rejection in the log for a run that never happened.
+func TestDryRunWritesAndCommitsNothing(t *testing.T) {
+	raw, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read the propose program: %v", err)
+	}
+	src := string(raw)
+
+	agents, ok := section(src, "## Agents")
+	if !ok {
+		t.Fatal("the propose program has no agents section")
+	}
+
+	outside := strings.Replace(src, agents, "", 1)
+	for _, effect := range []string{"git add", "git commit", "git push", LogPath} {
+		if !strings.Contains(agents, effect) {
+			t.Errorf("%q is not one of the agent's steps", effect)
+		}
+		if strings.Contains(outside, effect) {
+			t.Errorf("%q sits outside the agent's steps, so a dry run performs it", effect)
+		}
+	}
+}
+
+// TestRunThatRejectsNothingStillCommits checks the quiet run. Most runs reject
+// nothing, and the run still has to commit the cursor it advanced. The log is
+// staged unconditionally, so it has to exist in this repository: `git add` on a
+// path that has never been created fails, and a failed stage takes the cursor
+// commit down with it — every run, not just the quiet ones.
+func TestRunThatRejectsNothingStillCommits(t *testing.T) {
+	inRepo := "../../" + LogPath
+
+	raw, err := os.ReadFile(inRepo)
+	if err != nil {
+		t.Fatalf("the log is staged every run but does not exist in this repository: %v", err)
+	}
+	if _, err := Parse(string(raw)); err != nil {
+		t.Errorf("the log in this repository does not parse: %v", err)
+	}
+
+	// A run that appends nothing leaves the file byte-identical, so the stage
+	// is a no-op and the commit carries the cursor alone.
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, filepath.Dir(LogPath)), 0o755); err != nil {
+		t.Fatalf("seed the log directory: %v", err)
+	}
+	seeded := filepath.Join(root, LogPath)
+	if err := os.WriteFile(seeded, raw, 0o644); err != nil {
+		t.Fatalf("seed the log: %v", err)
+	}
+
+	before, err := os.Stat(seeded)
+	if err != nil {
+		t.Fatalf("stat the seeded log: %v", err)
+	}
+	got, err := os.ReadFile(seeded)
+	if err != nil {
+		t.Fatalf("read the seeded log: %v", err)
+	}
+	if string(got) != string(raw) || before.Size() != int64(len(raw)) {
+		t.Error("a run that rejected nothing changed the log")
+	}
+
+	// And the program says so, so the agent does not invent a second commit or
+	// skip the cursor when it has no rejections to report.
+	src, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read the propose program: %v", err)
+	}
+	agents, ok := section(string(src), "## Agents")
+	if !ok {
+		t.Fatal("the propose program has no agents section")
+	}
+	if !strings.Contains(agents, "rejected nothing") {
+		t.Error("the proposer is never told what to do when it rejects nothing")
+	}
+}
+
+// TestEntriesAccumulateAcrossRuns checks that a later run adds to the log
+// rather than replacing it. Each run sees only its own rejections, so a run
+// that rewrites the file erases every earlier one — and the cursors have long
+// since moved past those ideas, so nothing can rebuild them.
+func TestEntriesAccumulateAcrossRuns(t *testing.T) {
+	root := t.TempDir()
+
+	runs := []Entry{
+		{Idea: "first idea", Source: "src#1", Reason: Irrelevant, Note: "no use for it"},
+		{Idea: "second idea", Source: "src#2", Reason: Irrelevant, Note: "still no use"},
+		{Idea: "third idea", Source: "src#3", Reason: Irrelevant, Note: "nor this one"},
+	}
+
+	var after []string
+	for i, e := range runs {
+		if err := Append(root, e); err != nil {
+			t.Fatalf("run %d: %v", i+1, err)
+		}
+
+		raw, err := os.ReadFile(filepath.Join(root, LogPath))
+		if err != nil {
+			t.Fatalf("run %d: read the log: %v", i+1, err)
+		}
+		after = append(after, string(raw))
+
+		// Every earlier run's log is still a prefix of this one. Nothing above
+		// the new entry moved, and nothing was rewritten.
+		if i > 0 && !strings.HasPrefix(after[i], after[i-1]) {
+			t.Fatalf("run %d rewrote what run %d had already written:\n%s", i+1, i, after[i])
+		}
+	}
+
+	final := after[len(after)-1]
+	if n := strings.Count(final, "# Rejections"); n != 1 {
+		t.Errorf("the log carries its header %d times; it is written once and appended to after that", n)
+	}
+
+	got, err := Parse(final)
+	if err != nil {
+		t.Fatalf("parse the log: %v", err)
+	}
+	if len(got) != len(runs) {
+		t.Fatalf("%d runs each rejected one idea, log holds %d", len(runs), len(got))
+	}
+	for i, want := range runs {
+		if got[i].Idea != want.Idea {
+			t.Errorf("entry %d: got %q, want %q — oldest first", i, got[i].Idea, want.Idea)
+		}
+	}
+}
+
+// TestLogTravelsWithTheCursor checks that one commit carries both. The cursor
+// advancing is what makes a rejection permanent: the source item is never
+// offered again. If the run advances the cursor and the log does not reach the
+// same commit, the idea is gone and nothing says it ever existed. Two commits
+// are not enough either — the second can fail after the first has landed.
+func TestLogTravelsWithTheCursor(t *testing.T) {
+	raw, err := os.ReadFile(proposeProgram)
+	if err != nil {
+		t.Fatalf("read the propose program: %v", err)
+	}
+	agents, ok := section(string(raw), "## Agents")
+	if !ok {
+		t.Fatal("the propose program has no agents section")
+	}
+
+	// The cursor moves before anything is committed. A commit that precedes
+	// the advance leaves the log describing a source position the repository
+	// has not reached.
+	advance := strings.Index(agents, "Update `last_version`")
+	if advance < 0 {
+		t.Fatal("the proposer never advances the source cursor")
+	}
+	commit := strings.Index(agents, "git commit")
+	if commit < 0 {
+		t.Fatal("the proposer commits nothing")
+	}
+	if advance > commit {
+		t.Error("the proposer commits before it advances the cursor")
+	}
+
+	if n := strings.Count(agents, "git commit"); n != 1 {
+		t.Errorf("the run makes %d commits; the log and the cursor must land together in one", n)
+	}
+
+	add, ok := lineContaining(agents, "git add")
+	if !ok {
+		t.Fatal("the proposer stages nothing")
+	}
+	for _, want := range []string{LogPath, ".minions/sources.yaml", ".minions/programs/"} {
+		if !strings.Contains(add, want) {
+			t.Errorf("the single commit leaves out %q:\n%s", want, add)
+		}
+	}
+}
+
+// section returns the body of the named heading, from the heading to the next
+// heading of the same level or to the end. It ignores headings inside a fenced
+// block, because the entry template this program shows its agent is itself a
+// markdown heading and must not close the section that contains it.
+func section(src, heading string) (string, bool) {
+	lines := strings.Split(src, "\n")
+	closes := strings.Repeat("#", strings.Count(heading, "#")) + " "
+
+	start, fenced := -1, false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "```") {
+			fenced = !fenced
+			continue
+		}
+		if fenced {
+			continue
+		}
+
+		switch {
+		case start < 0 && trimmed == heading:
+			start = i + 1
+		case start >= 0 && strings.HasPrefix(trimmed, closes):
+			return strings.Join(lines[start:i], "\n"), true
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+	return strings.Join(lines[start:], "\n"), true
+}
+
+// readOne parses the log under root and returns its single entry.
+func readOne(t *testing.T, root string) Entry {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join(root, LogPath))
+	if err != nil {
+		t.Fatalf("read the log: %v", err)
+	}
+	got, err := Parse(string(raw))
+	if err != nil {
+		t.Fatalf("parse the log: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("wrote 1 entry, read back %d", len(got))
+	}
+	return got[0]
+}
+
+// lineContaining returns the first line of src that contains want.
+func lineContaining(src, want string) (string, bool) {
+	for _, line := range strings.Split(src, "\n") {
+		if strings.Contains(line, want) {
+			return line, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
Two features, one cause. Issue #30 rested on a claim about this
repository that was never true. This branch repairs the one real defect
the claim hid, and it stops the next false claim from reaching a build.

## 1. First-commit attribution — `fix(attribution)`

A first commit has no parent. The three commit-diff functions compared
`HEAD~1` against `HEAD`, so git answered `fatal: ambiguous argument`.
The attribution code fell back to git's empty tree, but its constant was
corrupted:

```
held: 4b825dc642cb6eb9a060e54bf899d69f82cf7ee2
real: 4b825dc642cb6eb9a060e54bf8d69288fbee4904
```

Git answered `fatal: bad object`. `Calculate` caught that error,
returned an empty result and reported no error. A first commit recorded
zero lines, and a failed measurement looked the same as an empty commit.

The git package now holds one `EmptyTree` constant and one `commitRange`
helper. The helper asks git for the parent instead of a guess.
`DiffNumstat`, `Diff` and `DiffNameOnly` all use it and keep their
signatures, so no caller changes. `Calculate` drops its own fallback and
sends a git failure to the caller, so a failed measurement is visible.

**Merge behaviour does not change.** A merge commit has a parent, so it
takes the unchanged path against its first parent. The `--root` flag
stays out of production code. Pull request #653 added it; measured
directly, `git diff-tree --no-commit-id -r --root --numstat` returns
nothing at all for a merge commit.

## 2. Proposal premise gate — `feat(minions)`

The proposer files proposals twice a day about code it has never read.
Issue #30 said the post-commit hook "performs a full tree walk… O(N) in
the number of tracked files". The hook never did that. The claim came
from a sibling product's changelog, where the problem was real.

The issue was filed on 2026-03-26 and built on 2026-08-10. Of 534 open
proposals, nine minion pull requests have ever merged.

A proposal now records the claims it rests on, one per line, each paired
with the path or command that proves it. Each stage rechecks the claims:
the proposer reads the code before it writes the claim, research
refreshes the premise, the build refuses a stale one, and proposals
filed before this gate are not exempt. A rejected idea leaves a record,
so the same false claim does not return.

This also repairs why the proposer improvised. The program format
discards every section except title, context, planner and agents. Five
programs carried their instructions under `## Steps`, so those steps
never reached the model. A shape check now fails on a dropped section.

New packages: `internal/premise`, `internal/programshape`,
`internal/rejection`.

## The benchmark, and what it says about #653

The git package now holds a benchmark, because the repository held no
measurement and the speed claim could not be checked. Median of 5 runs,
milliseconds per call, on a repository whose file count is in the
benchmark name:

| Measurement | 1000 files | 10000 files |
|---|---|---|
| Current `DiffNumstat` (parent lookup + `git diff`) | 1.34 | 1.74 |
| The `git diff` command alone | 0.74 | 1.17 |
| Proposed `git diff-tree … --root --numstat` | 0.74 | 1.47 |

Read row three against row two, not row one. Row one starts two git
processes, because the current code asks git for the parent first. Row
three starts one. A git process costs about 0.6 ms on this machine.

Command against command, the proposal is level on 1000 files and **26
percent slower on 10000 files**. It is never faster.

**Issue #30's premise is not supported.** Ten times the files raise the
current call 30 percent, not tenfold. Process startup dominates.

The `git diff-tree` call is in the benchmark file only. Production code
keeps one strategy. The alternative is measured, not adopted.

## Checks

- `make test` passes. It does not run the benchmark.
- `make lint` reports 0 issues.
- Both ran on this branch's base, after the rebase onto `main`.

## Open decision, for the operator

Pull request #653 replaces the current strategy with the slower one, and
it drops merge-commit attribution to zero. **This branch does not close
it.** The numbers above are the input to that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
