### PR TITLE
fix(minions): verify a proposal that carries no premise block

### DIFF
--- a/.minions/programs/premise-gate.md
+++ b/.minions/programs/premise-gate.md
@@ -50,21 +50,29 @@ working directory. Read it. Do not decide a claim from the issue text,
 and do not decide it from memory of how similar projects work.
 
 1. Read the parent issue body, which is provided under the "Issue"
-   section of your prompt, and take the `## Premise` section that
-   carries the `<!-- partio:premise:v1 -->` marker. That block is what
-   you verify.
+   section of your prompt, and find the claims you must verify.
 
-2. Apply `.minions/premise-verifier.md` to that block against the
+   When the body carries a `## Premise` section with the
+   `<!-- partio:premise:v1 -->` marker, that block is what you verify,
+   and you do not verify the prose around it.
+
+   When the body carries no such marker, the claims come from the prose
+   instead. Every proposal filed before the block format existed is in
+   this state, and none of them is exempt. The verifier's `## When there
+   is no block` section describes the extraction. Follow it as written.
+
+2. Apply `.minions/premise-verifier.md` to the claims against the
    checked-out tree. It describes verification once, for every stage
    that needs it. Follow it as written — gather the evidence each claim
    names, then decide, then record the excerpt that decided it. Do not
-   restate its procedure and do not invent your own.
+   restate its procedure and do not invent your own. A claim from the
+   prose meets the same bar as a claim from a block.
 
 3. Apply `.minions/stage-gate.md` to the verdict it produced. That file
    describes what a stage does when a premise does not hold, and what it
    does when it holds. Follow it as written.
 
-4. When the block does not hold, the gate has already labelled the issue
+4. When the premise does not hold, the gate has already labelled the issue
    and posted the comment naming what you checked and what you found.
    Stop there. Write no code, produce no further artifact, and do not
    close the issue. Which label the gate applies, and how the operator
@@ -72,26 +80,33 @@ and do not decide it from memory of how similar projects work.
    yours to decide from the issue's current labels. Verify against the
    tree on every run, whatever labels the issue already carries.
 
-5. When the block holds, refresh the premise section in the parent issue
-   with the evidence you just gathered, and record every claim, the
-   evidence it named, its verdict, and the excerpt that produced it — for
-   a block that holds as well as for one that does not. A build that
-   proceeds carries the evidence it rests on.
+5. When the premise holds, record every claim, the evidence it named,
+   its verdict, and the excerpt that produced it — for a premise that
+   holds as well as for one that does not. A build that proceeds carries
+   the evidence it rests on.
 
-   Read the current body, replace the evidence excerpts inside the
-   `## Premise` section with what you read on this run, and keep the
-   section's marker and every claim. Leave the rest of the body untouched
-   — you are refreshing evidence, not rewriting the proposal. Then write
-   the whole body to the shared path and put it back:
+   Refresh the issue body only when the issue carries a premise block.
+   An issue whose claims you extracted from its prose gets no block: the
+   extraction lives in your report and nowhere else. Leave that body as
+   the operator wrote it. Do not backfill a block into it.
+
+   To refresh a block, read the current body, replace the evidence
+   excerpts inside the `## Premise` section with what you read on this
+   run, and keep the section's marker and every claim. Leave the rest of
+   the body untouched — you are refreshing evidence, not rewriting the
+   proposal. Then write the whole body to the shared path and put it
+   back:
 
    ```
    REFRESHED_BODY="/tmp/minion-build-body-${MINION_ISSUE_NUMBER:-0}.md"
    gh issue edit "$MINION_ISSUE_NUMBER" --repo partio-io/cli --body-file "$REFRESHED_BODY"
    ```
 
-A parent issue whose body carries no `## Premise` section at all is out
-of scope for this program and is not your call to make. Leave the issue
-alone and stop.
+Some proposals only describe what to build. When the body states no
+checkable fact about this repository — in a block or in its prose — there
+is nothing to verify, and the build continues. That is not `unresolved`.
+Say so in your report: state that the body makes no checkable claim, and
+name what you read to decide that.
 
 Do not create or modify any file in the working directory. Every file
 you write goes under `/tmp`. A file left in the working directory is

--- a/internal/premise/repo_build_test.go
+++ b/internal/premise/repo_build_test.go
@@ -227,7 +227,10 @@ func TestHoldingPremiseLetsTheBuildProceedUnchanged(t *testing.T) {
 	for _, want := range []string{
 		"record every claim",
 		"the excerpt that produced it",
-		"for a block that holds",
+		// "premise", not "block": the gate also verifies claims extracted
+		// from the prose of a proposal filed before the block format, and
+		// those record their evidence on the holding path too.
+		"for a premise that holds",
 	} {
 		if !containsPhrase(checker, want) {
 			t.Errorf("### premise-checker does not record %q, so a build that proceeds carries no evidence", want)
@@ -296,6 +299,40 @@ func TestImplementProgramInstructionsReachTheModel(t *testing.T) {
 	} {
 		if !containsPhrase(agents, want) {
 			t.Errorf("the instruction %q does not live under ## Agents, so the parser drops it", want)
+		}
+	}
+}
+
+// TestBuildVerifiesAProposalThatCarriesNoBlock pins the case that covers the
+// whole backlog. No open proposal carried a premise block when the gate
+// shipped, so a gate that treats a blockless issue as out of scope labels
+// nothing. The workflow reads a missing label as "not blocked" and builds, and
+// the gate passes every issue it was added to stop. The verifier already
+// describes where those claims come from, so the gate routes to it and does
+// not stop.
+func TestBuildVerifiesAProposalThatCarriesNoBlock(t *testing.T) {
+	if !containsPhrase(readRepoFile(t, verifierDoc), NoBlockSection) {
+		t.Fatalf("%s no longer carries %q, so no stage has a described route for a blockless proposal",
+			VerifierPath, NoBlockSection)
+	}
+
+	checker, ok := section(readRepoFile(t, gateProgram), "### premise-checker")
+	if !ok {
+		t.Fatalf("%s has no ### premise-checker agent", gateProgram)
+	}
+
+	if !containsPhrase(checker, NoBlockSection) {
+		t.Errorf("### premise-checker never routes to %q in %s, so a proposal with no block is never verified",
+			NoBlockSection, VerifierPath)
+	}
+
+	// The exact wording that shipped the bug. A gate that tells the checker to
+	// stop on a blockless issue reaches no verdict, and a build with no verdict
+	// runs.
+	for _, escape := range []string{"out of scope", "Leave the issue alone"} {
+		if containsPhrase(checker, escape) {
+			t.Errorf("### premise-checker says %q of a blockless issue; that is every open proposal, so every build goes through ungated",
+				escape)
 		}
 	}
 }

--- a/internal/premise/verifier.go
+++ b/internal/premise/verifier.go
@@ -13,6 +13,12 @@ const (
 	// VerifierMarker names the description and its format version. Exactly
 	// one file carries it, which is what makes "described once" checkable.
 	VerifierMarker = "<!-- partio:premise-verifier:v1 -->"
+
+	// NoBlockSection is where the description covers a proposal filed before
+	// the block format existed. Its claims come from the issue prose. Every
+	// proposal open when the gate shipped was in that state, so a stage that
+	// treats a blockless issue as out of scope exempts the entire backlog.
+	NoBlockSection = "## When there is no block"
 )
 
 // Verdict is the outcome of checking one claim against the tree.


### PR DESCRIPTION
## What this fixes

The premise gate told the checker to skip the only issues it can
receive. The last instruction in `.minions/programs/premise-gate.md`
read:

> A parent issue whose body carries no `## Premise` section at all is
> out of scope for this program and is not your call to make. Leave the
> issue alone and stop.

**No open proposal carries a block.** Of 554 open `minion-proposal`
issues, **0** hold the `<!-- partio:premise:v1 -->` marker, and 0 hold a
`## Premise` heading. This includes the newest proposal, filed
2026-08-17. So that instruction covered every issue a build can start
from.

## Why it made the gate inert

The workflow reads the verdict back as a label:

```
if gh issue view "$ISSUE_NUM" ... | grep -qx 'do-not-build'; then
  blocked=true
else
  blocked=false
```

A checker that stops labels nothing. `blocked` is `false`, and the build
runs. The gate passed every proposal it was added to stop.

## The contradiction

Step 2 of the same program sends the checker to
`.minions/premise-verifier.md`. That file carries a section titled
`## When there is no block`:

> Hundreds of proposals were filed before the block format existed. They
> state their facts in prose, and they are not exempt.

`.minions/stage-gate.md` agrees. It handles a claim "extracted from the
issue prose". Commit 7366713 states the intent in one line: "Proposals
filed before this gate are not exempt."

## The change

- Step 1 now names both sources of claims. A block, when the marker is
  present. The prose, through the verifier's `## When there is no block`
  section, when it is not.
- Step 5 refreshes the issue body only when the issue carries a block.
  An extracted claim is not written back, which is what `stage-gate.md`
  already says.
- The closing paragraph now covers the case the verifier calls "no
  checkable claim": the build continues, and that is not `unresolved`.
- Steps 4 and 5 say "premise" where they said "block".

## Test

`TestBuildVerifiesAProposalThatCarriesNoBlock` pins the case. It fails
on the old file for all three reasons — the missing route to the
verifier's section, and each half of the escape wording:

```
--- FAIL: TestBuildVerifiesAProposalThatCarriesNoBlock
    ### premise-checker never routes to "## When there is no block" ...
    ### premise-checker says "out of scope" of a blockless issue ...
    ### premise-checker says "Leave the issue alone" of a blockless issue ...
```

`TestHoldingPremiseLetsTheBuildProceedUnchanged` pinned the literal
phrase "for a block that holds". It now pins "for a premise that holds",
because a prose-extracted claim records its evidence on the same path.

`make test` and `make lint` pass.

## Not verified yet

This changes the instruction, not the model's behaviour. The gate has
never run against a real issue. The test run that found this defect is
recorded in `docs/2026-08-18-premise-gate-test-run/handoff.md`, and its
step 2 is still open: it needs this branch on `main` first, because the
build workflow checks out the default branch.
