### PR TITLE
fix(minions): let the zombie-session program reach the model

### DIFF
--- a/.minions/programs/zombie-session-self-heal-precommit.md
+++ b/.minions/programs/zombie-session-self-heal-precommit.md
@@ -12,7 +12,7 @@ pr_labels:
   - enhancement
 ---
 
-## Self-heal zombie sessions on pre-commit
+# Self-heal zombie sessions on pre-commit
 
 Partio records a new active session in the pre-commit hook (`internal/hooks/precommit.go`). When an agent crashes without running a stop hook, it leaves a session in ACTIVE or IDLE state indefinitely. Today the only way to resolve it is to run `partio cleanup` or `partio status` manually.
 


### PR DESCRIPTION
## What is broken

`main` is red. `TestRepoProgramsKeepInstructionsReachable` fails on a
clean checkout:

```
--- FAIL: TestRepoProgramsKeepInstructionsReachable
    .minions/programs/zombie-session-self-heal-precommit.md:
    instructions do not reach the model
        the dropped section "## Self-heal zombie sessions on pre-commit"
        carries a command or code block
```

The program carried its whole specification under an H2 heading. The
parser keeps the H1 prose, `## Context`, `## Planner` and `## Agents`,
and drops every other H2 with its body. This program defines no agents,
so the executor synthesizes one whose entire instruction set is the H1
prose — and the file had no H1. The model would have received a title
and nothing else.

This is the same defect `internal/programshape` was added to catch in
#672, and it is the same class of defect that produced issue #30.

## The change

One character. The heading is now an H1. Everything under it, the
implementation sketch included, sits before the first H2, so the parser
keeps it.

## How it got in

The program arrived with #675, merged 2026-08-20. That pull request ran
no checks at all — `gh pr checks 675` reports "no checks reported on the
'minion/propose-proposer' branch". The `Checks` workflow triggers only
on `pull_request` and never on push to `main`, so nothing caught it
afterwards either.

`propose.yml` sets `GH_TOKEN: ${{ secrets.GH_PAT }}`, so these pull
requests should trigger `Checks`. Why they do not is still open, and it
is worth settling separately: #645 shows the same "no checks reported".
Until then, every minion proposal pull request merges unverified.

## Verification

`make test` exit 0. `make lint` 0 issues.
